### PR TITLE
Fix crashing when picking language

### DIFF
--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -56,6 +56,10 @@
 #include <wx/menu.h>
 #include <wx/settings.h>
 
+// Maximum number of languages (locales)
+// It should be above 100 (at least 242) and probably not more than 1000
+#define LANGS_MAX 1000
+
 /// Event ids
 enum {
 	EDIT_MENU_SPLIT_PRESERVE = 1400,
@@ -73,7 +77,7 @@ enum {
 	EDIT_MENU_THESAURUS_SUGS,
 	EDIT_MENU_DIC_LANGUAGE = 1600,
 	EDIT_MENU_DIC_LANGS,
-	EDIT_MENU_THES_LANGUAGE = 1700,
+	EDIT_MENU_THES_LANGUAGE = EDIT_MENU_DIC_LANGUAGE + LANGS_MAX,
 	EDIT_MENU_THES_LANGS
 };
 
@@ -178,7 +182,7 @@ BEGIN_EVENT_TABLE(SubsTextEditCtrl,wxStyledTextCtrl)
 	EVT_MENU_RANGE(EDIT_MENU_SUGGESTIONS,EDIT_MENU_THESAURUS-1,SubsTextEditCtrl::OnUseSuggestion)
 	EVT_MENU_RANGE(EDIT_MENU_THESAURUS_SUGS,EDIT_MENU_DIC_LANGUAGE-1,SubsTextEditCtrl::OnUseSuggestion)
 	EVT_MENU_RANGE(EDIT_MENU_DIC_LANGS,EDIT_MENU_THES_LANGUAGE-1,SubsTextEditCtrl::OnSetDicLanguage)
-	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+100,SubsTextEditCtrl::OnSetThesLanguage)
+	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+LANGS_MAX,SubsTextEditCtrl::OnSetThesLanguage)
 END_EVENT_TABLE()
 
 void SubsTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {


### PR DESCRIPTION
Aegisub crashes immediately after selecting any language from the end of the list (above the 100th position).
This is because it can support no more than 100 languages.
This patch extends this limit up to 1000 languages (locales).

Fixes #131

---

Test results from my system.

Number of dictionaries:
```
$ find /usr/share/myspell/ -xtype f -iname '*.dic' -exec printf %.0s. {} + | wc -m
242
```
Number of thesaurus:
```
$ find /usr/share/myspell/ -xtype f -iname '*.aff' -exec printf %.0s. {} + | wc -m
242
```
Number of languages:
```
$ cat <( find /usr/share/myspell/ -xtype f -iname '*.dic' -exec printf %.0s. {} + | wc -m ) <( find /usr/share/myspell/ -xtype f -iname '*.aff' -exec printf %.0s. {} + | wc -m ) | sort -nr | head -n 1
242
```
Number of locales:
```
locale -a | wc -l
791
```

---

See also:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=935724#10
https://bugs.launchpad.net/ubuntu/+source/aegisub/+bug/1841381/comments/2