### PR TITLE
Fix crash on right click due to no spell checker

### DIFF
--- a/src/spellchecker.cpp
+++ b/src/spellchecker.cpp
@@ -22,10 +22,12 @@
 #include <libaegisub/make_unique.h>
 #include <libaegisub/spellchecker.h>
 
+#ifdef __APPLE__
 namespace agi {
 class OptionValue;
 std::unique_ptr<agi::SpellChecker> CreateCocoaSpellChecker(OptionValue *opt);
 }
+#endif
 
 std::unique_ptr<agi::SpellChecker> SpellCheckerFactory::GetSpellChecker() {
 #ifdef __APPLE__

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -366,15 +366,16 @@ void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	currentWord = line_text.substr(currentWordPos.first, currentWordPos.second);
 
 	wxMenu menu;
-	if (spellchecker)
+	if (spellchecker) {
 		AddSpellCheckerEntries(menu);
 
-	// Append language list
-	menu.Append(-1,_("Spell checker language"), GetLanguagesMenu(
-		EDIT_MENU_DIC_LANGS,
-		to_wx(OPT_GET("Tool/Spell Checker/Language")->GetString()),
-		to_wx(spellchecker->GetLanguageList())));
-	menu.AppendSeparator();
+		// Append language list
+		menu.Append(-1, _("Spell checker language"), GetLanguagesMenu(
+			EDIT_MENU_DIC_LANGS,
+			to_wx(OPT_GET("Tool/Spell Checker/Language")->GetString()),
+			to_wx(spellchecker->GetLanguageList())));
+		menu.AppendSeparator();
+	}
 
 	AddThesaurusEntries(menu);
 


### PR DESCRIPTION
Fix crash on right click due to no spell checker.

See: #131

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=935724#15
https://github.com/wangqr/Aegisub/commit/0b8b286767bf796ecfc993c38c4ad14091703162#diff-64304e039535719d12a4a36d333a555c

A similar patch is going to be included in the official Debian packages.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=935724#25