### PR TITLE
build: sort wildcard results for repeatable builds

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -1,10 +1,10 @@
 include $(dir $(lastword $(MAKEFILE_LIST)))../header.mk
 
 DATA_AUTOMATION := \
-	$(wildcard $(d)autoload/*) \
-	$(wildcard $(d)demos/*) \
-	$(wildcard $(d)include/*.lua) \
-	$(wildcard $(d)include/aegisub/*)
+	$(sort $(wildcard $(d)autoload/*)) \
+	$(sort $(wildcard $(d)demos/*)) \
+	$(sort $(wildcard $(d)include/*.lua)) \
+	$(sort $(wildcard $(d)include/aegisub/*))
 
 DATA_AUTOMATION_REL := $(subst $(d),,$(DATA_AUTOMATION))
 DATA_AUTOMATION_INSTALLED = $(addprefix $(DESTDIR)$(P_DATA)/automation/, $(DATA_AUTOMATION_REL))

--- a/libaegisub/Makefile
+++ b/libaegisub/Makefile
@@ -5,12 +5,12 @@ aegisub_OBJ := \
 	$(d)ass/dialogue_parser.o \
 	$(d)ass/time.o \
 	$(d)ass/uuencode.o \
-	$(subst .cpp,.o,$(wildcard $(d)audio/*.cpp)) \
-	$(subst .cpp,.o,$(wildcard $(d)common/cajun/*.cpp)) \
-	$(subst .cpp,.o,$(wildcard $(d)lua/modules/*.cpp)) \
-	$(subst .c,.o,$(wildcard $(d)lua/modules/*.c)) \
-	$(subst .cpp,.o,$(wildcard $(d)lua/*.cpp)) \
-	$(subst .cpp,.o,$(wildcard $(d)unix/*.cpp)) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)audio/*.cpp))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)common/cajun/*.cpp))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)lua/modules/*.cpp))) \
+	$(subst .c,.o,$(sort $(wildcard $(d)lua/modules/*.c))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)lua/*.cpp))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)unix/*.cpp))) \
 	$(d)common/calltip_provider.o \
 	$(d)common/character_count.o \
 	$(d)common/charset.o \
@@ -38,7 +38,7 @@ aegisub_OBJ := \
 	$(d)common/ycbcr_conv.o
 
 ifeq (yes, $(BUILD_DARWIN))
-aegisub_OBJ += $(subst .mm,.o,$(wildcard $(d)osx/*.mm))
+aegisub_OBJ += $(subst .mm,.o,$(sort $(wildcard $(d)osx/*.mm)))
 else
 aegisub_OBJ += $(d)common/dispatch.o
 endif

--- a/packages/desktop/Makefile
+++ b/packages/desktop/Makefile
@@ -1,7 +1,7 @@
 include $(dir $(lastword $(MAKEFILE_LIST)))../../header.mk
 DESKTOP_SRC := $(d)
 
-ICONS = $(wildcard $(d)*.png) $(wildcard $(d)*.svg)
+ICONS = $(sort $(wildcard $(d)*.png)) $(sort $(wildcard $(d)*.svg))
 ICONS_INSTALLED = $(DESTDIR)$(P_ICON)/hicolor/%/apps/aegisub.
 
 DESKTOP_FILE := $(d)aegisub.desktop

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,10 +11,10 @@ src_PCH := $(d)agi_pre.h
 src_INSTALLNAME := $(AEGISUB_COMMAND)
 
 src_OBJ := \
-	$(subst .cpp,.o,$(wildcard $(d)command/*.cpp)) \
-	$(subst .cpp,.o,$(wildcard $(d)dialog_*.cpp)) \
-	$(subst .cpp,.o,$(wildcard $(d)subtitle_format*.cpp)) \
-	$(subst .cpp,.o,$(wildcard $(d)visual_tool*.cpp)) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)command/*.cpp))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)dialog_*.cpp))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)subtitle_format*.cpp))) \
+	$(subst .cpp,.o,$(sort $(wildcard $(d)visual_tool*.cpp))) \
 	$(d)MatroskaParser.o \
 	$(d)aegisublocale.o \
 	$(d)ass_attachment.o \
@@ -118,7 +118,7 @@ src_OBJ := \
 
 ifeq (yes, $(BUILD_DARWIN))
 src_OBJ += $(d)font_file_lister_coretext.o
-src_OBJ += $(subst .mm,.o,$(wildcard $(d)osx/*.mm))
+src_OBJ += $(subst .mm,.o,$(sort $(wildcard $(d)osx/*.mm)))
 $(d)font_file_lister_coretext.o_FLAGS := -fobjc-arc
 else
 src_OBJ += $(d)font_file_lister_fontconfig.o

--- a/vendor/luabins/Makefile
+++ b/vendor/luabins/Makefile
@@ -1,6 +1,6 @@
 include $(dir $(lastword $(MAKEFILE_LIST)))../../header.mk
 
-luabins_OBJ := $(subst .c,.o,$(wildcard $(d)src/*.c))
+luabins_OBJ := $(subst .c,.o,$(sort $(wildcard $(d)src/*.c)))
 luabins_CPPFLAGS := $(CFLAGS_LUA)
 
 LIB += luabins


### PR DESCRIPTION
Wildcard result order depends on filesystem stuff.
This matters for lunix packaging systems etc.