### PR TITLE
support show previous line for subtitles editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ vendor/luajit/src/lj_vm.s
 vendor/luajit/src/luajit
 
 .nuget
+out/
+.vscode

--- a/src/base_grid.h
+++ b/src/base_grid.h
@@ -117,15 +117,15 @@ class BaseGrid final : public wxWindow {
 	int GetRows() const { return index_line_map.size(); }
 	void MakeRowVisible(int row);
 
-	/// @brief Get dialogue by index
-	/// @param n Index to look up
-	/// @return Subtitle dialogue line for index, or 0 if invalid index
-	AssDialogue *GetDialogue(int n) const;
 
 public:
 	BaseGrid(wxWindow* parent, agi::Context *context);
 	~BaseGrid();
 
+	/// @brief Get dialogue by index
+	/// @param n Index to look up
+	/// @return Subtitle dialogue line for index, or 0 if invalid index
+	AssDialogue *GetDialogue(int n) const;
 	void SetByFrame(bool state);
 	void ScrollTo(int y);
 

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -354,6 +354,7 @@ void SubsEditBox::UpdateFields(int type, bool repopulate_lists) {
 	}
 
 	if (type & AssFile::COMMIT_DIAG_TEXT) {
+		prev_editor->SetTextTo(prev_line->Text);
 		edit_ctrl->SetTextTo(line->Text);
 		UpdateCharacterCount(line->Text);
 	}
@@ -407,6 +408,9 @@ void SubsEditBox::PopulateList(wxComboBox *combo, boost::flyweight<std::string> 
 
 void SubsEditBox::OnActiveLineChanged(AssDialogue *new_line) {
 	wxEventBlocker blocker(this);
+	if(new_line != line) {
+		prev_line = line;
+	}
 	line = new_line;
 	commit_id = -1;
 

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -250,6 +250,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	 });
 
 	context->textSelectionController->SetControl(edit_ctrl);
+
 	edit_ctrl->SetFocus();
 }
 
@@ -354,7 +355,9 @@ void SubsEditBox::UpdateFields(int type, bool repopulate_lists) {
 	}
 
 	if (type & AssFile::COMMIT_DIAG_TEXT) {
-		prev_editor->SetTextTo(prev_line->Text);
+		if(prev_line) {
+			prev_editor->SetValue(to_wx(prev_line->Text));
+		}
 		edit_ctrl->SetTextTo(line->Text);
 		UpdateCharacterCount(line->Text);
 	}
@@ -408,9 +411,8 @@ void SubsEditBox::PopulateList(wxComboBox *combo, boost::flyweight<std::string> 
 
 void SubsEditBox::OnActiveLineChanged(AssDialogue *new_line) {
 	wxEventBlocker blocker(this);
-	if(new_line != line) {
-		prev_line = line;
-	}
+
+	prev_line = c->subsGrid->GetDialogue(new_line->Row - 1);
 	line = new_line;
 	commit_id = -1;
 
@@ -424,9 +426,6 @@ void SubsEditBox::OnSelectedSetChanged() {
 void SubsEditBox::OnLineInitialTextChanged(std::string const& new_text) {
 	if (split_box->IsChecked())
 		secondary_editor->SetValue(to_wx(new_text));
-
-	if (prev_box->IsChecked())
-		prev_editor->SetValue(to_wx(new_text));
 }
 
 void SubsEditBox::UpdateFrameTiming(agi::vfr::Framerate const& fps) {

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -192,7 +192,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	middle_right_sizer->Add(split_box, wxSizerFlags().Center().Left());
 
 	prev_box = new wxCheckBox(this,-1,_("Show Prev Line"));
-	prev_box->SetToolTip(_("Show the contents of the subtitle line when it was first selected above the edit box. This is sometimes useful when editing subtitles or translating subtitles into another language."));
+	prev_box->SetToolTip(_("Show previous line. This is sometimes useful when editing bilingual subtitles. "));
 	prev_box->Bind(wxEVT_CHECKBOX, &SubsEditBox::OnPrev, this);
 	middle_right_sizer->Add(prev_box, wxSizerFlags().Center().Left());
 

--- a/src/subs_edit_box.h
+++ b/src/subs_edit_box.h
@@ -69,6 +69,9 @@ class SubsEditBox final : public wxPanel {
 
 	std::vector<agi::signal::Connection> connections;
 
+	/// Previous dialogue line
+	AssDialogue *prev_line = nullptr;
+
 	/// Currently active dialogue line
 	AssDialogue *line = nullptr;
 	AssStyle *active_style = nullptr;

--- a/src/subs_edit_box.h
+++ b/src/subs_edit_box.h
@@ -97,6 +97,9 @@ class SubsEditBox final : public wxPanel {
 	wxRadioButton *by_frame;
 	wxTextCtrl *char_count;
 	wxCheckBox *split_box;
+	wxCheckBox *prev_box;
+
+
 
 	wxSizer *top_sizer;
 	wxSizer *middle_right_sizer;
@@ -152,6 +155,7 @@ class SubsEditBox final : public wxPanel {
 	void OnEffectChange(wxCommandEvent &);
 	void OnSize(wxSizeEvent &event);
 	void OnSplit(wxCommandEvent&);
+	void OnPrev(wxCommandEvent&);
 
 	void SetPlaceholderCtrl(wxControl *ctrl, wxString const& value);
 
@@ -197,6 +201,7 @@ class SubsEditBox final : public wxPanel {
 
 	SubsTextEditCtrl *edit_ctrl;
 	wxTextCtrl *secondary_editor;
+	wxTextCtrl *prev_editor;
 
 public:
 	/// @brief Constructor


### PR DESCRIPTION
support show previous line. This is sometimes useful when editing bilingual subtitles. 