### PR TITLE
Fix deprecated calls to wxSTC

### DIFF
--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -400,7 +400,11 @@ void DialogFontsCollector::OnAddText(ValueEvent<color_str_pair> &event) {
 	auto const& utf8 = str.second.utf8_str();
 	collection_log->AppendTextRaw(utf8.data(), utf8.length());
 	if (str.first) {
+		#if wxCHECK_VERSION(3, 1, 0)
+		collection_log->StartStyling(pos);
+		#else
 		collection_log->StartStyling(pos, 31);
+		#endif
 		collection_log->SetStyling(utf8.length(), str.first);
 	}
 	collection_log->GotoPos(pos + utf8.length());

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -244,7 +244,11 @@ void DialogTranslation::UpdateDisplay() {
 			int initial_pos = original_text->GetLength();
 			original_text->AppendTextRaw(block->GetText().c_str());
 			if (i == cur_block) {
+				#if wxCHECK_VERSION(3, 1, 0)
+				original_text->StartStyling(initial_pos);
+				#else
 				original_text->StartStyling(initial_pos, 31);
+				#endif
 				original_text->SetStyling(block->GetText().size(), 1);
 			}
 		}

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -261,7 +261,11 @@ void SubsTextEditCtrl::UpdateStyle() {
 	cursor_pos = -1;
 	UpdateCallTip();
 
+	#if wxCHECK_VERSION(3, 1, 0)
+	StartStyling(0);
+	#else
 	StartStyling(0,255);
+	#endif
 
 	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
 		SetStyling(line_text.size(), 0);


### PR DESCRIPTION
wxStyledTextCtrl::StartStyling() should take only one argument since wxWidgets 3.1.

Steps to reproduce:
1. Get the latest version of Aegisub compiled against wxWidgets 3.1.2 (Gtk+2 or Gtk+3)
2. Paste any text from clipboard

Warning message:
```
./src/stc/stc.cpp(5177): assert "unused==0" failed in StartStyling(): The second argument passed to StartStyling should be 0
```

Fixes #133