### PR TITLE
Remove duplicate check for libc++.

### DIFF
--- a/aegisub/configure.ac
+++ b/aegisub/configure.ac
@@ -168,7 +168,6 @@ AS_IF([test x$enable_compiler_flags != xno], [
   AC_CXX_FLAG([-pipe])
   AC_CXX_FLAG([-g])
   AC_CXX_FLAG([-std=c++11])
-  AC_CXX_FLAG([-stdlib=libc++])
   AC_LD_FLAG([-stdlib=libc++])
 
   # -O* messes with debugging.


### PR DESCRIPTION
Some compilers accept `-stdlib=libc++` in the compilation phase even if libc++ is not present on the system. In such cases, the check for `CXXFLAGS` passes but that of `LDFLAGS` fails, because the linker can't link to libc++ if it doesn't exist. Since `CXX` is invoked with both `CXXFLAGS` and `LDFLAGS`, `-stdlib=libc++` continues to be passed on the command line and all subsequent link operations fail.

I see this problem with `clang version 3.1 (branches/release_31 157047)` on openSUSE 12.2 / Tumbleweed.

Since `CXX` is used for both the compiler and the linker, there is no need to check separately for support in both `CXXFLAGS` and `LDFLAGS`.

Example output is below:

```
###########
sh autogen.sh CC=clang CXX=clang++
###########

configure:6815: checking whether clang++ supports -std=c++11
configure:6828: clang++ -c -march=native -Wall -Wextra -Wno-unused-parameter -Wno-long-long -fno-strict-aliasing -pipe -g -std=c++11  conftest.cpp >&5
configure:6828: $? = 0
configure:6829: result: yes
configure:6856: checking whether clang++ supports -stdlib=libc++
configure:6869: clang++ -c -march=native -Wall -Wextra -Wno-unused-parameter -Wno-long-long -fno-strict-aliasing -pipe -g -std=c++11 -stdlib=libc++  conftest.cpp >&5
configure:6869: $? = 0
configure:6870: result: yes
configure:6897: checking whether clang++ supports -stdlib=libc++
configure:6910: clang++ -o conftest -march=native -Wall -Wextra -Wno-unused-parameter -Wno-long-long -fno-strict-aliasing -pipe -g -std=c++11 -stdlib=libc++   -stdlib=libc++ conftest.cpp  >&5
/usr/bin/ld: cannot find -lc++
clang: error: linker command failed with exit code 1 (use -v to see invocation)
configure:6910: $? = 1


###########
After this, "-stdlib=libc++" is removed from LDFLAGS. However, CXXFLAGS still contains it. As a result, all later steps in the configure script fail (the ones which build a binary with the linker, that is) because libc++ doesn't exist for the linker to use.
###########

configure:7605: checking for main in -lm
configure:7624: clang++ -o conftest -march=native -Wall -Wextra -Wno-unused-parameter -Wno-long-long -fno-strict-aliasing -pipe -g -std=c++11 -stdlib=libc++ -O3   conftest.cpp -lm   >&5
/usr/bin/ld: cannot find -lc++
clang: error: linker command failed with exit code 1 (use -v to see invocation)
configure:7624: $? = 1

###########
and so on...
###########
```

This is the easy way out, I suppose. This fix would not be desirable if there is any invocation of `CXX` as just a compiler and not a linker, i.e., only `CXXFLAGS` is passed on the command line and not `LDFLAGS`. If there is such an invocation, then the only way I can see is to create a new `AC_CHECK_LIBC++` macro (similar to the existing `AC_CXXFLAG` and `AC_LD_FLAG` macros) to check specifically for libc++ support and set both `CXXFLAGS` and `LDFLAGS` in the same macro.
