### PR TITLE
Expose more stuff for automation

### DIFF
--- a/src/auto4_lua.cpp
+++ b/src/auto4_lua.cpp
@@ -233,7 +233,7 @@ namespace {
 		lua_pop(L, 1);
 		if (c) {
 			c->videoController->LoadKeyframes(path);
-			if (c->videoController->OverKeyFramesLoaded()) {
+			if (c->videoController->OverKeyFramesLoaded() && (c->videoController->GetKeyFramesName() == path)) {
 				lua_pushboolean(L, true);
 				return 1;
 			}
@@ -261,7 +261,7 @@ namespace {
 		lua_pop(L, 1);
 		if (c && c->videoController->IsLoaded()) {
 			c->videoController->LoadTimecodes(path);
-			if (c->videoController->OverTimecodesLoaded()) {
+			if (c->videoController->OverTimecodesLoaded() && (c->videoController->GetTimecodesName() == path)) {
 				lua_pushboolean(L, true);
 				return 1;
 			}
@@ -289,7 +289,7 @@ namespace {
 		lua_pop(L, 1);
 		if (c) {
 			c->videoController->SetVideo(path);
-			if (c->videoController->IsLoaded()) {
+			if (c->videoController->IsLoaded() && (c->videoController->GetVideoName() == path)) {
 				lua_pushboolean(L, true);
 				return 1;
 			}
@@ -317,7 +317,7 @@ namespace {
 		lua_pop(L, 1);
 		if (c) {
 			c->audioController->OpenAudio(path);
-			if (c->audioController->IsAudioOpen()) {
+			if (c->audioController->IsAudioOpen() && (c->audioController->GetAudioURL() == path)) {
 				lua_pushboolean(L, true);
 				return 1;
 			}


### PR DESCRIPTION
New _aegisub._**\* function:
- **active_frame()** - returns active video frame or nil.

The next _aegisub._**\* functions load/close corresponding file returning true on success or nil otherwise. 
- **load_keyframes**(path), **close_keyframes**()
- **load_timecodes**(path), **close_timecodes**()
- **load_video**(path), **close_video**()
- **load_audio**(path), **close_audio**()
