### PR TITLE
Updated library references

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ(2.57)
 ###################
 # Required packages
 ###################
-m4_define([boost_required_version], [1.50.0])
+m4_define([boost_required_version], [1.68.0])
 m4_define([curl_required_version], [7.18.2])
 m4_define([ffms2_required_version], [2.16])
 m4_define([fftw3_required_version], [3.3])

--- a/src/colour_button.cpp
+++ b/src/colour_button.cpp
@@ -18,7 +18,7 @@
 
 #include "dialogs.h"
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 AGI_DEFINE_EVENT(EVT_COLOR, agi::Color);
 

--- a/src/subtitles_provider_libass.cpp
+++ b/src/subtitles_provider_libass.cpp
@@ -46,7 +46,7 @@
 #include <libaegisub/util.h>
 
 #include <atomic>
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <memory>
 #include <mutex>
 

--- a/src/video_frame.cpp
+++ b/src/video_frame.cpp
@@ -16,7 +16,7 @@
 
 #include "video_frame.h"
 
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 #include <wx/image.h>
 
 namespace {

--- a/src/video_provider_dummy.cpp
+++ b/src/video_provider_dummy.cpp
@@ -45,7 +45,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/path.hpp>
 #include <libaegisub/format.h>
-#include <boost/gil/gil_all.hpp>
+#include <boost/gil.hpp>
 
 DummyVideoProvider::DummyVideoProvider(double fps, int frames, int width, int height, agi::Color colour, bool pattern)
 : framecount(frames)


### PR DESCRIPTION
`boost/gil/gil_all.hpp` has been replaced by `boost/gil.hpp` since boost version 1.68.