### PR TITLE
Fixes for Boost 1.69.0

### DIFF
--- a/src/colour_button.cpp
+++ b/src/colour_button.cpp
@@ -18,7 +18,11 @@
 
 #include "dialogs.h"
 
+#if BOOST_VERSION >= 106900
+#include <boost/gil.hpp>
+#else
 #include <boost/gil/gil_all.hpp>
+#endif
 
 AGI_DEFINE_EVENT(EVT_COLOR, agi::Color);
 

--- a/src/subtitles_provider_libass.cpp
+++ b/src/subtitles_provider_libass.cpp
@@ -46,7 +46,11 @@
 #include <libaegisub/util.h>
 
 #include <atomic>
+#if BOOST_VERSION >= 106900
+#include <boost/gil.hpp>
+#else
 #include <boost/gil/gil_all.hpp>
+#endif
 #include <memory>
 #include <mutex>
 

--- a/src/video_frame.cpp
+++ b/src/video_frame.cpp
@@ -16,7 +16,11 @@
 
 #include "video_frame.h"
 
+#if BOOST_VERSION >= 106900
+#include <boost/gil.hpp>
+#else
 #include <boost/gil/gil_all.hpp>
+#endif
 #include <wx/image.h>
 
 namespace {

--- a/src/video_provider_dummy.cpp
+++ b/src/video_provider_dummy.cpp
@@ -45,7 +45,11 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/path.hpp>
 #include <libaegisub/format.h>
+#if BOOST_VERSION >= 106900
+#include <boost/gil.hpp>
+#else
 #include <boost/gil/gil_all.hpp>
+#endif
 
 DummyVideoProvider::DummyVideoProvider(double fps, int frames, int width, int height, agi::Color colour, bool pattern)
 : framecount(frames)


### PR DESCRIPTION
Fixes for Boost 1.69.0.

https://github.com/Aegisub/Aegisub/issues/93
https://github.com/wangqr/Aegisub/commit/bb1f66a01f6e4661ab9c6610c5c2eee67bd0bd61
https://github.com/gentoo/gentoo/blob/e2087ed19aa3327eb00833f64e5bf315d43816fa/media-video/aegisub/files/3.2.2_p20160518/aegisub-3.2.2_p20160518-fix-boost170-build.patch

This patch is present in the official Gentoo packages.
https://github.com/gentoo/gentoo/blob/be23ef21ed508c8e580f3ee8f302ce2abc5c3fbe/media-video/aegisub
Similar patches are present in the official RPM Fusion (Fedora) and openSUSE packages.
http://download1.rpmfusion.org/free/fedora/development/rawhide/source/SRPMS/aegisub-3.2.2-15.20180710.git524c611.fc31.src.rpm
http://download.opensuse.org/repositories/openSUSE:/Factory/standard/src/aegisub-3.2.2+git20180710-3.6.src.rpm