### PR TITLE
Fix compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,20 +133,18 @@ AS_IF([test x$build_darwin != xyes], [
 AC_ARG_ENABLE(compiler-flags, AS_HELP_STRING([--disable-compiler-flags],[Disable *all* additional compiler flags. [no]]))
 
 AS_IF([test x$enable_compiler_flags != xno], [
-  CFLAGS="$CFLAGS -Wall -Wextra -Wno-unused-parameter -std=gnu99 -pipe -g"
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing -pipe -g"
+  CFLAGS="$CFLAGS -Wall -Wextra -Wno-unused-parameter"
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing"
+  AC_C_FLAG([-std=gnu99])
   AC_CXX_FLAG([-std=c++11])
-  AC_CXX_FLAG([-Wno-c++11-narrowing])
+  AC_CXX_FLAG([-Wno-narrowing])
   AC_C_FLAG([-Wno-unused-local-typedefs])
   AC_CXX_FLAG([-Wno-unused-local-typedefs])
 
   # -O* messes with debugging.
   AS_IF([test x$enable_debug = xyes], [
-    CFLAGS="$CFLAGS -O0"
-    CXXFLAGS="$CXXFLAGS -O0"
-  ], [
-    CFLAGS="$CFLAGS -O3"
-    CXXFLAGS="$CXXFLAGS -O3"
+    CFLAGS="$CFLAGS -O0 -g"
+    CXXFLAGS="$CXXFLAGS -O0 -g"
   ])
 ])
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -188,14 +188,13 @@ endif
 #####################
 # SOURCE-LEVEL CFLAGS
 #####################
-$(d)MatroskaParser.o_FLAGS              := -Wno-sometimes-uninitialized
 $(d)audio_player.o_FLAGS                := $(CFLAGS_ALSA) $(CFLAGS_PORTAUDIO) $(CFLAGS_LIBPULSE) $(CFLAGS_OPENAL)
 $(d)audio_provider_factory.o_FLAGS      := $(CFLAGS_FFMS2)
 $(d)auto4_base.o_FLAGS                  := $(CFLAGS_FREETYPE)
 $(d)charset_detect.o_FLAGS              := -D_X86_
 $(d)font_file_lister_fontconfig.o_FLAGS := $(CFLAGS_FONTCONFIG)
 $(d)subtitles_provider.o_FLAGS          := $(CFLAGS_LIBASS)
-$(d)subtitles_provider_libass.o_FLAGS   := $(CFLAGS_LIBASS) -Wno-c++11-narrowing
+$(d)subtitles_provider_libass.o_FLAGS   := $(CFLAGS_LIBASS) -Wno-narrowing
 $(d)text_file_reader.o_FLAGS            := -D_X86_
 $(d)video_provider_manager.o_FLAGS      := $(CFLAGS_FFMS2)
 $(d)auto4_lua.o_FLAGS                   := $(CFLAGS_LUA)


### PR DESCRIPTION
Fix compiler flags.

https://web.archive.org/web/20161027172607/http://devel.aegisub.org/ticket/1899
https://web.archive.org/web/20161027171240/http://devel.aegisub.org/ticket/1900
https://github.com/Aegisub/Aegisub/pull/29
https://github.com/gentoo/gentoo/blob/be23ef21ed508c8e580f3ee8f302ce2abc5c3fbe/media-video/aegisub/files/3.2.2_p20160518/aegisub-3.2.2_p20160518-respect-compiler-flags.patch

Similar patches are present in the official RPM Fusion (Fedora), openSUSE and Gentoo packages.
http://download1.rpmfusion.org/free/fedora/development/rawhide/source/SRPMS/aegisub-3.2.2-15.20180710.git524c611.fc31.src.rpm
http://download.opensuse.org/repositories/openSUSE:/Factory/standard/src/aegisub-3.2.2+git20180710-3.6.src.rpm
https://github.com/gentoo/gentoo/blob/be23ef21ed508c8e580f3ee8f302ce2abc5c3fbe/media-video/aegisub