### PR TITLE
Fix typo in the Italian localization

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -547,7 +547,7 @@ msgstr "Analisi Matroska"
 
 #: ../src/mkv_wrap.cpp:224
 msgid "Reading subtitles from Matroska file."
-msgstr "Lettura sottotitoli dal file Martoska."
+msgstr "Lettura sottotitoli dal file Matroska."
 
 #: ../src/dialog_styling_assistant.cpp:58
 #: ../src/command/tool.cpp:142


### PR DESCRIPTION
There is a little typo in the Italian localization and because of the place where it is located I can do nothing but to see it everytime I open an MKV file with Aegisub. This patch fixes it.