### PR TITLE
Fix paths

### DIFF
--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -56,7 +56,9 @@ P_LOCALE      = @localedir@
 
 P_DESKTOP     = @P_DESKTOP@
 P_ICON        = @P_ICON@
-P_DATA        = $(P_DATAROOT)/aegisub/
+P_DATA        = $(P_DATAROOT)/aegisub
+
+P_DICTIONARY  = @P_DICTIONARY@
 
 ###############
 # LIBRARY FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,15 @@ AC_ARG_WITH(icon-dir,
 P_ICON=${with_icon_dir:-$datarootdir/icons}
 AC_SUBST(P_ICON)
 
+# Handle location of dictionaries: https://github.com/hunspell/hunspell/blob/v1.7.0/src/tools/hunspell.cxx#L119
+AC_ARG_WITH(dict-dir,
+            AS_HELP_STRING([--with-dict-dir=PATH],[dictionary locations [/usr/share/hunspell]]))
+
+P_DICTIONARY=${with_dict_dir:-/usr/share/hunspell}
+AC_SUBST(P_DICTIONARY)
+
+AC_DEFINE_UNQUOTED([P_DICTIONARY], ["${P_DICTIONARY}"], [Location of dictionaries])
+
 # Install prefix
 # If a user doesn't supply --prefix then it is set to NONE so we
 # set it to $ac_default_prefix if it hasn't been supplied.
@@ -90,6 +99,41 @@ AS_IF([test x$use_build_credit = xyes],
     AC_DEFINE_UNQUOTED([BUILD_CREDIT], ["$with_build_credit"], [Build credit supplied in application title using --with-build-credit=])
   ]),
   [AC_MSG_RESULT([no])])
+
+####################
+# XDG dirs support
+####################
+# If enabled, Aegisub will try to use XDG compatible base directories.
+# https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+# https://developer.gnome.org/basedir-spec/
+xdg_dirs_level_default=3
+
+xdg_dirs_level_default_disabled=0
+xdg_dirs_level_default_enabled=$(( xdg_dirs_level_default > 1 ? xdg_dirs_level_default : 1 ))
+
+AC_ARG_ENABLE(xdg-dirs,
+  [AS_HELP_STRING([--disable-xdg-dirs],[Disable compatibility with XDG dirs.])
+AS_HELP_STRING([--enable-xdg-dirs],[Enable compatibility with XDG dirs.])
+AS_HELP_STRING([--enable-xdg-dirs=LEVEL],[Specify the LEVEL of compatibility with XDG dirs:])
+  AS_HELP_STRING([],[0: none (disabled)])
+  AS_HELP_STRING([],[1: +XDG_CONFIG_HOME])
+  AS_HELP_STRING([],[2: +XDG_DATA_HOME])
+  AS_HELP_STRING([],[3: +XDG_CACHE_HOME])],
+  [case "${enableval}" in
+         no)  xdg_dirs_level=${xdg_dirs_level_default_disabled} ;;
+    [[0-3]])  xdg_dirs_level=${enableval} ;;
+        yes)  xdg_dirs_level=${xdg_dirs_level_default_enabled} ;;
+          *)  AC_MSG_ERROR(Unknown argument to --enable-xdg-dirs: ${enableval}) ;;
+  esac],
+  [xdg_dirs_level=${xdg_dirs_level_default}]
+)
+
+case "${xdg_dirs_level}" in
+    0)  AC_DEFINE([XDG_DIRS], 0, [XDG dirs: none (disabled)]) ;;
+    1)  AC_DEFINE([XDG_DIRS], 1, [XDG dirs: XDG_CONFIG_HOME]) ;;
+    2)  AC_DEFINE([XDG_DIRS], 2, [XDG dirs: XDG_CONFIG_HOME, XDG_DATA_HOME]) ;;
+    3)  AC_DEFINE([XDG_DIRS], 3, [XDG dirs: XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME]) ;;
+esac
 
 ####################
 # Check for programs
@@ -605,12 +649,13 @@ AC_MSG_RESULT([
 Configure settings
   Install prefix:        $prefix
   Revision:              $BUILD_GIT_VERSION_STRING
-  Debug                  $enable_debug
-  CFLAGS                 $CFLAGS
-  CXXFLAGS               $CXXFLAGS
-  CPPFLAGS               $CPPFLAGS
-  LDFLAGS                $LDFLAGS
-  LIBS                   $LIBS
+  XDG dirs support:      level ${xdg_dirs_level:-0}
+  Debug:                 $enable_debug
+  CFLAGS:                $CFLAGS
+  CXXFLAGS:              $CXXFLAGS
+  CPPFLAGS:              $CPPFLAGS
+  LDFLAGS:               $LDFLAGS
+  LIBS:                  $LIBS
 
 Default Settings
   Audio Player:          $DEFAULT_PLAYER_AUDIO

--- a/libaegisub/common/path.cpp
+++ b/libaegisub/common/path.cpp
@@ -18,6 +18,8 @@
 
 #include "libaegisub/fs.h"
 
+#include <iostream>
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/distance.hpp>
 
@@ -58,6 +60,12 @@ Path::Path() {
 	static_assert(sizeof(paths) / sizeof(paths[0]) == sizeof(tokens) / sizeof(tokens[0]),
 		"Token and path arrays need to be the same size");
 	FillPlatformSpecificPaths();
+	std::cout << "Paths:" << std::endl;
+	std::cout << "?user: " << Decode("?user") << std::endl;
+	std::cout << "?local: " << Decode("?local") << std::endl;
+	std::cout << "?data: " << Decode("?data") << std::endl;
+	std::cout << "?dictionary: " << Decode("?dictionary") << std::endl;
+	std::cout << "?temp: " << Decode("?temp") << std::endl;
 }
 
 fs::path Path::Decode(std::string const& path) const {


### PR DESCRIPTION
# Fix paths

## Allow to use a custom path for dictionaries

You can use the `--with-dict-dir=PATH` option to specify the path for dictionaries, e.g. `/usr/share/hunspell`, `/usr/share/myspell`, `/app/share/hunspell`, `/usr/local/share/hunspell`, `/opt/share/hunspell`, etc.

## Respect the XDG Base Directory Specification

Add 3 options:
 - `--disable-xdg-dirs`
 - `--enable-xdg-dirs`
 - `--enable-xdg-dirs=LEVEL`

Possible levels:
 - 0: none (disabled)
 - 1: +`XDG_CONFIG_HOME`
 - 2: +`XDG_DATA_HOME`
 - 3: +`XDG_CACHE_HOME`

# Print platform specific paths

Print values of the platform specific paths:
 - `?user`
 - `?local`
 - `?data`
 - `?dictionary`
 - `?temp`