### PR TITLE
Option to create portable builds on Linux

### DIFF
--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -56,7 +56,7 @@ P_LOCALE      = @localedir@
 
 P_DESKTOP     = @P_DESKTOP@
 P_ICON        = @P_ICON@
-P_DATA        = $(P_DATAROOT)/aegisub/
+P_DATA        = @P_DATA@
 
 ###############
 # LIBRARY FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -50,9 +50,10 @@ AC_SUBST(AEGISUB_COMMAND)
 AC_DEFINE_UNQUOTED([AEGISUB_COMMAND], ["${AEGISUB_COMMAND}"], [Name of the Aegisub executable])
 
 # Name of gettext catalog.
-AEGISUB_CATALOG="aegisub"
-AC_SUBST(AEGISUB_CATALOG)
-AC_DEFINE_UNQUOTED([AEGISUB_CATALOG], ["${AEGISUB_CATALOG}"], [Name of the Aegisub gettext catalog])
+# See '--enable-appimage'
+#AEGISUB_CATALOG="aegisub"
+#AC_SUBST(AEGISUB_CATALOG)
+#AC_DEFINE_UNQUOTED([AEGISUB_CATALOG], ["${AEGISUB_CATALOG}"], [Name of the Aegisub gettext catalog])
 
 # Handle location of desktop files: http://freedesktop.org/wiki/Specifications/desktop-entry-spec
 AC_ARG_WITH(desktop-dir,
@@ -558,6 +559,32 @@ AC_SUBST(DEFAULT_PLAYER_AUDIO)
 # Set some friendly strings if some of the above aren't detected.
 DEFAULT_PLAYER_AUDIO=${DEFAULT_PLAYER_AUDIO:-NONE}
 
+################
+# AppImage build
+################
+# If enabled, localization and automation data is obtained from the binary's
+# path and never from the system's root. It will also install files that
+# Aegisub will lookup next to the binary, so be careful with "make install".
+AC_ARG_ENABLE(appimage,
+              AS_HELP_STRING([--enable-appimage],
+                             [Enable certain relocation settings useful for building AppImages or generic portable builds [no]]))
+
+P_DATA="$datarootdir/aegisub"
+AEGISUB_CATALOG="aegisub"
+
+AS_IF([test x$enable_appimage = xyes], [
+  AC_DEFINE([APPIMAGE_BUILD], [], [Define to enable AppImage compatible relocations])
+  P_DATA="$bindir"
+  localedir="$bindir/locale"
+  # use a different catalog name
+  AEGISUB_CATALOG="aegisub-appimage"
+])
+
+enable_appimage=${enable_appimage:-no}
+AC_SUBST(P_DATA)
+AC_SUBST(AEGISUB_CATALOG)
+AC_DEFINE_UNQUOTED([AEGISUB_CATALOG], ["${AEGISUB_CATALOG}"], [Name of the Aegisub gettext catalog])
+
 ###############
 # Misc settings
 ###############
@@ -605,12 +632,13 @@ AC_MSG_RESULT([
 Configure settings
   Install prefix:        $prefix
   Revision:              $BUILD_GIT_VERSION_STRING
-  Debug                  $enable_debug
-  CFLAGS                 $CFLAGS
-  CXXFLAGS               $CXXFLAGS
-  CPPFLAGS               $CPPFLAGS
-  LDFLAGS                $LDFLAGS
-  LIBS                   $LIBS
+  Debug:                 $enable_debug
+  AppImage:              $enable_appimage
+  CFLAGS:                $CFLAGS
+  CXXFLAGS:              $CXXFLAGS
+  CPPFLAGS:              $CPPFLAGS
+  LDFLAGS:               $LDFLAGS
+  LIBS:                  $LIBS
 
 Default Settings
   Audio Player:          $DEFAULT_PLAYER_AUDIO

--- a/src/Makefile
+++ b/src/Makefile
@@ -202,6 +202,7 @@ $(d)auto4_lua.o_FLAGS                   := $(CFLAGS_LUA)
 $(d)auto4_lua_assfile.o_FLAGS           := $(CFLAGS_LUA)
 $(d)auto4_lua_dialog.o_FLAGS            := $(CFLAGS_LUA)
 $(d)auto4_lua_progresssink.o_FLAGS      := $(CFLAGS_LUA)
+$(d)aegisublocale.o_FLAGS               := -DP_LOCALE=\"$(P_LOCALE)\"
 
 $(src_OBJ): $(d)libresrc/bitmap.h $(d)libresrc/default_config.h
 

--- a/src/aegisublocale.cpp
+++ b/src/aegisublocale.cpp
@@ -55,6 +55,9 @@ wxTranslations *AegisubLocale::GetTranslations() {
 	if (!translations) {
 		wxTranslations::Set(translations = new wxTranslations);
 		wxFileTranslationsLoader::AddCatalogLookupPathPrefix(config::path->Decode("?data/locale/").wstring());
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined(APPIMAGE_BUILD)
+		wxFileTranslationsLoader::AddCatalogLookupPathPrefix(P_LOCALE);
+#endif
 	}
 	return translations;
 }


### PR DESCRIPTION
Configuring with `--enable-appimage` will set certain relocations that allow Aegisub to be used in a portable way on Linux. Nothing changes if `--enable-appimage` was not given, with one exception: the configured locale path will now be added explicitly to the search path if the OS isn't Windows or Mac and if `--enable-appimage` wasn't set.
A portable build will look for automation files and localizations in the same path as the binary is stored.

Here's an AppImage I built using these changes:
https://drive.google.com/file/d/18xHvZBpwqzYy9zKCBoZQSCX2RdCGAn-c/view?usp=sharing

Here's the build script: https://gist.github.com/darealshinji/9bc9689394b9bd8c6ea6d5f9b1732617