### PR TITLE
update calling busted.runner

### DIFF
--- a/automation/tests/busted.lua
+++ b/automation/tests/busted.lua
@@ -1,1 +1,1 @@
-require 'busted.runner'({ batch = true })
+require 'busted.runner'({ standalone = false, batch = true })


### PR DESCRIPTION
Busted 2.0.rc11-0 has the following main file:

```lua
require 'busted.runner'({ standalone = false })
```

Previous Busted versions had batch = true instead of standalone = false.
Use both of them to be compatible with both Busted versions