### PR TITLE
Fix compilation by adding pthread dependency

### DIFF
--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -29,7 +29,7 @@ CXXFLAGS            = @CXXFLAGS@
 CPPFLAGS            = @CPPFLAGS@
 CFLAGS_DEP          = -MMD -MP
 LIBS                = @LIBS@
-LDFLAGS             = @LDFLAGS@
+LDFLAGS             = @LDFLAGS@ -pthread
 INSTALL_FLAGS       = -m 644
 LIB_SHARED_LINK     = -shared -Wl,-soname -Wl,$(LIB_SHARED_FULL)
 LIB_SHARED_LINK_OSX = -dynamiclib -Wl,-undefined -Wl,dynamic_lookup -compatibility_version $(LIB_VERSION) -current_version $(LIB_VERSION) -Wl,-single_module -mmacosx-version-min=10.8 -install_name ${CURDIR}/$(LIB_SHARED_FULL)


### PR DESCRIPTION
Fix compilation by adding pthread dependency.

This patch is present in the official RPM Fusion (Fedora), openSUSE and Arch packages.
http://download1.rpmfusion.org/free/fedora/development/rawhide/source/SRPMS/aegisub-3.2.2-15.20180710.git524c611.fc31.src.rpm
http://download.opensuse.org/repositories/openSUSE:/Factory/standard/src/aegisub-3.2.2+git20180710-3.6.src.rpm
https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/aegisub&id=b743d16ff429c8227c3905a64e0f02de8163814a#n51
Similar patches are present in the official Debian and Ubuntu packages.
http://deb.debian.org/debian/pool/main/a/aegisub/aegisub_3.2.2+dfsg-4.debian.tar.xz
http://archive.ubuntu.com/ubuntu/pool/universe/a/aegisub/aegisub_3.2.2+dfsg-4build1.debian.tar.xz