### PR TITLE
Pass all font attachments to font renderer

### DIFF
--- a/src/subtitles_provider.cpp
+++ b/src/subtitles_provider.cpp
@@ -17,6 +17,7 @@
 #include "include/aegisub/subtitles_provider.h"
 
 #include "ass_dialogue.h"
+#include "ass_attachment.h"
 #include "ass_file.h"
 #include "ass_info.h"
 #include "ass_style.h"
@@ -85,6 +86,17 @@ void SubtitlesProvider::LoadSubtitles(AssFile *subs, int time) {
 	push_header("[V4+ Styles]\n");
 	for (auto const& line : subs->Styles)
 		push_line(line.GetEntryData());
+
+	if (!subs->Attachments.empty()) {
+		// TODO: some scripts may have a lot of attachments, 
+		// so ideally we'd want to write only those actually used on the requested video frame,
+		// but this would require some pre-parsing of the attached font files with FreeType,
+		// which isn't probably trivial.
+		push_header("[Fonts]\n");
+		for (auto const& attachment : subs->Attachments)
+			if (attachment.Group() == AssEntryGroup::FONT)
+				push_line(attachment.GetEntryData());
+	}
 
 	push_header("[Events]\n");
 	for (auto const& line : subs->Events) {


### PR DESCRIPTION
Related bug: #1805 "Attached Font Not Working".

This fix alone is only one part of the deal apparently: Aegisub's csri/xy-vsfilter-aegisub##.dll (May 1, 2014) also needs an update because it doesn't use the attached fonts, whereas the official xy-VSFilter 3.0.0.306 dll (copied to Aegisub/csri directory and selected as a primary renderer) is showing the fonts correctly.