### PR TITLE
Fix compilation against icu 59.1

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -44,6 +44,7 @@
 #include <boost/filesystem/path.hpp>
 #include <map>
 #include <unicode/locid.h>
+#include <unicode/unistr.h>
 #include <wx/clipbrd.h>
 #include <wx/filedlg.h>
 #include <wx/stdpaths.h>


### PR DESCRIPTION
icu was just updated to 59.1 in Arch Linux' repositories, breaking aegisub in the process. It builds fine again with this additional header.