### PR TITLE
Makefiles: replace the use of subst macro with patsubst

### DIFF
--- a/libaegisub/Makefile
+++ b/libaegisub/Makefile
@@ -5,12 +5,12 @@ aegisub_OBJ := \
 	$(d)ass/dialogue_parser.o \
 	$(d)ass/time.o \
 	$(d)ass/uuencode.o \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)audio/*.cpp))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)common/cajun/*.cpp))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)lua/modules/*.cpp))) \
-	$(subst .c,.o,$(sort $(wildcard $(d)lua/modules/*.c))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)lua/*.cpp))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)unix/*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)audio/*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)common/cajun/*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)lua/modules/*.cpp))) \
+	$(patsubst %.c,%.o,$(sort $(wildcard $(d)lua/modules/*.c))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)lua/*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)unix/*.cpp))) \
 	$(d)common/calltip_provider.o \
 	$(d)common/character_count.o \
 	$(d)common/charset.o \
@@ -38,7 +38,7 @@ aegisub_OBJ := \
 	$(d)common/ycbcr_conv.o
 
 ifeq (yes, $(BUILD_DARWIN))
-aegisub_OBJ += $(subst .mm,.o,$(sort $(wildcard $(d)osx/*.mm)))
+aegisub_OBJ += $(patsubst %.mm,%.o,$(sort $(wildcard $(d)osx/*.mm)))
 else
 aegisub_OBJ += $(d)common/dispatch.o
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,10 +11,10 @@ src_PCH := $(d)agi_pre.h
 src_INSTALLNAME := $(AEGISUB_COMMAND)
 
 src_OBJ := \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)command/*.cpp))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)dialog_*.cpp))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)subtitle_format*.cpp))) \
-	$(subst .cpp,.o,$(sort $(wildcard $(d)visual_tool*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)command/*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)dialog_*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)subtitle_format*.cpp))) \
+	$(patsubst %.cpp,%.o,$(sort $(wildcard $(d)visual_tool*.cpp))) \
 	$(d)MatroskaParser.o \
 	$(d)aegisublocale.o \
 	$(d)ass_attachment.o \
@@ -118,7 +118,7 @@ src_OBJ := \
 
 ifeq (yes, $(BUILD_DARWIN))
 src_OBJ += $(d)font_file_lister_coretext.o
-src_OBJ += $(subst .mm,.o,$(sort $(wildcard $(d)osx/*.mm)))
+src_OBJ += $(patsubst %.mm,%.o,$(sort $(wildcard $(d)osx/*.mm)))
 $(d)font_file_lister_coretext.o_FLAGS := -fobjc-arc
 else
 src_OBJ += $(d)font_file_lister_fontconfig.o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ run_CPPFLAGS := -I$(TOP)libaegisub/include -I$(TOP) -I$(d)support \
 run_CXXFLAGS := -Wno-unused-value -Wno-sign-compare
 run_LIBS := $(LIBS_BOOST) $(LIBS_ICU) $(LIBS_UCHARDET) $(LIBS_PTHREAD)
 run_OBJ := \
-	$(subst .cpp,.o,$(wildcard $(d)tests/*.cpp)) \
+	$(patsubst %.cpp,%.o,$(wildcard $(d)tests/*.cpp)) \
 	$(d)support/main.o \
 	$(d)support/util.o \
 	$(TOP)lib/libaegisub.a \

--- a/vendor/luabins/Makefile
+++ b/vendor/luabins/Makefile
@@ -1,6 +1,6 @@
 include $(dir $(lastword $(MAKEFILE_LIST)))../../header.mk
 
-luabins_OBJ := $(subst .c,.o,$(sort $(wildcard $(d)src/*.c)))
+luabins_OBJ := $(patsubst %.c,%.o,$(sort $(wildcard $(d)src/*.c)))
 luabins_CPPFLAGS := $(CFLAGS_LUA)
 
 LIB += luabins


### PR DESCRIPTION
$(subst .c,.o,...) replaces '.c' with '.o' everywhere in pathnames. For
example, renaming the "Aegisub" folder to "Aegisub.cool" will make the
build system generate "Aegisub.oool/.../.o" objects.

https://www.gnu.org/software/make/manual/make.html#Text-Functions