### PR TITLE
don't be too pedantic on the OpenAL checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -334,9 +334,9 @@ AS_IF([test x$with_openal != xno], [
 #endif
 int main(void) {
   ALCdevice *device = alcOpenDevice(0);
-  if (!device) return 1;
   ALCcontext *context = alcCreateContext(device, 0);
-  if (!context) return 1;
+  alcDestroyContext(context);
+  alcCloseDevice(device);
   return 0;
 } ])
 ])


### PR DESCRIPTION
Building Aegisub on Ubuntu just with `./configure && make` makes the check succeed, but if I use `debuild` to build a Debian package the OpenAL check will fail.

Here's the part from config.log:
```
configure:11659: checking whether OpenAL works
configure:11689: g++ -o conftest  -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -pipe -g -std=c++11 -Wno-c++11-narrowing -Wno-unused-local-typedefs -O3  -I/usr/include/AL  conftest.cpp -ldl -lm  -lopenal >&5
configure:11689: $? = 0
configure:11689: ./conftest
ALSA lib pulse.c:243:(pulse_connect) PulseAudio: Unable to connect: Connection terminated

AL lib: (EE) ALCplaybackAlsa_open: Could not open playback device 'default': Connection refused
configure:11689: $? = 1
configure: program exited with status 1
```