### PR TITLE
Fix MRU menus

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -419,7 +419,7 @@ class AutomationMenu final : public wxMenu {
 		WorkItem *FindOrMakeSubitem(std::string const &name) {
 			auto sub = std::find_if(subitems.begin(), subitems.end(), [&](WorkItem const &item) { return item.displayname == name; });
 			if (sub != subitems.end()) return &*sub;
-			
+
 			subitems.emplace_back(name);
 			return &subitems.back();
 		}
@@ -529,8 +529,13 @@ namespace menu {
 			}
 		}
 
+#ifdef __WXMAC__
 		menu->Bind(wxEVT_MENU_OPEN, &CommandManager::OnMenuOpen, &menu->cm);
 		menu->Bind(wxEVT_MENU, &CommandManager::OnMenuClick, &menu->cm);
+#else
+		window->Bind(wxEVT_MENU_OPEN, &CommandManager::OnMenuOpen, &menu->cm);
+		window->Bind(wxEVT_MENU, &CommandManager::OnMenuClick, &menu->cm);
+#endif
 
 #ifdef __WXMAC__
 		bind_events(menu.get());


### PR DESCRIPTION
MRU menus aren't populated with actual menu items ever since 9bbfdddde046c151b4ebaa06de10b2d51216cbec (at least on Linux, possibly on Windows as well) even if there are positions in the JSON file. I don't understand why the author made such a change, so I left their solution by wrapping it with a `#ifdef` guard.
