### PR TITLE
dialog_about: only include build date with credit

### DIFF
--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -120,7 +120,10 @@ void ShowAboutDialog(wxWindow *parent) {
 		"    FFTW - Copyright (c) Matteo Frigo, Massachusetts Institute of Technology;\n"
 #endif
 		+ _("\nSee the help file for full credits.\n")
-		+ fmt_tl("Built by %s on %s.", GetAegisubBuildCredit(), GetAegisubBuildTime());
+#ifdef BUILD_CREDIT
+		+ fmt_tl("Built by %s on %s.", GetAegisubBuildCredit(), GetAegisubBuildTime())
+#endif
+		;
 
 	// Replace copyright symbol
 	wxChar copySymbol = 0xA9;

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -55,17 +55,16 @@ const char *GetAegisubShortVersionString() {
 	return BUILD_GIT_VERSION_STRING DEBUG_SUFFIX;
 }
 
+#ifdef BUILD_CREDIT
 const char *GetAegisubBuildTime() {
 	return __DATE__ " " __TIME__;
 }
 
 const char *GetAegisubBuildCredit() {
-#ifdef BUILD_CREDIT
 	return BUILD_CREDIT;
-#else
 	return "";
-#endif
 }
+#endif
 
 bool GetIsOfficialRelease() {
 	return false;


### PR DESCRIPTION
The build date is largely irrelevant and prevents reproducible builds.
Make it optional.