### PR TITLE
Don't use -fPIC

### DIFF
--- a/libaegisub/Makefile
+++ b/libaegisub/Makefile
@@ -44,7 +44,7 @@ aegisub_OBJ += $(d)common/dispatch.o
 endif
 
 aegisub_PCH := $(d)lagi_pre.h
-aegisub_CPPFLAGS := -I$(d)include -I$(TOP) -fPIC $(CPPFLAGS_BOOST) $(CFLAGS_LUA)
+aegisub_CPPFLAGS := -I$(d)include -I$(TOP) $(CPPFLAGS_BOOST) $(CFLAGS_LUA)
 
 $(d)common/charset_conv.o_FLAGS := $(CFLAGS_ICONV)
 $(d)common/parser.o_FLAGS := -ftemplate-depth=256


### PR DESCRIPTION
`-fPIC` is only useful when building shared libraries.