### PR TITLE
Unbreak build against Boost 1.68

### DIFF
--- a/src/search_replace_engine.cpp
+++ b/src/search_replace_engine.cpp
@@ -253,7 +253,7 @@ bool SearchReplaceEngine::ReplaceAll() {
 			if (MatchState ms = matches(&diag, 0)) {
 				auto& diag_field = diag.*get_dialogue_field(settings.field);
 				std::string const& text = diag_field.get();
-				count += distance(
+				count += std::distance(
 					boost::u32regex_iterator<std::string::const_iterator>(begin(text), end(text), *ms.re),
 					boost::u32regex_iterator<std::string::const_iterator>());
 				diag_field = u32regex_replace(text, *ms.re, settings.replace_with);


### PR DESCRIPTION
After boostorg/range@69409ed63a9e1 build fails. See [Aegisub-3.2.2 error log](https://ptpb.pw/fjhH).

Sorry, I can't test `master` because it doesn't build on FreeBSD.
