### PR TITLE
Add missing AM_GNU_GETTEXT_VERSION macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -505,6 +505,7 @@ AC_PCH_FLAG([-fpch-preprocess])
 # Internationalisation support
 ##############################
 AM_GNU_GETTEXT([external])
+AM_GNU_GETTEXT_VERSION([0.18.1])
 
 ################
 # Update checker


### PR DESCRIPTION
Add missing AM_GNU_GETTEXT_VERSION macro.

https://web.archive.org/web/20160729163303/http://devel.aegisub.org/ticket/1914

This patch is present in the official Mageia packages.
http://distrib-coffee.ipsl.jussieu.fr/pub/linux/Mageia/distrib/cauldron/SRPMS/core/release/aegisub-3.2.2-14.git20180730.7.mga8.src.rpm