### PR TITLE
Fix millisecond to centisecond convertion

### DIFF
--- a/libaegisub/ass/time.cpp
+++ b/libaegisub/ass/time.cpp
@@ -60,25 +60,35 @@ Time::Time(std::string const& text) {
 }
 
 std::string Time::GetAssFormatted(bool msPrecision) const {
+	int ass_time = msPrecision ? time : int(*this);
 	std::string ret(10 + msPrecision, ':');
-	ret[0] = '0' + GetTimeHours();
-	ret[2] = '0' + (time % (60 * 60 * 1000)) / (60 * 1000 * 10);
-	ret[3] = '0' + (time % (10 * 60 * 1000)) / (60 * 1000);
-	ret[5] = '0' + (time % (60 * 1000)) / (1000 * 10);
-	ret[6] = '0' + (time % (10 * 1000)) / 1000;
+	ret[0] = '0' + ass_time / 3600000;
+	ret[2] = '0' + (ass_time % (60 * 60 * 1000)) / (60 * 1000 * 10);
+	ret[3] = '0' + (ass_time % (10 * 60 * 1000)) / (60 * 1000);
+	ret[5] = '0' + (ass_time % (60 * 1000)) / (1000 * 10);
+	ret[6] = '0' + (ass_time % (10 * 1000)) / 1000;
 	ret[7] = '.';
-	ret[8] = '0' + (time % 1000) / 100;
-	ret[9] = '0' + (time % 100) / 10;
+	ret[8] = '0' + (ass_time % 1000) / 100;
+	ret[9] = '0' + (ass_time % 100) / 10;
 	if (msPrecision)
-		ret[10] = '0' + time % 10;
+		ret[10] = '0' + ass_time % 10;
 	return ret;
 }
 
-int Time::GetTimeHours() const { return time / 3600000; }
-int Time::GetTimeMinutes() const { return (time % 3600000) / 60000; }
-int Time::GetTimeSeconds() const { return (time % 60000) / 1000; }
-int Time::GetTimeMiliseconds() const { return (time % 1000); }
-int Time::GetTimeCentiseconds() const { return (time % 1000) / 10; }
+std::string Time::GetSrtFormatted() const {
+	std::string ret(12, ':');
+	ret[0] = '0';
+	ret[1] = '0' + time / 3600000;
+	ret[3] = '0' + (time % (60 * 60 * 1000)) / (60 * 1000 * 10);
+	ret[4] = '0' + (time % (10 * 60 * 1000)) / (60 * 1000);
+	ret[6] = '0' + (time % (60 * 1000)) / (1000 * 10);
+	ret[7] = '0' + (time % (10 * 1000)) / 1000;
+	ret[8] = ',';
+	ret[9] = '0' + (time % 1000) / 100;
+	ret[10] = '0' + (time % 100) / 10;
+	ret[11] = '0' + time % 10;
+	return ret;
+}
 
 SmpteFormatter::SmpteFormatter(vfr::Framerate fps, char sep)
 : fps(std::move(fps))

--- a/libaegisub/ass/time.cpp
+++ b/libaegisub/ass/time.cpp
@@ -24,7 +24,7 @@
 #include <algorithm>
 
 namespace agi {
-Time::Time(int time) : time(util::mid(0, time, 10 * 60 * 60 * 1000 - 1)) { }
+Time::Time(int time) : time(util::mid(0, time, 10 * 60 * 60 * 1000 - 6)) { }
 
 Time::Time(std::string const& text) {
 	int after_decimal = -1;
@@ -56,7 +56,7 @@ Time::Time(std::string const& text) {
 		time = (time * 60 + current) * 1000;
 
 	// Limit to the valid range
-	time = util::mid(0, time, 10 * 60 * 60 * 1000 - 1);
+	time = util::mid(0, time, 10 * 60 * 60 * 1000 - 6);
 }
 
 std::string Time::GetAssFormatted(bool msPrecision) const {

--- a/libaegisub/include/libaegisub/ass/time.h
+++ b/libaegisub/include/libaegisub/ass/time.h
@@ -28,16 +28,14 @@ public:
 	Time(std::string const& text);
 
 	/// Get millisecond, rounded to centisecond precision
-	operator int() const { return time / 10 * 10; }
-
-	int GetTimeHours() const;        ///< Get the hours portion of this time
-	int GetTimeMinutes() const;      ///< Get the minutes portion of this time
-	int GetTimeSeconds() const;      ///< Get the seconds portion of this time
-	int GetTimeMiliseconds() const;  ///< Get the miliseconds portion of this time
-	int GetTimeCentiseconds() const; ///< Get the centiseconds portion of this time
+	// Always round up for 5ms because the range is [start, stop)
+	operator int() const { return (time + 5) - (time + 5) % 10; }
 
 	/// Return the time as a string
 	/// @param ms Use milliseconds precision, for non-ASS formats
 	std::string GetAssFormatted(bool ms=false) const;
+
+	/// Return the time as a string
+	std::string GetSrtFormatted() const;
 };
 }

--- a/src/subtitle_format_srt.cpp
+++ b/src/subtitle_format_srt.cpp
@@ -279,7 +279,7 @@ public:
 
 std::string WriteSRTTime(agi::Time const& ts)
 {
-	return agi::format("%02d:%02d:%02d,%03d", ts.GetTimeHours(), ts.GetTimeMinutes(), ts.GetTimeSeconds(), ts.GetTimeMiliseconds());
+	return ts.GetSrtFormatted();
 }
 
 }

--- a/tests/tests/time.cpp
+++ b/tests/tests/time.cpp
@@ -62,17 +62,9 @@ TEST(lagi_time, extra_garbage_is_ignored) {
 	EXPECT_STREQ("1:23:45.67", Time("1a:b2c3d:e4f5g.!6&7").GetAssFormatted().c_str());
 }
 
-TEST(lagi_time, component_getters) {
-	Time t("1:23:45.67");
-	EXPECT_EQ(1, t.GetTimeHours());
-	EXPECT_EQ(23, t.GetTimeMinutes());
-	EXPECT_EQ(45, t.GetTimeSeconds());
-	EXPECT_EQ(67, t.GetTimeCentiseconds());
-	EXPECT_EQ(670, t.GetTimeMiliseconds());
-}
-
 TEST(lagi_time, srt_time) {
 	EXPECT_STREQ("1:23:45.678", Time("1:23:45,678").GetAssFormatted(true).c_str());
+	EXPECT_STREQ("01:23:45,678", Time("1:23:45,678").GetSrtFormatted().c_str());
 }
 
 TEST(lagi_time, smpte_parse_valid) {


### PR DESCRIPTION
In original algorithm, the millisecond of the video frame is recorded when using ctrl+3/4. Ass only support centisecond, and the value is floor-ed to centisecond. In some cases this will shift the postion by 1 frame. This PR changes floor to round, to fix this issue. In case the last digit is 5, the value is always rounded up, so the next frame will be correctly included, but the previous frame is not. This only works with video framerate <= 100fps, but centisecond is only capable to be frame accurate for less than 100fps anyway.

This fix Aegisub/Aegisub#94