### PR TITLE
fix: infinite recursion when loading video

### DIFF
--- a/src/video_display.cpp
+++ b/src/video_display.cpp
@@ -409,12 +409,14 @@ void VideoDisplay::SetZoomFromBoxText(wxCommandEvent &) {
 }
 
 void VideoDisplay::SetTool(std::unique_ptr<VisualToolBase> new_tool) {
+	// Set the tool first to prevent repeated initialization from VideoDisplay::Render
+	tool = std::move(new_tool);
+
+	// Hide the tool bar first to eliminate unecessary size changes
+	toolBar->Show(false);
 	toolBar->ClearTools();
 	toolBar->AddSeparator();
 	toolBar->Realize();
-	toolBar->Show(false);
-
-	tool = std::move(new_tool);
 	tool->SetToolbar(toolBar);
 
 	// Update size as the new typesetting tool may have changed the subtoolbar size


### PR DESCRIPTION
In 888be0607fdfc2ed7801fd67f46ab4f98257d419 some changes have been made to video_display.cpp which causes infinite recursion: the video display enables video/tool/cross tool when running VideoDisplay::Render() for the first time.
But when setting up the tool, the video box size is changed, which calls VideoDisplay::Render() again. So we need to set the tool BEFORE it modifies the box by "AddSeparator".

Fix wangqr/Aegisub#21

Co-authored-by: Charlie Jiang <cqjjjzr@126.com>