### PR TITLE
Fix compilation by adding libatomic dependency

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,8 @@ src_CPPFLAGS := -I$(d) -I.. -I$(d)include -I$(TOP)libaegisub/include -I$(TOP)bui
 	$(CFLAGS_PTHREAD) $(CFLAGS_FFTW3) $(CFLAGS_ICU) $(CPPFLAGS_BOOST)
 src_CXXFLAGS := $(CXXFLAGS_WX)
 src_LIBS := $(LIBS_GL) $(LIBS_PTHREAD) $(LIBS_WX) $(LIBS_FREETYPE) \
-	$(LIBS_LIBASS) $(LIBS_FONTCONFIG) $(LIBS_FFTW3)  $(LIBS_BOOST) $(LIBS_ICU)
+	$(LIBS_LIBASS) $(LIBS_FONTCONFIG) $(LIBS_FFTW3)  $(LIBS_BOOST) $(LIBS_ICU) \
+        -latomic
 src_PCH := $(d)agi_pre.h
 src_INSTALLNAME := $(AEGISUB_COMMAND)
 


### PR DESCRIPTION
Fix compilation by adding libatomic dependency.

This should fix compilation on some arches, especially MIPS and PPC.

This patch is present in the official Debian and Ubuntu packages.
http://deb.debian.org/debian/pool/main/a/aegisub/aegisub_3.2.2+dfsg-4.debian.tar.xz
http://archive.ubuntu.com/ubuntu/pool/universe/a/aegisub/aegisub_3.2.2+dfsg-4build1.debian.tar.xz