### PR TITLE
Resolve #155: minor inaccuracy in Chinese translations

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -404,8 +404,8 @@ msgid ""
 "extend or shrink start time of the second line; if totally to right, it will "
 "extend or shrink the end time of the first line."
 msgstr ""
-"设置如何紧贴字幕行，如果设为完全向左，将扩展至次行的开始时间；如果完全向右,将"
-"扩展至首行的结束时间。"
+"设置如何紧贴字幕行，如果设为完全向左，将扩展或收缩次行的开始时间；如果完全向右,将"
+"扩展或收缩首行的结束时间。"
 
 #: ../src/dialog_timing_processor.cpp:204
 msgid "Bias: Start <- "

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -404,8 +404,8 @@ msgid ""
 "extend or shrink start time of the second line; if totally to right, it will "
 "extend or shrink the end time of the first line."
 msgstr ""
-"設置如何緊貼字幕行，如果設為完全向左，將擴展至次行的開始時間；如果完全向右,將"
-"擴展至首行的結束時間。"
+"設置如何緊貼字幕行，如果設為完全向左，將擴展或收縮次行的開始時間；如果完全向右,將"
+"擴展或收縮首行的結束時間。"
 
 #: ../src/dialog_timing_processor.cpp:204
 msgid "Bias: Start <- "


### PR DESCRIPTION
Minor fix for both the traditional and simplified Chinese translations as per [#155](https://github.com/Aegisub/Aegisub/issues/155):

English:
> extend or shrink the ......

Chinese - current corrected version:
> 擴展或收縮 ......
> 扩展或收缩 ......

Chinese - original incorrect version:
> 擴展至 ......
> 扩展至 ......