### PR TITLE
Localization improvements and updated Catalan translation

### DIFF
--- a/automation/autoload/macro-2-mkfullwitdh.lua
+++ b/automation/autoload/macro-2-mkfullwitdh.lua
@@ -3,8 +3,8 @@
 
 local tr = aegisub.gettext
 
-script_name = tr("Make text fullwidth")
-script_description = tr("Shows how to use the unicode include to iterate over characters and a lookup table to convert those characters to something else.")
+script_name = tr"Make text fullwidth"
+script_description = tr"Shows how to use the unicode include to iterate over characters and a lookup table to convert those characters to something else."
 script_author = "Niels Martin Hansen"
 script_version = "1"
 

--- a/po/aegisub.pot
+++ b/po/aegisub.pot
@@ -8,151 +8,815 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-07-01 10:53-0700\n"
+"POT-Creation-Date: 2020-02-17 17:47+0100\n"
 "PO-Revision-Date: 2005-2014-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../src/dialog_shift_times.cpp:92
-msgid "unsaved"
+#: ../src/visual_tool_drag.cpp:57
+msgid "Toggle between \\move and \\pos"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:96
-#, c-format
-msgid "%s frames"
+#: ../src/visual_tool_drag.cpp:330 ../src/visual_tool_cross.cpp:62
+msgid "positioning"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:98
-msgid "backward"
+#: ../src/preferences.cpp:62 ../src/preferences.cpp:64
+#: ../src/preferences.cpp:330 ../src/preferences.cpp:351
+msgid "General"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:98
-msgid "forward"
+#: ../src/preferences.cpp:65
+msgid "Check for updates on startup"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:102
-msgid "s+e"
+#: ../src/preferences.cpp:66
+msgid "Show main toolbar"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:103
-msgid "s"
+#: ../src/preferences.cpp:67
+msgid "Save UI state in subtitles files"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:104
-msgid "e"
+#: ../src/preferences.cpp:70
+msgid "Toolbar Icon Size"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:111
-msgid "all"
+#: ../src/preferences.cpp:71 ../src/preferences.cpp:196
+msgid "Never"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:113
-#, c-format
-msgid "from %d onward"
+#: ../src/preferences.cpp:71
+msgid "Always"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:115
-msgid "sel "
+#: ../src/preferences.cpp:71 ../src/preferences.cpp:196
+msgid "Ask"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:133 ../src/command/time.cpp:153
-msgid "Shift Times"
+#: ../src/preferences.cpp:73
+msgid "Automatically load linked files"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:142
-msgid "&Time: "
+#: ../src/preferences.cpp:74
+msgid "Undo Levels"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:143
-msgid "Shift by time"
+#: ../src/preferences.cpp:76
+msgid "Recently Used Lists"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:146
-msgid "&Frames: "
+#: ../src/preferences.cpp:77 ../src/dialog_autosave.cpp:70
+msgid "Files"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:147
-msgid "Shift by frames"
+#: ../src/preferences.cpp:78
+msgid "Find/Replace"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:151
-msgid "Enter time in h:mm:ss.cs notation"
+#: ../src/preferences.cpp:84
+msgid "Default styles"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:154
-msgid "Enter number of frames to shift by"
+#: ../src/preferences.cpp:86
+msgid "Default style catalogs"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:156
-msgid "For&ward"
-msgstr ""
-
-#: ../src/dialog_shift_times.cpp:157
+#: ../src/preferences.cpp:90
 msgid ""
-"Shifts subs forward, making them appear later. Use if they are appearing too "
-"soon."
+"The chosen style catalogs will be loaded when you start a new file or import "
+"files in the various formats.\n"
+"\n"
+"You can set up style catalogs in the Style Manager."
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:159
-msgid "&Backward"
+#: ../src/preferences.cpp:115
+msgid "New files"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:160
+#: ../src/preferences.cpp:116
+msgid "MicroDVD import"
+msgstr ""
+
+#: ../src/preferences.cpp:117
+msgid "SRT import"
+msgstr ""
+
+#: ../src/preferences.cpp:118
+msgid "TTXT import"
+msgstr ""
+
+#: ../src/preferences.cpp:119
+msgid "Plain text import"
+msgstr ""
+
+#: ../src/preferences.cpp:126 ../src/preferences.cpp:364
+msgid "Audio"
+msgstr ""
+
+#: ../src/preferences.cpp:128 ../src/preferences.cpp:168
+#: ../src/dialog_timing_processor.cpp:168 ../src/command/app.cpp:206
+#: ../src/dialog_properties.cpp:146
+msgid "Options"
+msgstr ""
+
+#: ../src/preferences.cpp:129
+msgid "Default mouse wheel to zoom"
+msgstr ""
+
+#: ../src/preferences.cpp:130
+msgid "Lock scroll on cursor"
+msgstr ""
+
+#: ../src/preferences.cpp:131
+msgid "Snap markers by default"
+msgstr ""
+
+#: ../src/preferences.cpp:132
+msgid "Auto-focus on mouse over"
+msgstr ""
+
+#: ../src/preferences.cpp:133
+msgid "Play audio when stepping in video"
+msgstr ""
+
+#: ../src/preferences.cpp:134
+msgid "Left-click-drag moves end marker"
+msgstr ""
+
+#: ../src/preferences.cpp:135
+msgid "Default timing length (ms)"
+msgstr ""
+
+#: ../src/preferences.cpp:136
+msgid "Default lead-in length (ms)"
+msgstr ""
+
+#: ../src/preferences.cpp:137
+msgid "Default lead-out length (ms)"
+msgstr ""
+
+#: ../src/preferences.cpp:139
+msgid "Marker drag-start sensitivity (px)"
+msgstr ""
+
+#: ../src/preferences.cpp:140
+msgid "Line boundary thickness (px)"
+msgstr ""
+
+#: ../src/preferences.cpp:141
+msgid "Maximum snap distance (px)"
+msgstr ""
+
+#: ../src/preferences.cpp:143
+msgid "Don't show"
+msgstr ""
+
+#: ../src/preferences.cpp:143
+msgid "Show previous"
+msgstr ""
+
+#: ../src/preferences.cpp:143
+msgid "Show previous and next"
+msgstr ""
+
+#: ../src/preferences.cpp:143
+msgid "Show all"
+msgstr ""
+
+#: ../src/preferences.cpp:145
+msgid "Show inactive lines"
+msgstr ""
+
+#: ../src/preferences.cpp:147
+msgid "Include commented inactive lines"
+msgstr ""
+
+#: ../src/preferences.cpp:149
+msgid "Display Visual Options"
+msgstr ""
+
+#: ../src/preferences.cpp:150
+msgid "Keyframes in dialogue mode"
+msgstr ""
+
+#: ../src/preferences.cpp:151
+msgid "Keyframes in karaoke mode"
+msgstr ""
+
+#: ../src/preferences.cpp:152
+msgid "Cursor time"
+msgstr ""
+
+#: ../src/preferences.cpp:153
+msgid "Video position"
+msgstr ""
+
+#: ../src/preferences.cpp:154 ../src/preferences.cpp:250
+msgid "Seconds boundaries"
+msgstr ""
+
+#: ../src/preferences.cpp:156
+msgid "Waveform Style"
+msgstr ""
+
+#: ../src/preferences.cpp:158
+msgid "Audio labels"
+msgstr ""
+
+#: ../src/preferences.cpp:166 ../src/preferences.cpp:427
+#: ../src/dialog_video_details.cpp:66
+msgid "Video"
+msgstr ""
+
+#: ../src/preferences.cpp:169
+msgid "Show keyframes in slider"
+msgstr ""
+
+#: ../src/preferences.cpp:171
+msgid "Only show visual tools when mouse is over video"
+msgstr ""
+
+#: ../src/preferences.cpp:173
+msgid "Seek video to line start on selection change"
+msgstr ""
+
+#: ../src/preferences.cpp:175
+msgid "Automatically open audio when opening video"
+msgstr ""
+
+#: ../src/preferences.cpp:180
+msgid "Default Zoom"
+msgstr ""
+
+#: ../src/preferences.cpp:182
+msgid "Fast jump step in frames"
+msgstr ""
+
+#: ../src/preferences.cpp:186
+msgid "Screenshot save path"
+msgstr ""
+
+#: ../src/preferences.cpp:188
+msgid "Script Resolution"
+msgstr ""
+
+#: ../src/preferences.cpp:189
+msgid "Use resolution of first video opened"
+msgstr ""
+
+#: ../src/preferences.cpp:192
+msgid "Default width"
+msgstr ""
+
+#: ../src/preferences.cpp:194
+msgid "Default height"
+msgstr ""
+
+#: ../src/preferences.cpp:196
+msgid "Always set"
+msgstr ""
+
+#: ../src/preferences.cpp:196
+msgid "Always resample"
+msgstr ""
+
+#: ../src/preferences.cpp:198
+msgid "Match video resolution on open"
+msgstr ""
+
+#: ../src/preferences.cpp:205
+msgid "Interface"
+msgstr ""
+
+#: ../src/preferences.cpp:207
+msgid "Edit Box"
+msgstr ""
+
+#: ../src/preferences.cpp:208
+msgid "Enable call tips"
+msgstr ""
+
+#: ../src/preferences.cpp:209
+msgid "Overwrite in time boxes"
+msgstr ""
+
+#: ../src/preferences.cpp:211
+msgid "Enable syntax highlighting"
+msgstr ""
+
+#: ../src/preferences.cpp:212
+msgid "Dictionaries path"
+msgstr ""
+
+#: ../src/preferences.cpp:215
+msgid "Character Counter"
+msgstr ""
+
+#: ../src/preferences.cpp:216
+msgid "Maximum characters per line"
+msgstr ""
+
+#: ../src/preferences.cpp:217
+msgid "Characters Per Second Warning Threshold"
+msgstr ""
+
+#: ../src/preferences.cpp:218
+msgid "Characters Per Second Error Threshold"
+msgstr ""
+
+#: ../src/preferences.cpp:219
+msgid "Ignore whitespace"
+msgstr ""
+
+#: ../src/preferences.cpp:220
+msgid "Ignore punctuation"
+msgstr ""
+
+#: ../src/preferences.cpp:222
+msgid "Grid"
+msgstr ""
+
+#: ../src/preferences.cpp:223
+msgid "Focus grid on click"
+msgstr ""
+
+#: ../src/preferences.cpp:224
+msgid "Highlight visible subtitles"
+msgstr ""
+
+#: ../src/preferences.cpp:225
+msgid "Hide overrides symbol"
+msgstr ""
+
+#: ../src/preferences.cpp:228 ../src/command/tool.cpp:201
+#: ../src/dialog_translation.cpp:66
+msgid "Translation Assistant"
+msgstr ""
+
+#: ../src/preferences.cpp:229
+msgid "Skip over whitespace"
+msgstr ""
+
+#: ../src/preferences.cpp:236 ../src/dialog_style_editor.cpp:180
+msgid "Colors"
+msgstr ""
+
+#: ../src/preferences.cpp:244
+msgid "Audio Display"
+msgstr ""
+
+#: ../src/preferences.cpp:245
+msgid "Play cursor"
+msgstr ""
+
+#: ../src/preferences.cpp:246
+msgid "Line boundary start"
+msgstr ""
+
+#: ../src/preferences.cpp:247
+msgid "Line boundary end"
+msgstr ""
+
+#: ../src/preferences.cpp:248
+msgid "Line boundary inactive line"
+msgstr ""
+
+#: ../src/preferences.cpp:249
+msgid "Syllable boundaries"
+msgstr ""
+
+#: ../src/preferences.cpp:252
+msgid "Syntax Highlighting"
+msgstr ""
+
+#: ../src/preferences.cpp:253
+msgid "Background"
+msgstr ""
+
+#: ../src/preferences.cpp:254
+msgid "Normal"
+msgstr ""
+
+#: ../src/preferences.cpp:255
+msgid "Comments"
+msgstr ""
+
+#: ../src/preferences.cpp:256
+msgid "Drawings"
+msgstr ""
+
+#: ../src/preferences.cpp:257
+msgid "Brackets"
+msgstr ""
+
+#: ../src/preferences.cpp:258
+msgid "Slashes and Parentheses"
+msgstr ""
+
+#: ../src/preferences.cpp:259
+msgid "Tags"
+msgstr ""
+
+#: ../src/preferences.cpp:260
+msgid "Parameters"
+msgstr ""
+
+#: ../src/preferences.cpp:261 ../src/dialog_fonts_collector.cpp:303
+#: ../src/dialog_fonts_collector.cpp:308 ../src/dialog_fonts_collector.cpp:313
+#: ../src/dialog_kara_timing_copy.cpp:574
+#: ../src/dialog_kara_timing_copy.cpp:576
+#: ../src/dialog_kara_timing_copy.cpp:626
+msgid "Error"
+msgstr ""
+
+#: ../src/preferences.cpp:262
+msgid "Error Background"
+msgstr ""
+
+#: ../src/preferences.cpp:263
+msgid "Line Break"
+msgstr ""
+
+#: ../src/preferences.cpp:264
+msgid "Karaoke templates"
+msgstr ""
+
+#: ../src/preferences.cpp:265
+msgid "Karaoke variables"
+msgstr ""
+
+#: ../src/preferences.cpp:271
+msgid "Audio Color Schemes"
+msgstr ""
+
+#: ../src/preferences.cpp:273 ../src/preferences.cpp:380
+msgid "Spectrum"
+msgstr ""
+
+#: ../src/preferences.cpp:274
+msgid "Waveform"
+msgstr ""
+
+#: ../src/preferences.cpp:276
+msgid "Subtitle Grid"
+msgstr ""
+
+#: ../src/preferences.cpp:277
+msgid "Standard foreground"
+msgstr ""
+
+#: ../src/preferences.cpp:278
+msgid "Standard background"
+msgstr ""
+
+#: ../src/preferences.cpp:279
+msgid "Selection foreground"
+msgstr ""
+
+#: ../src/preferences.cpp:280
+msgid "Selection background"
+msgstr ""
+
+#: ../src/preferences.cpp:281
+msgid "Collision foreground"
+msgstr ""
+
+#: ../src/preferences.cpp:282
+msgid "In frame background"
+msgstr ""
+
+#: ../src/preferences.cpp:283
+msgid "Comment background"
+msgstr ""
+
+#: ../src/preferences.cpp:284
+msgid "Selected comment background"
+msgstr ""
+
+#: ../src/preferences.cpp:285
+msgid "Header background"
+msgstr ""
+
+#: ../src/preferences.cpp:286
+msgid "Left Column"
+msgstr ""
+
+#: ../src/preferences.cpp:287
+msgid "Active Line Border"
+msgstr ""
+
+#: ../src/preferences.cpp:288
+msgid "Lines"
+msgstr ""
+
+#: ../src/preferences.cpp:289
+msgid "CPS Error"
+msgstr ""
+
+#: ../src/preferences.cpp:291
+msgid "Visual Typesetting Tools"
+msgstr ""
+
+#: ../src/preferences.cpp:292
+msgid "Primary Lines"
+msgstr ""
+
+#: ../src/preferences.cpp:293
+msgid "Secondary Lines"
+msgstr ""
+
+#: ../src/preferences.cpp:294
+msgid "Primary Highlight"
+msgstr ""
+
+#: ../src/preferences.cpp:295
+msgid "Secondary Highlight"
+msgstr ""
+
+#: ../src/preferences.cpp:298
+msgid "Visual Typesetting Tools Alpha"
+msgstr ""
+
+#: ../src/preferences.cpp:299
+msgid "Shaded Area"
+msgstr ""
+
+#: ../src/preferences.cpp:308
+msgid "Backup"
+msgstr ""
+
+#: ../src/preferences.cpp:310
+msgid "Automatic Save"
+msgstr ""
+
+#: ../src/preferences.cpp:311 ../src/preferences.cpp:319
+msgid "Enable"
+msgstr ""
+
+#: ../src/preferences.cpp:314
+msgid "Interval in seconds"
+msgstr ""
+
+#: ../src/preferences.cpp:315 ../src/preferences.cpp:321
+#: ../src/preferences.cpp:378
+msgid "Path"
+msgstr ""
+
+#: ../src/preferences.cpp:316
+msgid "Autosave after every change"
+msgstr ""
+
+#: ../src/preferences.cpp:318
+msgid "Automatic Backup"
+msgstr ""
+
+#: ../src/preferences.cpp:328 ../src/command/automation.cpp:75
+#: ../src/command/automation.cpp:87
+msgid "Automation"
+msgstr ""
+
+#: ../src/preferences.cpp:332
+msgid "Base path"
+msgstr ""
+
+#: ../src/preferences.cpp:333
+msgid "Include path"
+msgstr ""
+
+#: ../src/preferences.cpp:334
+msgid "Auto-load path"
+msgstr ""
+
+#: ../src/preferences.cpp:336
+msgid "0: Fatal"
+msgstr ""
+
+#: ../src/preferences.cpp:336
+msgid "1: Error"
+msgstr ""
+
+#: ../src/preferences.cpp:336
+msgid "2: Warning"
+msgstr ""
+
+#: ../src/preferences.cpp:336
+msgid "3: Hint"
+msgstr ""
+
+#: ../src/preferences.cpp:336
+msgid "4: Debug"
+msgstr ""
+
+#: ../src/preferences.cpp:336
+msgid "5: Trace"
+msgstr ""
+
+#: ../src/preferences.cpp:338
+msgid "Trace level"
+msgstr ""
+
+#: ../src/preferences.cpp:340
+msgid "No scripts"
+msgstr ""
+
+#: ../src/preferences.cpp:340
+msgid "Subtitle-local scripts"
+msgstr ""
+
+#: ../src/preferences.cpp:340
+msgid "Global autoload scripts"
+msgstr ""
+
+#: ../src/preferences.cpp:340
+msgid "All scripts"
+msgstr ""
+
+#: ../src/preferences.cpp:342
+msgid "Autoreload on Export"
+msgstr ""
+
+#: ../src/preferences.cpp:349
+msgid "Advanced"
+msgstr ""
+
+#: ../src/preferences.cpp:353
 msgid ""
-"Shifts subs backward, making them appear earlier. Use if they are appearing "
-"too late."
+"Changing these settings might result in bugs and/or crashes.  Do not touch "
+"these unless you know what you're doing."
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:162
-msgid "&All rows"
+#: ../src/preferences.cpp:366 ../src/preferences.cpp:429
+msgid "Expert"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:162 ../src/dialog_search_replace.cpp:88
-msgid "Selected &rows"
+#: ../src/preferences.cpp:369
+msgid "Audio provider"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:162
-msgid "Selection &onward"
+#: ../src/preferences.cpp:372
+msgid "Audio player"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:163
-msgid "Affect"
+#: ../src/preferences.cpp:374
+msgid "Cache"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:165
-msgid "Start a&nd End times"
+#: ../src/preferences.cpp:375
+msgid "None (NOT RECOMMENDED)"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:165
-msgid "&Start times only"
+#: ../src/preferences.cpp:375
+msgid "RAM"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:165
-msgid "&End times only"
+#: ../src/preferences.cpp:375
+msgid "Hard Disk"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:166
-msgid "Times"
+#: ../src/preferences.cpp:377
+msgid "Cache type"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:170
-msgid "&Clear"
+#: ../src/preferences.cpp:382
+msgid "Regular quality"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:201
-msgid "Shift by"
+#: ../src/preferences.cpp:382
+msgid "Better quality"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:210
-msgid "Load from history"
+#: ../src/preferences.cpp:382
+msgid "High quality"
 msgstr ""
 
-#: ../src/dialog_shift_times.cpp:405
-msgid "shifting"
+#: ../src/preferences.cpp:382
+msgid "Insane quality"
+msgstr ""
+
+#: ../src/preferences.cpp:384
+msgid "Quality"
+msgstr ""
+
+#: ../src/preferences.cpp:386
+msgid "Cache memory max (MB)"
+msgstr ""
+
+#: ../src/preferences.cpp:392
+msgid "Avisynth down-mixer"
+msgstr ""
+
+#: ../src/preferences.cpp:393
+msgid "Force sample rate"
+msgstr ""
+
+#: ../src/preferences.cpp:399
+msgid "Ignore"
+msgstr ""
+
+#: ../src/preferences.cpp:399 ../src/command/edit.cpp:1222
+#: ../src/command/edit.cpp:1223
+msgid "Clear"
+msgstr ""
+
+#: ../src/preferences.cpp:399
+msgid "Stop"
+msgstr ""
+
+#: ../src/preferences.cpp:399
+msgid "Abort"
+msgstr ""
+
+#: ../src/preferences.cpp:401
+msgid "Audio indexing error handling mode"
+msgstr ""
+
+#: ../src/preferences.cpp:403
+msgid "Always index all audio tracks"
+msgstr ""
+
+#: ../src/preferences.cpp:408
+msgid "Portaudio device"
+msgstr ""
+
+#: ../src/preferences.cpp:413
+msgid "OSS Device"
+msgstr ""
+
+#: ../src/preferences.cpp:418
+msgid "Buffer latency"
+msgstr ""
+
+#: ../src/preferences.cpp:419
+msgid "Buffer length"
+msgstr ""
+
+#: ../src/preferences.cpp:432
+msgid "Video provider"
+msgstr ""
+
+#: ../src/preferences.cpp:435
+msgid "Subtitles provider"
+msgstr ""
+
+#: ../src/preferences.cpp:439
+msgid "Allow pre-2.56a Avisynth"
+msgstr ""
+
+#: ../src/preferences.cpp:441
+msgid "Avisynth memory limit"
+msgstr ""
+
+#: ../src/preferences.cpp:449
+msgid "Debug log verbosity"
+msgstr ""
+
+#: ../src/preferences.cpp:451
+msgid "Decoding threads"
+msgstr ""
+
+#: ../src/preferences.cpp:452
+msgid "Enable unsafe seeking"
+msgstr ""
+
+#: ../src/preferences.cpp:581
+msgid "Hotkeys"
+msgstr ""
+
+#: ../src/preferences.cpp:585 ../src/dialog_style_manager.cpp:203
+msgid "&New"
+msgstr ""
+
+#: ../src/preferences.cpp:586 ../src/dialog_style_manager.cpp:204
+msgid "&Edit"
+msgstr ""
+
+#: ../src/preferences.cpp:587 ../src/dialog_style_manager.cpp:206
+#: ../src/dialog_attachments.cpp:79
+msgid "&Delete"
+msgstr ""
+
+#: ../src/preferences.cpp:680
+msgid ""
+"Are you sure that you want to restore the defaults? All your settings will "
+"be overridden."
+msgstr ""
+
+#: ../src/preferences.cpp:680
+msgid "Restore defaults?"
+msgstr ""
+
+#: ../src/preferences.cpp:698
+msgid "Preferences"
+msgstr ""
+
+#: ../src/preferences.cpp:726
+msgid "&Restore Defaults"
 msgstr ""
 
 #: ../src/export_fixstyle.cpp:46
@@ -165,137 +829,128 @@ msgid ""
 "Default."
 msgstr ""
 
-#: ../src/audio_karaoke.cpp:72
-msgid "Discard all uncommitted splits"
+#: ../src/dialog_text_import.cpp:47
+msgid "Text import options"
 msgstr ""
 
-#: ../src/audio_karaoke.cpp:76
-msgid "Commit splits"
+#: ../src/dialog_text_import.cpp:54
+msgid "Actor separator:"
 msgstr ""
 
-#: ../src/audio_karaoke.cpp:239
-msgid "Karaoke tag"
+#: ../src/dialog_text_import.cpp:56
+msgid "Comment starter:"
 msgstr ""
 
-#: ../src/audio_karaoke.cpp:242
-msgid "Change karaoke tag to \\k"
+#: ../src/dialog_text_import.cpp:61
+msgid "Include blank lines"
 msgstr ""
 
-#: ../src/audio_karaoke.cpp:243
-msgid "Change karaoke tag to \\kf"
-msgstr ""
-
-#: ../src/audio_karaoke.cpp:244
-msgid "Change karaoke tag to \\ko"
-msgstr ""
-
-#: ../src/audio_karaoke.cpp:418
-msgid "karaoke split"
-msgstr ""
-
-#: ../src/timeedit_ctrl.cpp:208 ../src/dialog_style_manager.cpp:204
-#: ../src/subs_edit_ctrl.cpp:366
-msgid "&Copy"
-msgstr ""
-
-#: ../src/timeedit_ctrl.cpp:209 ../src/subs_edit_ctrl.cpp:367
-msgid "&Paste"
-msgstr ""
-
-#: ../src/auto4_base.cpp:460
+#: ../src/subtitle_format.cpp:102
 #, c-format
-msgid ""
-"Failed to load Automation script '%s':\n"
-"%s"
+msgid "From video (%g)"
 msgstr ""
 
-#: ../src/auto4_base.cpp:467
-#, c-format
-msgid "The file was not recognised as an Automation script: %s"
+#: ../src/subtitle_format.cpp:104
+msgid "From video (VFR)"
 msgstr ""
 
-#: ../src/auto4_base.cpp:496 ../src/command/timecode.cpp:74
-#: ../src/command/timecode.cpp:94 ../src/command/video.cpp:568
-#: ../src/command/audio.cpp:84 ../src/command/keyframe.cpp:74
-msgid "All Files"
+#: ../src/subtitle_format.cpp:110
+msgid "15.000 FPS"
 msgstr ""
 
-#: ../src/auto4_base.cpp:502 ../src/command/timecode.cpp:74
-#: ../src/command/timecode.cpp:94 ../src/command/keyframe.cpp:74
-#: ../src/subtitle_format.cpp:312
+#: ../src/subtitle_format.cpp:111
+msgid "23.976 FPS (Decimated NTSC)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:112
+msgid "24.000 FPS (FILM)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:113
+msgid "25.000 FPS (PAL)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:114
+msgid "29.970 FPS (NTSC)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:116
+msgid "29.970 FPS (NTSC with SMPTE dropframe)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:117
+msgid "30.000 FPS"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:118
+msgid "50.000 FPS (PAL x2)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:119
+msgid "59.940 FPS (NTSC x2)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:120
+msgid "60.000 FPS"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:121
+msgid "119.880 FPS (NTSC x4)"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:122
+msgid "120.000 FPS"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:126
+msgid "Please choose the appropriate FPS for the subtitles:"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:126
+msgid "FPS"
+msgstr ""
+
+#: ../src/subtitle_format.cpp:315 ../src/auto4_base.cpp:499
+#: ../src/command/keyframe.cpp:75 ../src/command/timecode.cpp:74
+#: ../src/command/timecode.cpp:94
 msgid "All Supported Formats"
 msgstr ""
 
-#: ../src/auto4_base.cpp:508
-msgid "File was not recognized as a script"
+#: ../src/dialog_export.cpp:102
+msgid "Export"
 msgstr ""
 
-#: ../src/search_replace_engine.cpp:247 ../src/search_replace_engine.cpp:331
-msgid "replace"
+#: ../src/dialog_export.cpp:122
+msgid "Move &Up"
 msgstr ""
 
-#: ../src/search_replace_engine.cpp:332
-#, c-format
-msgid "One match was replaced."
-msgid_plural "%d matches were replaced."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../src/search_replace_engine.cpp:335
-msgid "No matches found."
+#: ../src/dialog_export.cpp:123
+msgid "Move &Down"
 msgstr ""
 
-#: ../src/visual_tool_drag.cpp:56
-msgid "Toggle between \\move and \\pos"
+#: ../src/dialog_export.cpp:124 ../src/command/subtitle.cpp:396
+#: ../src/subs_edit_ctrl.cpp:391 ../src/dialog_selected_choices.cpp:26
+msgid "Select &All"
 msgstr ""
 
-#: ../src/visual_tool_drag.cpp:326 ../src/visual_tool_cross.cpp:62
-msgid "positioning"
+#: ../src/dialog_export.cpp:125 ../src/dialog_selected_choices.cpp:33
+msgid "Select &None"
 msgstr ""
 
-#: ../src/font_file_lister_fontconfig.cpp:80
-msgid "Updating font cache\n"
+#: ../src/dialog_export.cpp:141
+msgid "Text encoding:"
 msgstr ""
 
-#: ../src/subtitle_format_ebu3264.cpp:408
-#, c-format
-msgid "Line over maximum length: %s"
+#: ../src/dialog_export.cpp:149
+msgid "Filters"
 msgstr ""
 
-#: ../src/dialog_video_details.cpp:44
-msgid "Video Details"
+#: ../src/dialog_export.cpp:156
+msgid "Export..."
 msgstr ""
 
-#: ../src/dialog_video_details.cpp:58
-msgid "File name:"
-msgstr ""
-
-#: ../src/dialog_video_details.cpp:59
-msgid "FPS:"
-msgstr ""
-
-#: ../src/dialog_video_details.cpp:60
-msgid "Resolution:"
-msgstr ""
-
-#: ../src/dialog_video_details.cpp:61
-msgid "Length:"
-msgstr ""
-
-#: ../src/dialog_video_details.cpp:61
-#, c-format
-msgid "1 frame"
-msgid_plural "%d frames (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../src/dialog_video_details.cpp:63
-msgid "Decoder:"
-msgstr ""
-
-#: ../src/dialog_video_details.cpp:65 ../src/preferences.cpp:165
-#: ../src/preferences.cpp:417
-msgid "Video"
+#: ../src/dialog_export.cpp:188
+msgid "Export subtitles file"
 msgstr ""
 
 #: ../src/dialog_timing_processor.cpp:139 ../src/command/tool.cpp:189
@@ -324,12 +979,6 @@ msgstr ""
 
 #: ../src/dialog_timing_processor.cpp:165
 msgid "Deselect all styles"
-msgstr ""
-
-#: ../src/dialog_timing_processor.cpp:168 ../src/command/app.cpp:207
-#: ../src/dialog_properties.cpp:138 ../src/preferences.cpp:127
-#: ../src/preferences.cpp:167
-msgid "Options"
 msgstr ""
 
 #: ../src/dialog_timing_processor.cpp:169
@@ -480,224 +1129,471 @@ msgstr ""
 msgid "timing processor"
 msgstr ""
 
-#: ../src/mkv_wrap.cpp:213
-msgid "Choose which track to read:"
+#: ../src/auto4_base.cpp:457
+#, c-format
+msgid ""
+"Failed to load Automation script '%s':\n"
+"%s"
 msgstr ""
 
-#: ../src/mkv_wrap.cpp:213
-msgid "Multiple subtitle tracks found"
+#: ../src/auto4_base.cpp:464
+#, c-format
+msgid "The file was not recognised as an Automation script: %s"
 msgstr ""
 
-#: ../src/mkv_wrap.cpp:251
-msgid "Parsing Matroska"
+#: ../src/auto4_base.cpp:493 ../src/command/keyframe.cpp:77
+#: ../src/command/video.cpp:568 ../src/command/timecode.cpp:74
+#: ../src/command/timecode.cpp:94 ../src/command/audio.cpp:85
+msgid "All Files"
 msgstr ""
 
-#: ../src/mkv_wrap.cpp:251
-msgid "Reading subtitles from Matroska file."
+#: ../src/auto4_base.cpp:505
+msgid "File was not recognized as a script"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:55 ../src/command/tool.cpp:123
-msgid "Styling Assistant"
+#: ../src/dialog_automation.cpp:106
+msgid "Automation Manager"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:65
-#: ../src/dialog_styling_assistant.cpp:66
-msgid "Current line"
+#: ../src/dialog_automation.cpp:117
+msgid "&Add"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:72
-msgid "Styles available"
+#: ../src/dialog_automation.cpp:118
+msgid "&Remove"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:80
-msgid "Set style"
+#: ../src/dialog_automation.cpp:119
+msgid "Re&load"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:87 ../src/dialog_translation.cpp:108
-msgid "Keys"
+#: ../src/dialog_automation.cpp:120
+msgid "Show &Info"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:90 ../src/command/tool.cpp:142
-#: ../src/command/tool.cpp:226 ../src/dialog_translation.cpp:111
-msgid "Accept changes"
+#: ../src/dialog_automation.cpp:121
+msgid "Re&scan Autoload Dir"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:91 ../src/command/tool.cpp:153
-#: ../src/command/tool.cpp:237 ../src/dialog_translation.cpp:112
-msgid "Preview changes"
+#: ../src/dialog_automation.cpp:122 ../src/dialog_attachments.cpp:89
+#: ../src/dialog_version_check.cpp:125 ../src/dialog_kara_timing_copy.cpp:504
+msgid "&Close"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:92 ../src/dialog_translation.cpp:113
-msgid "Previous line"
+#: ../src/dialog_automation.cpp:134
+msgid "Name"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:93 ../src/dialog_translation.cpp:114
-msgid "Next line"
+#: ../src/dialog_automation.cpp:135
+msgid "Filename"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:94 ../src/dialog_translation.cpp:116
-msgid "Play video"
+#: ../src/dialog_automation.cpp:136
+msgid "Description"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:95 ../src/dialog_translation.cpp:117
-msgid "Play audio"
+#: ../src/dialog_automation.cpp:222
+msgid "Add Automation script"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:96
-msgid "Click on list"
+#: ../src/dialog_automation.cpp:277
+#, c-format
+msgid ""
+"Total scripts loaded: %d\n"
+"Global scripts loaded: %d\n"
+"Local scripts loaded: %d\n"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:97
-msgid "Select style"
+#: ../src/dialog_automation.cpp:282
+msgid "Scripting engines installed:"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:101
-msgid "&Seek video to line start time"
+#: ../src/dialog_automation.cpp:295
+msgid "Correctly loaded"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:110 ../src/dialog_translation.cpp:129
-msgid "Actions"
+#: ../src/dialog_automation.cpp:295
+msgid "Failed to load"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:113 ../src/dialog_translation.cpp:131
-msgid "Play &Audio"
+#: ../src/dialog_automation.cpp:289
+#, c-format
+msgid ""
+"\n"
+"Script info:\n"
+"Name: %s\n"
+"Description: %s\n"
+"Author: %s\n"
+"Version: %s\n"
+"Full path: %s\n"
+"State: %s\n"
+"\n"
+"Features provided by script:"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:117 ../src/dialog_translation.cpp:136
-msgid "Play &Video"
+#: ../src/dialog_automation.cpp:298
+#, c-format
+msgid "    Macro: %s (%s)"
 msgstr ""
 
-#: ../src/dialog_styling_assistant.cpp:175
-msgid "styling assistant"
+#: ../src/dialog_automation.cpp:301
+#, c-format
+msgid "    Export filter: %s"
 msgstr ""
 
-#: ../src/audio_timing_karaoke.cpp:241
-msgid "karaoke timing"
+#: ../src/dialog_automation.cpp:305
+msgid "Automation Script Info"
 msgstr ""
 
-#: ../src/dialog_jumpto.cpp:66 ../src/command/video.cpp:523
-msgid "Jump to"
+#: ../src/dialog_search_replace.cpp:46
+msgid "Replace"
 msgstr ""
 
-#: ../src/dialog_jumpto.cpp:72
-msgid "Frame: "
+#: ../src/dialog_search_replace.cpp:46 ../src/command/subtitle.cpp:94
+msgid "Find"
 msgstr ""
 
-#: ../src/dialog_jumpto.cpp:73
-msgid "Time: "
+#: ../src/dialog_search_replace.cpp:67
+msgid "Find what:"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:188
-msgid "Move style up"
+#: ../src/dialog_search_replace.cpp:73 ../src/dialog_spellchecker.cpp:127
+msgid "Replace with:"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:78
+msgid "&Match case"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:79
+msgid "&Use regular expressions"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:80 ../src/dialog_spellchecker.cpp:182
+msgid "&Skip Comments"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:81
+msgid "S&kip Override Tags"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:87 ../src/dialog_selection.cpp:137
+msgid "&Text"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:87
+msgid "St&yle"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:87
+msgid "A&ctor"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:87 ../src/command/grid.cpp:133
+#: ../src/command/grid.cpp:145
+msgid "&Effect"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:88
+msgid "A&ll rows"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:88 ../src/dialog_shift_times.cpp:164
+msgid "Selected &rows"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:90 ../src/dialog_selection.cpp:138
+msgid "In Field"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:91
+msgid "Limit to"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:93
+msgid "&Find next"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:94
+msgid "Replace &next"
+msgstr ""
+
+#: ../src/dialog_search_replace.cpp:95 ../src/dialog_spellchecker.cpp:190
+msgid "Replace &all"
+msgstr ""
+
+#: ../src/search_replace_engine.cpp:189 ../src/search_replace_engine.cpp:273
+msgid "replace"
+msgstr ""
+
+#: ../src/search_replace_engine.cpp:274
+#, c-format
+msgid "One match was replaced."
+msgid_plural "%d matches were replaced."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/search_replace_engine.cpp:277
+msgid "No matches found."
+msgstr ""
+
+#: ../src/dialog_detached_video.cpp:66 ../src/dialog_detached_video.cpp:134
+#, c-format
+msgid "Video: %s"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:109
+msgid "Symlinking fonts to folder...\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:113
+msgid "Copying fonts to folder...\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:116
+msgid "Copying fonts to archive...\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:128
+#, c-format
+msgid "* Failed to create directory '%s': %s.\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:139
+#, c-format
+msgid "* Failed to open %s.\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:194
+#, c-format
+msgid "* Copied %s.\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:196
+#, c-format
+msgid "* %s already exists on destination.\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:198
+#, c-format
+msgid "* Symlinked %s.\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:200
+#, c-format
+msgid "* Failed to copy %s.\n"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:206
+msgid "Done. All fonts copied."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:208
+msgid "Done. Some fonts could not be copied."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:211
+msgid ""
+"\n"
+"Over 32 MB of fonts were copied. Some of the fonts may not be loaded by the "
+"player if they are all attached to a Matroska file."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:220 ../src/command/tool.cpp:84
+msgid "Fonts Collector"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:227
+msgid "Check fonts for availability"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:228
+msgid "Copy fonts to folder"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:229
+msgid "Copy fonts to subtitle file's folder"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:230
+msgid "Copy fonts to zipped archive"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:232
+msgid "Symlink fonts to folder"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:237 ../src/dialog_selection.cpp:150
+msgid "Action"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:243
+msgid "Destination"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:247
+msgid "&Browse..."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:256
+msgid "Log"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:269
+msgid "&Start!"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:303
+msgid "Invalid destination."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:308
+msgid "Could not create destination folder."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:313
+msgid "Invalid path for .zip file."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:337
+msgid "Select archive file name"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:344
+msgid "Select folder to save fonts on"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:363
+msgid "N/A"
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:371
+msgid ""
+"Choose the folder where the fonts will be collected to. It will be created "
+"if it doesn't exist."
+msgstr ""
+
+#: ../src/dialog_fonts_collector.cpp:378
+msgid ""
+"Enter the name of the destination zip file to collect the fonts to. If a "
+"folder is entered, a default name will be used."
+msgstr ""
+
+#: ../src/charset_detect.cpp:55
+msgid ""
+"Aegisub could not narrow down the character set to a single one.\n"
+"Please pick one below:"
+msgstr ""
+
+#: ../src/charset_detect.cpp:56
+msgid "Choose character set"
 msgstr ""
 
 #: ../src/dialog_style_manager.cpp:189
-msgid "Move style down"
+msgid "Move style up"
 msgstr ""
 
 #: ../src/dialog_style_manager.cpp:190
-msgid "Move style to top"
+msgid "Move style down"
 msgstr ""
 
 #: ../src/dialog_style_manager.cpp:191
-msgid "Move style to bottom"
+msgid "Move style to top"
 msgstr ""
 
 #: ../src/dialog_style_manager.cpp:192
+msgid "Move style to bottom"
+msgstr ""
+
+#: ../src/dialog_style_manager.cpp:193
 msgid "Sort styles alphabetically"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:202 ../src/preferences.cpp:578
-msgid "&New"
+#: ../src/dialog_style_manager.cpp:205 ../src/timeedit_ctrl.cpp:208
+#: ../src/subs_edit_ctrl.cpp:388
+msgid "&Copy"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:203 ../src/preferences.cpp:579
-msgid "&Edit"
-msgstr ""
-
-#: ../src/dialog_style_manager.cpp:205 ../src/preferences.cpp:580
-#: ../src/dialog_attachments.cpp:79
-msgid "&Delete"
-msgstr ""
-
-#: ../src/dialog_style_manager.cpp:218
+#: ../src/dialog_style_manager.cpp:219
 #, c-format
 msgid "%s - Copy"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:220
+#: ../src/dialog_style_manager.cpp:221
 #, c-format
 msgid "%s - Copy (%d)"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:243
+#: ../src/dialog_style_manager.cpp:244
 msgid "Could not parse style"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:248
+#: ../src/dialog_style_manager.cpp:249
 #, c-format
 msgid "Are you sure you want to delete this style?"
 msgid_plural "Are you sure you want to delete these %d styles?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/dialog_style_manager.cpp:259 ../src/command/tool.cpp:165
+#: ../src/dialog_style_manager.cpp:260 ../src/command/tool.cpp:165
 msgid "Styles Manager"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:273
+#: ../src/dialog_style_manager.cpp:274
 msgid "Catalog of available storages"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:275
+#: ../src/dialog_style_manager.cpp:276
 msgid "New"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:276
+#: ../src/dialog_style_manager.cpp:277
 msgid "Delete"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:282
+#: ../src/dialog_style_manager.cpp:283
 msgid "Copy to &current script ->"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:289
+#: ../src/dialog_style_manager.cpp:290
 msgid "Storage"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:295
+#: ../src/dialog_style_manager.cpp:296
 msgid "&Import from script..."
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:296
+#: ../src/dialog_style_manager.cpp:297
 msgid "<- Copy to &storage"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:307
+#: ../src/dialog_style_manager.cpp:308
 msgid "Current script"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:314 ../src/dialog_progress.cpp:179
+#: ../src/dialog_style_manager.cpp:315 ../src/command/subtitle.cpp:256
+#: ../src/command/subtitle.cpp:257 ../src/command/subtitle.cpp:258
+#: ../src/dialog_progress.cpp:179
 msgid "Close"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:454
+#: ../src/dialog_style_manager.cpp:455
 msgid "New storage name:"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:454
+#: ../src/dialog_style_manager.cpp:455
 msgid "New catalog entry"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:469
+#: ../src/dialog_style_manager.cpp:470
 msgid "A catalog with that name already exists."
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:469
+#: ../src/dialog_style_manager.cpp:470
 msgid "Catalog name conflict"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:476
+#: ../src/dialog_style_manager.cpp:477
 #, c-format
 msgid ""
 "The specified catalog name contains one or more illegal characters. They "
@@ -705,130 +1601,965 @@ msgid ""
 "The catalog has been renamed to \"%s\"."
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:477
+#: ../src/dialog_style_manager.cpp:478
 msgid "Invalid characters"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:490
+#: ../src/dialog_style_manager.cpp:491
 #, c-format
 msgid "Are you sure you want to delete the storage \"%s\" from the catalog?"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:491
+#: ../src/dialog_style_manager.cpp:492
 msgid "Confirm delete"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:509
+#: ../src/dialog_style_manager.cpp:510
 #, c-format
 msgid ""
 "There is already a style with the name \"%s\" in the current storage. "
 "Overwrite?"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:509 ../src/dialog_style_manager.cpp:536
-#: ../src/dialog_style_manager.cpp:714
+#: ../src/dialog_style_manager.cpp:510 ../src/dialog_style_manager.cpp:537
+#: ../src/dialog_style_manager.cpp:715
 msgid "Style name collision"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:536 ../src/dialog_style_manager.cpp:713
+#: ../src/dialog_style_manager.cpp:537 ../src/dialog_style_manager.cpp:714
 #, c-format
 msgid ""
 "There is already a style with the name \"%s\" in the current script. "
 "Overwrite?"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:547
+#: ../src/dialog_style_manager.cpp:548
 msgid "style copy"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:576
+#: ../src/dialog_style_manager.cpp:577
 msgid "style paste"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:620
+#: ../src/dialog_style_manager.cpp:621
 msgid "Confirm delete from storage"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:659
+#: ../src/dialog_style_manager.cpp:660
 msgid "Confirm delete from current"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:663
+#: ../src/dialog_style_manager.cpp:664
 msgid "style delete"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:668 ../src/command/subtitle.cpp:240
-#: ../src/command/subtitle.cpp:270
+#: ../src/dialog_style_manager.cpp:669 ../src/command/subtitle.cpp:275
+#: ../src/command/subtitle.cpp:305
 msgid "Open subtitles file"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:698
+#: ../src/dialog_style_manager.cpp:699
 msgid "The selected file has no available styles."
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:698
+#: ../src/dialog_style_manager.cpp:699
 msgid "Error Importing Styles"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:704
+#: ../src/dialog_style_manager.cpp:705
 msgid "Choose styles to import:"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:704
+#: ../src/dialog_style_manager.cpp:705
 msgid "Import Styles"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:730
+#: ../src/dialog_style_manager.cpp:731
 msgid "style import"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:839
+#: ../src/dialog_style_manager.cpp:840
 msgid "Are you sure? This cannot be undone!"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:839
+#: ../src/dialog_style_manager.cpp:840
 msgid "Sort styles"
 msgstr ""
 
-#: ../src/dialog_style_manager.cpp:880
+#: ../src/dialog_style_manager.cpp:881
 msgid "style move"
 msgstr ""
 
-#: ../src/command/timecode.cpp:52 ../src/command/timecode.cpp:53
-msgid "Close Timecodes File"
+#: ../src/audio_karaoke.cpp:72
+msgid "Discard all uncommitted splits"
 msgstr ""
 
-#: ../src/command/timecode.cpp:54
-msgid "Close the currently open timecodes file"
+#: ../src/audio_karaoke.cpp:76
+msgid "Commit splits"
 msgstr ""
 
-#: ../src/command/timecode.cpp:69
-msgid "Open Timecodes File..."
+#: ../src/audio_karaoke.cpp:239
+msgid "Karaoke tag"
 msgstr ""
 
-#: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
-msgid "Open Timecodes File"
+#: ../src/audio_karaoke.cpp:242
+msgid "Change karaoke tag to \\k"
 msgstr ""
 
-#: ../src/command/timecode.cpp:71
-msgid "Open a VFR timecodes v1 or v2 file"
+#: ../src/audio_karaoke.cpp:243
+msgid "Change karaoke tag to \\kf"
 msgstr ""
 
-#: ../src/command/timecode.cpp:84
-msgid "Save Timecodes File..."
+#: ../src/audio_karaoke.cpp:244
+msgid "Change karaoke tag to \\ko"
 msgstr ""
 
-#: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
-msgid "Save Timecodes File"
+#: ../src/audio_karaoke.cpp:421
+msgid "karaoke split"
 msgstr ""
 
-#: ../src/command/timecode.cpp:86
-msgid "Save a VFR timecodes v2 file"
+#: ../src/dialog_video_properties.cpp:44
+msgid "Resolution mismatch"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:46
+#, c-format
+msgid ""
+"The resolution of the loaded video and the resolution specified for the "
+"subtitles don't match.\n"
+"\n"
+"Video resolution:\t%d x %d\n"
+"Script resolution:\t%d x %d\n"
+"\n"
+"Change subtitles resolution to match video?"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
+msgid "Set to video resolution"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:55
+msgid "Resample script (stretch to new aspect ratio)"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:56
+msgid "Resample script (add borders)"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:57
+msgid "Resample script (remove borders)"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:64
+msgid "Resample script"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:163
+msgid "change script resolution"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:68
+msgid "Attachment List"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:76
+msgid "Attach &Font"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:77
+msgid "Attach &Graphics"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:78
+msgid "E&xtract"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:110
+msgid "Attachment name"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:111
+msgid "Size"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:112
+msgid "Group"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:138 ../src/dialog_attachments.cpp:147
+msgid "Choose file to be attached"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:142
+msgid "attach font file"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:152
+msgid "attach graphics file"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:164
+msgid "Select the path to save the files to:"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:167
+msgid "Select the path to save the file to:"
+msgstr ""
+
+#: ../src/dialog_attachments.cpp:189
+msgid "remove attachment"
+msgstr ""
+
+#: ../src/audio_timing_dialogue.cpp:512 ../src/audio_timing_dialogue.cpp:518
+#: ../src/command/time.cpp:177
+msgid "timing"
+msgstr ""
+
+#: ../src/subs_controller.cpp:246
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr ""
+
+#: ../src/subs_controller.cpp:246
+msgid "Unsaved changes"
+msgstr ""
+
+#: ../src/subs_controller.cpp:279
+#, c-format
+msgid "File backup saved as \"%s\"."
+msgstr ""
+
+#: ../src/subs_controller.cpp:404
+msgid "Untitled"
+msgstr ""
+
+#: ../src/subs_controller.cpp:406
+msgid "untitled"
+msgstr ""
+
+#: ../src/dialog_jumpto.cpp:67 ../src/command/video.cpp:523
+msgid "Jump to"
+msgstr ""
+
+#: ../src/dialog_jumpto.cpp:73
+msgid "Frame: "
+msgstr ""
+
+#: ../src/dialog_jumpto.cpp:74
+msgid "Time: "
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:93
+msgid "Version Checker"
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:118
+msgid "&Auto Check for Updates"
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:123
+msgid "Remind me again in a &week"
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:287
+msgid "Could not connect to updates server."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:309
+msgid "Could not download from updates server."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:311
+#, c-format
+msgid "HTTP request failed, got HTTP response %d."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:342
+msgid "An update to Aegisub was found."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:344
+msgid "Several possible updates to Aegisub were found."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:346
+msgid "There are no updates to Aegisub."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:374
+#, c-format
+msgid ""
+"There was an error checking for updates to Aegisub:\n"
+"%s\n"
+"\n"
+"If other applications can access the Internet fine, this is probably a "
+"temporary server problem on our end."
+msgstr ""
+
+#: ../src/dialog_version_check.cpp:378
+msgid "An unknown error occurred while checking for updates to Aegisub."
+msgstr ""
+
+#: ../src/grid_column.cpp:105
+msgid "#"
+msgstr ""
+
+#: ../src/grid_column.cpp:106
+msgid "Line Number"
+msgstr ""
+
+#: ../src/grid_column.cpp:129
+msgid "L"
+msgstr ""
+
+#: ../src/grid_column.cpp:130 ../src/dialog_paste_over.cpp:64
+#: ../src/command/grid.cpp:182 ../src/command/grid.cpp:194
+msgid "Layer"
+msgstr ""
+
+#: ../src/grid_column.cpp:151
+msgid "Start"
+msgstr ""
+
+#: ../src/grid_column.cpp:152 ../src/dialog_paste_over.cpp:65
+#: ../src/command/grid.cpp:206 ../src/command/grid.cpp:218
+msgid "Start Time"
+msgstr ""
+
+#: ../src/grid_column.cpp:169
+msgid "End"
+msgstr ""
+
+#: ../src/grid_column.cpp:170 ../src/dialog_paste_over.cpp:66
+#: ../src/command/grid.cpp:158 ../src/command/grid.cpp:170
+msgid "End Time"
+msgstr ""
+
+#: ../src/grid_column.cpp:200 ../src/grid_column.cpp:201
+#: ../src/dialog_paste_over.cpp:67
+msgid "Style"
+msgstr ""
+
+#: ../src/grid_column.cpp:214 ../src/grid_column.cpp:215
+#: ../src/dialog_paste_over.cpp:72 ../src/command/grid.cpp:134
+#: ../src/command/grid.cpp:146 ../src/subs_edit_box.cpp:144
+msgid "Effect"
+msgstr ""
+
+#: ../src/grid_column.cpp:228 ../src/grid_column.cpp:229
+#: ../src/dialog_paste_over.cpp:68 ../src/subs_edit_box.cpp:139
+msgid "Actor"
+msgstr ""
+
+#: ../src/grid_column.cpp:263 ../src/dialog_style_editor.cpp:289
+msgid "Left"
+msgstr ""
+
+#: ../src/grid_column.cpp:264
+msgid "Left Margin"
+msgstr ""
+
+#: ../src/grid_column.cpp:269 ../src/dialog_style_editor.cpp:289
+msgid "Right"
+msgstr ""
+
+#: ../src/grid_column.cpp:270
+msgid "Right Margin"
+msgstr ""
+
+#: ../src/grid_column.cpp:275 ../src/dialog_style_editor.cpp:289
+msgid "Vert"
+msgstr ""
+
+#: ../src/grid_column.cpp:276
+msgid "Vertical Margin"
+msgstr ""
+
+#: ../src/grid_column.cpp:294
+msgid "CPS"
+msgstr ""
+
+#: ../src/grid_column.cpp:295
+msgid "Characters Per Second"
+msgstr ""
+
+#: ../src/grid_column.cpp:362 ../src/grid_column.cpp:363
+#: ../src/dialog_paste_over.cpp:73 ../src/dialog_kara_timing_copy.cpp:475
+msgid "Text"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:55
+msgid "Select Fields to Paste Over"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:58
+msgid "Fields"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:59
+msgid "Please select the fields that you want to paste over:"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:63
+msgid "Comment"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:69
+msgid "Margin Left"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:70
+msgid "Margin Right"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:71
+msgid "Margin Vertical"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:92
+msgid "&Times"
+msgstr ""
+
+#: ../src/dialog_paste_over.cpp:94
+msgid "T&ext"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:56 ../src/command/vis_tool.cpp:57
+msgid "Standard"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:58
+msgid "Standard mode, double click sets position"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:64 ../src/command/vis_tool.cpp:65
+#: ../src/visual_tool_vector_clip.cpp:58
+msgid "Drag"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:66
+msgid "Drag subtitles"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:72 ../src/command/vis_tool.cpp:73
+msgid "Rotate Z"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:74
+msgid "Rotate subtitles on their Z axis"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:80 ../src/command/vis_tool.cpp:81
+msgid "Rotate XY"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:82
+msgid "Rotate subtitles on their X and Y axes"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:88 ../src/command/vis_tool.cpp:89
+msgid "Scale"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:90
+msgid "Scale subtitles on X and Y axes"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:96 ../src/command/vis_tool.cpp:97
+msgid "Clip"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:98
+msgid "Clip subtitles to a rectangle"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:104 ../src/command/vis_tool.cpp:105
+msgid "Vector Clip"
+msgstr ""
+
+#: ../src/command/vis_tool.cpp:106
+msgid "Clip subtitles to a vectorial area"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:50 ../src/command/keyframe.cpp:51
+msgid "Close Keyframes"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:52
+msgid ""
+"Discard the currently loaded keyframes and use those from the video, if any"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:67
+msgid "Open Keyframes..."
+msgstr ""
+
+#: ../src/command/keyframe.cpp:68
+msgid "Open Keyframes"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:69
+msgid "Open a keyframe list file"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:73
+msgid "Open keyframes file"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:88
+msgid "Save Keyframes..."
+msgstr ""
+
+#: ../src/command/keyframe.cpp:89
+msgid "Save Keyframes"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:90
+msgid "Save the current list of keyframes to a file"
+msgstr ""
+
+#: ../src/command/keyframe.cpp:98
+msgid "Save keyframes file"
+msgstr ""
+
+#: ../src/command/automation.cpp:48
+msgid "&Reload Automation scripts"
+msgstr ""
+
+#: ../src/command/automation.cpp:49
+msgid "Reload Automation scripts"
+msgstr ""
+
+#: ../src/command/automation.cpp:50
+msgid "Reload all Automation scripts and rescan the autoload folder"
+msgstr ""
+
+#: ../src/command/automation.cpp:55
+msgid "Reloaded all Automation scripts"
+msgstr ""
+
+#: ../src/command/automation.cpp:61
+msgid "R&eload autoload Automation scripts"
+msgstr ""
+
+#: ../src/command/automation.cpp:62
+msgid "Reload autoload Automation scripts"
+msgstr ""
+
+#: ../src/command/automation.cpp:63
+msgid "Rescan the Automation autoload folder"
+msgstr ""
+
+#: ../src/command/automation.cpp:67
+msgid "Reloaded autoload Automation scripts"
+msgstr ""
+
+#: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
+msgid "&Automation..."
+msgstr ""
+
+#: ../src/command/automation.cpp:76
+msgid "Open automation manager"
+msgstr ""
+
+#: ../src/command/automation.cpp:88
+msgid ""
+"Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
+"autoload folder and reload all automation scripts"
+msgstr ""
+
+#: ../src/command/app.cpp:57
+msgid "&About"
+msgstr ""
+
+#: ../src/command/app.cpp:58
+msgid "About"
+msgstr ""
+
+#: ../src/command/app.cpp:59 ../src/dialog_about.cpp:44
+msgid "About Aegisub"
+msgstr ""
+
+#: ../src/command/app.cpp:68
+msgid "&Audio+Subs View"
+msgstr ""
+
+#: ../src/command/app.cpp:69
+msgid "Audio+Subs View"
+msgstr ""
+
+#: ../src/command/app.cpp:70
+msgid "Display audio and the subtitles grid only"
+msgstr ""
+
+#: ../src/command/app.cpp:88
+msgid "&Full view"
+msgstr ""
+
+#: ../src/command/app.cpp:89
+msgid "Full view"
+msgstr ""
+
+#: ../src/command/app.cpp:90
+msgid "Display audio, video and then subtitles grid"
+msgstr ""
+
+#: ../src/command/app.cpp:108
+msgid "S&ubs Only View"
+msgstr ""
+
+#: ../src/command/app.cpp:109
+msgid "Subs Only View"
+msgstr ""
+
+#: ../src/command/app.cpp:110
+msgid "Display the subtitles grid only"
+msgstr ""
+
+#: ../src/command/app.cpp:124
+msgid "&Video+Subs View"
+msgstr ""
+
+#: ../src/command/app.cpp:125
+msgid "Video+Subs View"
+msgstr ""
+
+#: ../src/command/app.cpp:126
+msgid "Display video and the subtitles grid only"
+msgstr ""
+
+#: ../src/command/app.cpp:144
+msgid "E&xit"
+msgstr ""
+
+#: ../src/command/app.cpp:145
+msgid "Exit"
+msgstr ""
+
+#: ../src/command/app.cpp:146
+msgid "Exit the application"
+msgstr ""
+
+#: ../src/command/app.cpp:156
+msgid "&Language..."
+msgstr ""
+
+#: ../src/command/app.cpp:157
+msgid "Language"
+msgstr ""
+
+#: ../src/command/app.cpp:158
+msgid "Select Aegisub interface language"
+msgstr ""
+
+#: ../src/command/app.cpp:181
+msgid "&Log window"
+msgstr ""
+
+#: ../src/command/app.cpp:182 ../src/dialog_log.cpp:100
+msgid "Log window"
+msgstr ""
+
+#: ../src/command/app.cpp:183
+msgid "View the event log"
+msgstr ""
+
+#: ../src/command/app.cpp:193
+msgid "New &Window"
+msgstr ""
+
+#: ../src/command/app.cpp:194
+msgid "New Window"
+msgstr ""
+
+#: ../src/command/app.cpp:195
+msgid "Open a new application window"
+msgstr ""
+
+#: ../src/command/app.cpp:205
+msgid "&Options..."
+msgstr ""
+
+#: ../src/command/app.cpp:207
+msgid "Configure Aegisub"
+msgstr ""
+
+#: ../src/command/app.cpp:221 ../src/command/app.cpp:222
+msgid "Toggle global hotkey overrides"
+msgstr ""
+
+#: ../src/command/app.cpp:223
+msgid "Toggle global hotkey overrides (Medusa Mode)"
+msgstr ""
+
+#: ../src/command/app.cpp:238
+msgid "Toggle the main toolbar"
+msgstr ""
+
+#: ../src/command/app.cpp:243
+msgid "Hide Toolbar"
+msgstr ""
+
+#: ../src/command/app.cpp:244
+msgid "Show Toolbar"
+msgstr ""
+
+#: ../src/command/app.cpp:259
+msgid "&Check for Updates..."
+msgstr ""
+
+#: ../src/command/app.cpp:260
+msgid "Check for Updates"
+msgstr ""
+
+#: ../src/command/app.cpp:261
+msgid "Check to see if there is a new version of Aegisub available"
+msgstr ""
+
+#: ../src/command/app.cpp:271 ../src/command/app.cpp:272
+msgid "Minimize"
+msgstr ""
+
+#: ../src/command/app.cpp:273
+msgid "Minimize the active window"
+msgstr ""
+
+#: ../src/command/app.cpp:282 ../src/command/app.cpp:283
+msgid "Zoom"
+msgstr ""
+
+#: ../src/command/app.cpp:284
+msgid "Maximize the active window"
+msgstr ""
+
+#: ../src/command/app.cpp:293 ../src/command/app.cpp:294
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/command/app.cpp:295
+msgid "Bring forward all open documents to the front"
+msgstr ""
+
+#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:45
+#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:47
+#: ../src/command/recent.cpp:48 ../src/command/recent.cpp:52
+#: ../src/command/recent.cpp:53 ../src/command/recent.cpp:63
+#: ../src/command/recent.cpp:64 ../src/command/recent.cpp:74
+#: ../src/command/recent.cpp:75 ../src/command/recent.cpp:90
+#: ../src/command/recent.cpp:91 ../src/command/recent.cpp:101
+#: ../src/command/recent.cpp:102
+msgid "Recent"
+msgstr ""
+
+#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:54
+msgid "Open recent audio"
+msgstr ""
+
+#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:65
+msgid "Open recent keyframes"
+msgstr ""
+
+#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:76
+msgid "Open recent subtitles"
+msgstr ""
+
+#: ../src/command/recent.cpp:47 ../src/command/recent.cpp:92
+msgid "Open recent timecodes"
+msgstr ""
+
+#: ../src/command/recent.cpp:48
+msgid "Open recent video"
+msgstr ""
+
+#: ../src/command/recent.cpp:103
+msgid "Open recent videos"
 msgstr ""
 
 #: ../src/command/command.cpp:31
 #, c-format
 msgid "'%s' is not a valid command name"
+msgstr ""
+
+#: ../src/command/tool.cpp:58
+msgid "ASSDraw3..."
+msgstr ""
+
+#: ../src/command/tool.cpp:59
+msgid "ASSDraw3"
+msgstr ""
+
+#: ../src/command/tool.cpp:60
+msgid "Launch the ASSDraw3 tool for vector drawing"
+msgstr ""
+
+#: ../src/command/tool.cpp:70
+msgid "&Export Subtitles..."
+msgstr ""
+
+#: ../src/command/tool.cpp:71
+msgid "Export Subtitles"
+msgstr ""
+
+#: ../src/command/tool.cpp:72
+msgid ""
+"Save a copy of subtitles in a different format or with processing applied to "
+"it"
+msgstr ""
+
+#: ../src/command/tool.cpp:83
+msgid "&Fonts Collector..."
+msgstr ""
+
+#: ../src/command/tool.cpp:85
+msgid "Open fonts collector"
+msgstr ""
+
+#: ../src/command/tool.cpp:95
+msgid "S&elect Lines..."
+msgstr ""
+
+#: ../src/command/tool.cpp:96
+msgid "Select Lines"
+msgstr ""
+
+#: ../src/command/tool.cpp:97
+msgid "Select lines based on defined criteria"
+msgstr ""
+
+#: ../src/command/tool.cpp:107
+msgid "&Resample Resolution..."
+msgstr ""
+
+#: ../src/command/tool.cpp:108 ../src/dialog_resample.cpp:90
+msgid "Resample Resolution"
+msgstr ""
+
+#: ../src/command/tool.cpp:109
+msgid ""
+"Resample subtitles to maintain their current appearance at a different "
+"script resolution"
+msgstr ""
+
+#: ../src/command/tool.cpp:122
+msgid "St&yling Assistant..."
+msgstr ""
+
+#: ../src/command/tool.cpp:123 ../src/dialog_styling_assistant.cpp:55
+msgid "Styling Assistant"
+msgstr ""
+
+#: ../src/command/tool.cpp:124
+msgid "Open styling assistant"
+msgstr ""
+
+#: ../src/command/tool.cpp:141 ../src/command/tool.cpp:225
+msgid "&Accept changes"
+msgstr ""
+
+#: ../src/command/tool.cpp:142 ../src/command/tool.cpp:226
+#: ../src/dialog_styling_assistant.cpp:90 ../src/dialog_translation.cpp:113
+msgid "Accept changes"
+msgstr ""
+
+#: ../src/command/tool.cpp:143 ../src/command/tool.cpp:227
+msgid "Commit changes and move to the next line"
+msgstr ""
+
+#: ../src/command/tool.cpp:152 ../src/command/tool.cpp:236
+msgid "&Preview changes"
+msgstr ""
+
+#: ../src/command/tool.cpp:153 ../src/command/tool.cpp:237
+#: ../src/dialog_styling_assistant.cpp:91 ../src/dialog_translation.cpp:114
+msgid "Preview changes"
+msgstr ""
+
+#: ../src/command/tool.cpp:154 ../src/command/tool.cpp:238
+msgid "Commit changes and stay on the current line"
+msgstr ""
+
+#: ../src/command/tool.cpp:164
+msgid "&Styles Manager..."
+msgstr ""
+
+#: ../src/command/tool.cpp:166
+msgid "Open the styles manager"
+msgstr ""
+
+#: ../src/command/tool.cpp:176
+msgid "&Kanji Timer..."
+msgstr ""
+
+#: ../src/command/tool.cpp:177
+msgid "Kanji Timer"
+msgstr ""
+
+#: ../src/command/tool.cpp:178
+msgid "Open the Kanji timer copier"
+msgstr ""
+
+#: ../src/command/tool.cpp:188
+msgid "&Timing Post-Processor..."
+msgstr ""
+
+#: ../src/command/tool.cpp:190
+msgid ""
+"Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
+"to scene changes, etc."
+msgstr ""
+
+#: ../src/command/tool.cpp:200
+msgid "&Translation Assistant..."
+msgstr ""
+
+#: ../src/command/tool.cpp:202
+msgid "Open translation assistant"
+msgstr ""
+
+#: ../src/command/tool.cpp:210
+msgid "There is nothing to translate in the file."
+msgstr ""
+
+#: ../src/command/tool.cpp:247
+msgid "&Next Line"
+msgstr ""
+
+#: ../src/command/tool.cpp:248 ../src/command/time.cpp:356
+#: ../src/command/time.cpp:357 ../src/command/grid.cpp:51
+#: ../src/command/grid.cpp:52 ../src/command/grid.cpp:63
+#: ../src/command/grid.cpp:64
+msgid "Next Line"
+msgstr ""
+
+#: ../src/command/tool.cpp:249
+msgid "Move to the next line without committing changes"
+msgstr ""
+
+#: ../src/command/tool.cpp:258
+msgid "&Previous Line"
+msgstr ""
+
+#: ../src/command/tool.cpp:259 ../src/command/time.cpp:368
+#: ../src/command/time.cpp:369 ../src/command/grid.cpp:90
+#: ../src/command/grid.cpp:91
+msgid "Previous Line"
+msgstr ""
+
+#: ../src/command/tool.cpp:260
+msgid "Move to the previous line without committing changes"
+msgstr ""
+
+#: ../src/command/tool.cpp:269
+msgid "&Insert Original"
+msgstr ""
+
+#: ../src/command/tool.cpp:270 ../src/command/edit.cpp:1254
+#: ../src/command/edit.cpp:1255
+msgid "Insert Original"
+msgstr ""
+
+#: ../src/command/tool.cpp:271
+msgid "Insert the untranslated text"
 msgstr ""
 
 #: ../src/command/video.cpp:84
@@ -879,7 +2610,7 @@ msgstr ""
 msgid "&Default"
 msgstr ""
 
-#: ../src/command/video.cpp:146 ../src/ass_style.cpp:194
+#: ../src/command/video.cpp:146 ../src/ass_style.cpp:196
 msgid "Default"
 msgstr ""
 
@@ -1118,7 +2849,7 @@ msgstr ""
 msgid "Open a video file"
 msgstr ""
 
-#: ../src/command/video.cpp:567 ../src/command/audio.cpp:83
+#: ../src/command/video.cpp:567 ../src/command/audio.cpp:84
 msgid "Video Formats"
 msgstr ""
 
@@ -1158,8 +2889,8 @@ msgstr ""
 msgid "Play line"
 msgstr ""
 
-#: ../src/command/video.cpp:623 ../src/command/audio.cpp:260
-#: ../src/command/audio.cpp:261
+#: ../src/command/video.cpp:623 ../src/command/audio.cpp:206
+#: ../src/command/audio.cpp:207
 msgid "Play current line"
 msgstr ""
 
@@ -1237,1023 +2968,183 @@ msgstr ""
 msgid "Zoom video out"
 msgstr ""
 
-#: ../src/command/edit.cpp:131 ../src/command/edit.cpp:831
-msgid "paste"
+#: ../src/command/time.cpp:101
+msgid "adjoin"
 msgstr ""
 
-#: ../src/command/edit.cpp:369
-msgid "set color"
+#: ../src/command/time.cpp:106
+msgid "Change &End"
 msgstr ""
 
-#: ../src/command/edit.cpp:383
-msgid "Primary Color..."
+#: ../src/command/time.cpp:107
+msgid "Change End"
 msgstr ""
 
-#: ../src/command/edit.cpp:384
-msgid "Primary Color"
+#: ../src/command/time.cpp:108
+msgid "Change end times of lines to the next line's start time"
 msgstr ""
 
-#: ../src/command/edit.cpp:385
-msgid "Set the primary fill color (\\c) at the cursor position"
+#: ../src/command/time.cpp:117
+msgid "Change &Start"
 msgstr ""
 
-#: ../src/command/edit.cpp:395
-msgid "Secondary Color..."
+#: ../src/command/time.cpp:118
+msgid "Change Start"
 msgstr ""
 
-#: ../src/command/edit.cpp:396
-msgid "Secondary Color"
+#: ../src/command/time.cpp:119
+msgid "Change start times of lines to the previous line's end time"
 msgstr ""
 
-#: ../src/command/edit.cpp:397
-msgid "Set the secondary (karaoke) fill color (\\2c) at the cursor position"
+#: ../src/command/time.cpp:129
+msgid "Shift to &Current Frame"
 msgstr ""
 
-#: ../src/command/edit.cpp:407
-msgid "Outline Color..."
+#: ../src/command/time.cpp:130
+msgid "Shift to Current Frame"
 msgstr ""
 
-#: ../src/command/edit.cpp:408
-msgid "Outline Color"
+#: ../src/command/time.cpp:131
+msgid "Shift selection so that the active line starts at current frame"
 msgstr ""
 
-#: ../src/command/edit.cpp:409
-msgid "Set the outline color (\\3c) at the cursor position"
+#: ../src/command/time.cpp:147
+msgid "shift to frame"
 msgstr ""
 
-#: ../src/command/edit.cpp:419
-msgid "Shadow Color..."
+#: ../src/command/time.cpp:154
+msgid "S&hift Times..."
 msgstr ""
 
-#: ../src/command/edit.cpp:420
-msgid "Shadow Color"
+#: ../src/command/time.cpp:155 ../src/dialog_shift_times.cpp:135
+msgid "Shift Times"
 msgstr ""
 
-#: ../src/command/edit.cpp:421
-msgid "Set the shadow color (\\4c) at the cursor position"
+#: ../src/command/time.cpp:156
+msgid "Shift subtitles by time or frames"
 msgstr ""
 
-#: ../src/command/edit.cpp:431 ../src/command/edit.cpp:432
-msgid "Toggle Bold"
+#: ../src/command/time.cpp:183
+msgid "Snap &End to Video"
 msgstr ""
 
-#: ../src/command/edit.cpp:433
+#: ../src/command/time.cpp:184
+msgid "Snap End to Video"
+msgstr ""
+
+#: ../src/command/time.cpp:185
+msgid "Set end of selected subtitles to current video frame"
+msgstr ""
+
+#: ../src/command/time.cpp:195
+msgid "Snap to S&cene"
+msgstr ""
+
+#: ../src/command/time.cpp:196
+msgid "Snap to Scene"
+msgstr ""
+
+#: ../src/command/time.cpp:197
 msgid ""
-"Toggle bold (\\b) for the current selection or at the current cursor position"
+"Set start and end of subtitles to the keyframes around current video frame"
 msgstr ""
 
-#: ../src/command/edit.cpp:436
-msgid "toggle bold"
+#: ../src/command/time.cpp:234
+msgid "snap to scene"
 msgstr ""
 
-#: ../src/command/edit.cpp:443 ../src/command/edit.cpp:444
-msgid "Toggle Italics"
+#: ../src/command/time.cpp:240 ../src/command/time.cpp:241
+msgid "Add lead in and out"
 msgstr ""
 
-#: ../src/command/edit.cpp:445
+#: ../src/command/time.cpp:242
+msgid "Add both lead in and out to the selected lines"
+msgstr ""
+
+#: ../src/command/time.cpp:254 ../src/command/time.cpp:255
+msgid "Add lead in"
+msgstr ""
+
+#: ../src/command/time.cpp:256
+msgid "Add the lead in time to the selected lines"
+msgstr ""
+
+#: ../src/command/time.cpp:266 ../src/command/time.cpp:267
+msgid "Add lead out"
+msgstr ""
+
+#: ../src/command/time.cpp:268
+msgid "Add the lead out time to the selected lines"
+msgstr ""
+
+#: ../src/command/time.cpp:277 ../src/command/time.cpp:278
+msgid "Increase length"
+msgstr ""
+
+#: ../src/command/time.cpp:279
+msgid "Increase the length of the current timing unit"
+msgstr ""
+
+#: ../src/command/time.cpp:288 ../src/command/time.cpp:289
+msgid "Increase length and shift"
+msgstr ""
+
+#: ../src/command/time.cpp:290
 msgid ""
-"Toggle italics (\\i) for the current selection or at the current cursor "
-"position"
+"Increase the length of the current timing unit and shift the following items"
 msgstr ""
 
-#: ../src/command/edit.cpp:448
-msgid "toggle italic"
+#: ../src/command/time.cpp:299 ../src/command/time.cpp:300
+msgid "Decrease length"
 msgstr ""
 
-#: ../src/command/edit.cpp:455 ../src/command/edit.cpp:456
-msgid "Toggle Underline"
+#: ../src/command/time.cpp:301
+msgid "Decrease the length of the current timing unit"
 msgstr ""
 
-#: ../src/command/edit.cpp:457
+#: ../src/command/time.cpp:310 ../src/command/time.cpp:311
+msgid "Decrease length and shift"
+msgstr ""
+
+#: ../src/command/time.cpp:312
 msgid ""
-"Toggle underline (\\u) for the current selection or at the current cursor "
-"position"
+"Decrease the length of the current timing unit and shift the following items"
 msgstr ""
 
-#: ../src/command/edit.cpp:460
-msgid "toggle underline"
+#: ../src/command/time.cpp:321 ../src/command/time.cpp:322
+msgid "Shift start time forward"
 msgstr ""
 
-#: ../src/command/edit.cpp:467 ../src/command/edit.cpp:468
-msgid "Toggle Strikeout"
+#: ../src/command/time.cpp:323
+msgid "Shift the start time of the current timing unit forward"
 msgstr ""
 
-#: ../src/command/edit.cpp:469
-msgid ""
-"Toggle strikeout (\\s) for the current selection or at the current cursor "
-"position"
+#: ../src/command/time.cpp:332 ../src/command/time.cpp:333
+msgid "Shift start time backward"
 msgstr ""
 
-#: ../src/command/edit.cpp:472
-msgid "toggle strikeout"
+#: ../src/command/time.cpp:334
+msgid "Shift the start time of the current timing unit backward"
 msgstr ""
 
-#: ../src/command/edit.cpp:479
-msgid "Font Face..."
+#: ../src/command/time.cpp:344
+msgid "Snap &Start to Video"
 msgstr ""
 
-#: ../src/command/edit.cpp:480 ../src/preferences_base.cpp:251
-msgid "Font Face"
+#: ../src/command/time.cpp:345
+msgid "Snap Start to Video"
 msgstr ""
 
-#: ../src/command/edit.cpp:481
-msgid "Select a font face and size"
+#: ../src/command/time.cpp:346
+msgid "Set start of selected subtitles to current video frame"
 msgstr ""
 
-#: ../src/command/edit.cpp:508
-msgid "set font"
+#: ../src/command/time.cpp:358
+msgid "Next line or syllable"
 msgstr ""
 
-#: ../src/command/edit.cpp:535
-msgid "Find and R&eplace..."
-msgstr ""
-
-#: ../src/command/edit.cpp:536
-msgid "Find and Replace"
-msgstr ""
-
-#: ../src/command/edit.cpp:537
-msgid "Find and replace words in subtitles"
-msgstr ""
-
-#: ../src/command/edit.cpp:598
-msgid "&Copy Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:599
-msgid "Copy Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:600
-msgid "Copy subtitles to the clipboard"
-msgstr ""
-
-#: ../src/command/edit.cpp:621
-msgid "Cu&t Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:622
-msgid "Cut Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:623
-msgid "Cut subtitles"
-msgstr ""
-
-#: ../src/command/edit.cpp:630
-msgid "cut lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:638
-msgid "De&lete Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:639
-msgid "Delete Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:640
-msgid "Delete currently selected lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:643
-msgid "delete lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:708 ../src/command/edit.cpp:1093
-msgid "split"
-msgstr ""
-
-#: ../src/command/edit.cpp:708
-msgid "duplicate lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:715
-msgid "&Duplicate Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:716
-msgid "Duplicate Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:717
-msgid "Duplicate the selected lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:726 ../src/command/edit.cpp:727
-msgid "Split lines after current frame"
-msgstr ""
-
-#: ../src/command/edit.cpp:728
-msgid ""
-"Split the current line into a line which ends on the current frame and a "
-"line which starts on the next frame"
-msgstr ""
-
-#: ../src/command/edit.cpp:738 ../src/command/edit.cpp:739
-msgid "Split lines before current frame"
-msgstr ""
-
-#: ../src/command/edit.cpp:740
-msgid ""
-"Split the current line into a line which ends on the previous frame and a "
-"line which starts on the current frame"
-msgstr ""
-
-#: ../src/command/edit.cpp:775
-msgid "As &Karaoke"
-msgstr ""
-
-#: ../src/command/edit.cpp:776
-msgid "As Karaoke"
-msgstr ""
-
-#: ../src/command/edit.cpp:777
-msgid "Join selected lines in a single one, as karaoke"
-msgstr ""
-
-#: ../src/command/edit.cpp:780
-msgid "join as karaoke"
-msgstr ""
-
-#: ../src/command/edit.cpp:786
-msgid "&Concatenate"
-msgstr ""
-
-#: ../src/command/edit.cpp:787
-msgid "Concatenate"
-msgstr ""
-
-#: ../src/command/edit.cpp:788
-msgid "Join selected lines in a single one, concatenating text together"
-msgstr ""
-
-#: ../src/command/edit.cpp:791 ../src/command/edit.cpp:802
-msgid "join lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:797
-msgid "Keep &First"
-msgstr ""
-
-#: ../src/command/edit.cpp:798
-msgid "Keep First"
-msgstr ""
-
-#: ../src/command/edit.cpp:799
-msgid ""
-"Join selected lines in a single one, keeping text of first and discarding "
-"remaining"
-msgstr ""
-
-#: ../src/command/edit.cpp:840
-msgid "&Paste Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:841
-msgid "Paste Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:842
-msgid "Paste subtitles"
-msgstr ""
-
-#: ../src/command/edit.cpp:871
-msgid "Paste Lines &Over..."
-msgstr ""
-
-#: ../src/command/edit.cpp:872
-msgid "Paste Lines Over"
-msgstr ""
-
-#: ../src/command/edit.cpp:873
-msgid "Paste subtitles over others"
-msgstr ""
-
-#: ../src/command/edit.cpp:956
-msgid "Recom&bine Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:957
-msgid "Recombine Lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:958
-msgid "Recombine subtitles which have been split and merged"
-msgstr ""
-
-#: ../src/command/edit.cpp:1028
-msgid "combining"
-msgstr ""
-
-#: ../src/command/edit.cpp:1034 ../src/command/edit.cpp:1035
-msgid "Split Lines (by karaoke)"
-msgstr ""
-
-#: ../src/command/edit.cpp:1036
-msgid "Use karaoke timing to split line into multiple smaller lines"
-msgstr ""
-
-#: ../src/command/edit.cpp:1070
-msgid "splitting"
-msgstr ""
-
-#: ../src/command/edit.cpp:1098 ../src/command/edit.cpp:1099
-#: ../src/subs_edit_ctrl.cpp:375
-msgid "Split at cursor (estimate times)"
-msgstr ""
-
-#: ../src/command/edit.cpp:1100
-msgid ""
-"Split the current line at the cursor, dividing the original line's duration "
-"between the new ones"
-msgstr ""
-
-#: ../src/command/edit.cpp:1114 ../src/command/edit.cpp:1115
-#: ../src/subs_edit_ctrl.cpp:374
-msgid "Split at cursor (preserve times)"
-msgstr ""
-
-#: ../src/command/edit.cpp:1116
-msgid ""
-"Split the current line at the cursor, setting both lines to the original "
-"line's times"
-msgstr ""
-
-#: ../src/command/edit.cpp:1125 ../src/command/edit.cpp:1126
-msgid "Split at cursor (at video frame)"
-msgstr ""
-
-#: ../src/command/edit.cpp:1127
-msgid ""
-"Split the current line at the cursor, dividing the line's duration at the "
-"current video frame"
-msgstr ""
-
-#: ../src/command/edit.cpp:1143
-msgid "Redo last undone action"
-msgstr ""
-
-#: ../src/command/edit.cpp:1148
-msgid "Nothing to &redo"
-msgstr ""
-
-#: ../src/command/edit.cpp:1149
-#, c-format
-msgid "&Redo %s"
-msgstr ""
-
-#: ../src/command/edit.cpp:1153
-msgid "Nothing to redo"
-msgstr ""
-
-#: ../src/command/edit.cpp:1154
-#, c-format
-msgid "Redo %s"
-msgstr ""
-
-#: ../src/command/edit.cpp:1169
-msgid "Undo last action"
-msgstr ""
-
-#: ../src/command/edit.cpp:1174
-msgid "Nothing to &undo"
-msgstr ""
-
-#: ../src/command/edit.cpp:1175
-#, c-format
-msgid "&Undo %s"
-msgstr ""
-
-#: ../src/command/edit.cpp:1179
-msgid "Nothing to undo"
-msgstr ""
-
-#: ../src/command/edit.cpp:1180
-#, c-format
-msgid "Undo %s"
-msgstr ""
-
-#: ../src/command/edit.cpp:1194 ../src/command/edit.cpp:1195
-msgid "Revert"
-msgstr ""
-
-#: ../src/command/edit.cpp:1196
-msgid "Revert the active line to its initial state (shown in the upper editor)"
-msgstr ""
-
-#: ../src/command/edit.cpp:1201
-msgid "revert line"
-msgstr ""
-
-#: ../src/command/edit.cpp:1207 ../src/command/edit.cpp:1208
-#: ../src/preferences.cpp:389
-msgid "Clear"
-msgstr ""
-
-#: ../src/command/edit.cpp:1209
-msgid "Clear the current line's text"
-msgstr ""
-
-#: ../src/command/edit.cpp:1214 ../src/command/edit.cpp:1233
-msgid "clear line"
-msgstr ""
-
-#: ../src/command/edit.cpp:1221 ../src/command/edit.cpp:1222
-msgid "Clear Text"
-msgstr ""
-
-#: ../src/command/edit.cpp:1223
-msgid "Clear the current line's text, leaving override tags"
-msgstr ""
-
-#: ../src/command/edit.cpp:1239 ../src/command/edit.cpp:1240
-#: ../src/command/tool.cpp:271
-msgid "Insert Original"
-msgstr ""
-
-#: ../src/command/edit.cpp:1241
-msgid "Insert the original line text at the cursor"
-msgstr ""
-
-#: ../src/command/edit.cpp:1249
-msgid "insert original"
-msgstr ""
-
-#: ../src/command/recent.cpp:43 ../src/command/recent.cpp:44
-#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:46
-#: ../src/command/recent.cpp:47 ../src/command/recent.cpp:51
-#: ../src/command/recent.cpp:52 ../src/command/recent.cpp:62
-#: ../src/command/recent.cpp:63 ../src/command/recent.cpp:73
-#: ../src/command/recent.cpp:74 ../src/command/recent.cpp:85
-#: ../src/command/recent.cpp:86 ../src/command/recent.cpp:96
-#: ../src/command/recent.cpp:97
-msgid "Recent"
-msgstr ""
-
-#: ../src/command/recent.cpp:43 ../src/command/recent.cpp:53
-msgid "Open recent audio"
-msgstr ""
-
-#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:64
-msgid "Open recent keyframes"
-msgstr ""
-
-#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:75
-msgid "Open recent subtitles"
-msgstr ""
-
-#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:87
-msgid "Open recent timecodes"
-msgstr ""
-
-#: ../src/command/recent.cpp:47
-msgid "Open recent video"
-msgstr ""
-
-#: ../src/command/recent.cpp:98
-msgid "Open recent videos"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:78
-msgid "A&ttachments..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:79
-msgid "Attachments"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:80
-msgid "Open the attachment manager dialog"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:91
-msgid "&Find..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:92 ../src/dialog_search_replace.cpp:46
-msgid "Find"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:93
-msgid "Search for text in the subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:104
-msgid "Find &Next"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:105
-msgid "Find Next"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:106
-msgid "Find next match of last search"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:126 ../src/command/subtitle.cpp:160
-#: ../src/command/subtitle.cpp:202 ../src/command/grid.cpp:82
-msgid "line insertion"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:133
-msgid "&After Current"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:134
-msgid "After Current"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:135
-msgid "Insert a new line after the current one"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:167 ../src/command/subtitle.cpp:168
-msgid "After Current, at Video Time"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:169
-msgid "Insert a new line after the current one, starting at video time"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:178
-msgid "&Before Current"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:179
-msgid "Before Current"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:180
-msgid "Insert a new line before the current one"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:209 ../src/command/subtitle.cpp:210
-msgid "Before Current, at Video Time"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:211
-msgid "Insert a new line before the current one, starting at video time"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:221
-msgid "&New Subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:222
-msgid "New Subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:223
-msgid "New subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:234
-msgid "&Open Subtitles..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:235
-msgid "Open Subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:236
-msgid "Open a subtitles file"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:248
-msgid "Open A&utosaved Subtitles..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:249
-msgid "Open Autosaved Subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:250
-msgid "Open a previous version of a file which was autosaved by Aegisub"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:263
-msgid "Open Subtitles with &Charset..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:264
-msgid "Open Subtitles with Charset"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:265
-msgid "Open a subtitles file with a specific file encoding"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:273
-msgid "Choose charset code:"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:273
-msgid "Charset"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:282
-msgid "Open Subtitles from &Video"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:283
-msgid "Open Subtitles from Video"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:284
-msgid "Open the subtitles from the current video file"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:300
-msgid "&Properties..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:301
-msgid "Properties"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:302
-msgid "Open script properties window"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:313
-msgid "Save subtitles file"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:333
-msgid "&Save Subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:334
-msgid "Save Subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:335
-msgid "Save the current subtitles"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:350
-msgid "Save Subtitles &as..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:351
-msgid "Save Subtitles as"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:352
-msgid "Save subtitles with another name"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:361 ../src/dialog_selected_choices.cpp:26
-#: ../src/subs_edit_ctrl.cpp:369 ../src/dialog_export.cpp:125
-msgid "Select &All"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:362
-msgid "Select All"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:363
-msgid "Select all dialogue lines"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:375 ../src/command/subtitle.cpp:376
-msgid "Select Visible"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:377
-msgid "Select all dialogue lines that are visible on the current video frame"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:407
-msgid "Spell &Checker..."
-msgstr ""
-
-#: ../src/command/subtitle.cpp:408 ../src/dialog_spellchecker.cpp:103
-msgid "Spell Checker"
-msgstr ""
-
-#: ../src/command/subtitle.cpp:409
-msgid "Open spell checker"
-msgstr ""
-
-#: ../src/command/tool.cpp:58
-msgid "ASSDraw3..."
-msgstr ""
-
-#: ../src/command/tool.cpp:59
-msgid "ASSDraw3"
-msgstr ""
-
-#: ../src/command/tool.cpp:60
-msgid "Launch the ASSDraw3 tool for vector drawing"
-msgstr ""
-
-#: ../src/command/tool.cpp:70
-msgid "&Export Subtitles..."
-msgstr ""
-
-#: ../src/command/tool.cpp:71
-msgid "Export Subtitles"
-msgstr ""
-
-#: ../src/command/tool.cpp:72
-msgid ""
-"Save a copy of subtitles in a different format or with processing applied to "
-"it"
-msgstr ""
-
-#: ../src/command/tool.cpp:83
-msgid "&Fonts Collector..."
-msgstr ""
-
-#: ../src/command/tool.cpp:84 ../src/dialog_fonts_collector.cpp:218
-msgid "Fonts Collector"
-msgstr ""
-
-#: ../src/command/tool.cpp:85
-msgid "Open fonts collector"
-msgstr ""
-
-#: ../src/command/tool.cpp:95
-msgid "S&elect Lines..."
-msgstr ""
-
-#: ../src/command/tool.cpp:96
-msgid "Select Lines"
-msgstr ""
-
-#: ../src/command/tool.cpp:97
-msgid "Select lines based on defined criteria"
-msgstr ""
-
-#: ../src/command/tool.cpp:107
-msgid "&Resample Resolution..."
-msgstr ""
-
-#: ../src/command/tool.cpp:108 ../src/dialog_resample.cpp:90
-msgid "Resample Resolution"
-msgstr ""
-
-#: ../src/command/tool.cpp:109
-msgid ""
-"Resample subtitles to maintain their current appearance at a different "
-"script resolution"
-msgstr ""
-
-#: ../src/command/tool.cpp:122
-msgid "St&yling Assistant..."
-msgstr ""
-
-#: ../src/command/tool.cpp:124
-msgid "Open styling assistant"
-msgstr ""
-
-#: ../src/command/tool.cpp:141 ../src/command/tool.cpp:225
-msgid "&Accept changes"
-msgstr ""
-
-#: ../src/command/tool.cpp:143 ../src/command/tool.cpp:227
-msgid "Commit changes and move to the next line"
-msgstr ""
-
-#: ../src/command/tool.cpp:152 ../src/command/tool.cpp:236
-msgid "&Preview changes"
-msgstr ""
-
-#: ../src/command/tool.cpp:154 ../src/command/tool.cpp:238
-msgid "Commit changes and stay on the current line"
-msgstr ""
-
-#: ../src/command/tool.cpp:164
-msgid "&Styles Manager..."
-msgstr ""
-
-#: ../src/command/tool.cpp:166
-msgid "Open the styles manager"
-msgstr ""
-
-#: ../src/command/tool.cpp:176
-msgid "&Kanji Timer..."
-msgstr ""
-
-#: ../src/command/tool.cpp:177
-msgid "Kanji Timer"
-msgstr ""
-
-#: ../src/command/tool.cpp:178
-msgid "Open the Kanji timer copier"
-msgstr ""
-
-#: ../src/command/tool.cpp:188
-msgid "&Timing Post-Processor..."
-msgstr ""
-
-#: ../src/command/tool.cpp:190
-msgid ""
-"Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
-"to scene changes, etc."
-msgstr ""
-
-#: ../src/command/tool.cpp:200
-msgid "&Translation Assistant..."
-msgstr ""
-
-#: ../src/command/tool.cpp:201 ../src/dialog_translation.cpp:64
-msgid "Translation Assistant"
-msgstr ""
-
-#: ../src/command/tool.cpp:202
-msgid "Open translation assistant"
-msgstr ""
-
-#: ../src/command/tool.cpp:210
-msgid "There is nothing to translate in the file."
-msgstr ""
-
-#: ../src/command/tool.cpp:247
-msgid "&Next Line"
-msgstr ""
-
-#: ../src/command/tool.cpp:248 ../src/command/grid.cpp:51
-#: ../src/command/grid.cpp:52 ../src/command/grid.cpp:63
-#: ../src/command/grid.cpp:64 ../src/command/time.cpp:354
-#: ../src/command/time.cpp:355
-msgid "Next Line"
-msgstr ""
-
-#: ../src/command/tool.cpp:249
-msgid "Move to the next line without committing changes"
-msgstr ""
-
-#: ../src/command/tool.cpp:258
-msgid "&Previous Line"
-msgstr ""
-
-#: ../src/command/tool.cpp:259 ../src/command/grid.cpp:90
-#: ../src/command/grid.cpp:91 ../src/command/time.cpp:366
-#: ../src/command/time.cpp:367
-msgid "Previous Line"
-msgstr ""
-
-#: ../src/command/tool.cpp:260
-msgid "Move to the previous line without committing changes"
-msgstr ""
-
-#: ../src/command/tool.cpp:270
-msgid "&Insert Original"
-msgstr ""
-
-#: ../src/command/tool.cpp:272
-msgid "Insert the untranslated text"
-msgstr ""
-
-#: ../src/command/app.cpp:58
-msgid "&About"
-msgstr ""
-
-#: ../src/command/app.cpp:59
-msgid "About"
-msgstr ""
-
-#: ../src/command/app.cpp:60 ../src/dialog_about.cpp:44
-msgid "About Aegisub"
-msgstr ""
-
-#: ../src/command/app.cpp:69
-msgid "&Audio+Subs View"
-msgstr ""
-
-#: ../src/command/app.cpp:70
-msgid "Audio+Subs View"
-msgstr ""
-
-#: ../src/command/app.cpp:71
-msgid "Display audio and the subtitles grid only"
-msgstr ""
-
-#: ../src/command/app.cpp:89
-msgid "&Full view"
-msgstr ""
-
-#: ../src/command/app.cpp:90
-msgid "Full view"
-msgstr ""
-
-#: ../src/command/app.cpp:91
-msgid "Display audio, video and then subtitles grid"
-msgstr ""
-
-#: ../src/command/app.cpp:109
-msgid "S&ubs Only View"
-msgstr ""
-
-#: ../src/command/app.cpp:110
-msgid "Subs Only View"
-msgstr ""
-
-#: ../src/command/app.cpp:111
-msgid "Display the subtitles grid only"
-msgstr ""
-
-#: ../src/command/app.cpp:125
-msgid "&Video+Subs View"
-msgstr ""
-
-#: ../src/command/app.cpp:126
-msgid "Video+Subs View"
-msgstr ""
-
-#: ../src/command/app.cpp:127
-msgid "Display video and the subtitles grid only"
-msgstr ""
-
-#: ../src/command/app.cpp:145
-msgid "E&xit"
-msgstr ""
-
-#: ../src/command/app.cpp:146
-msgid "Exit"
-msgstr ""
-
-#: ../src/command/app.cpp:147
-msgid "Exit the application"
-msgstr ""
-
-#: ../src/command/app.cpp:157
-msgid "&Language..."
-msgstr ""
-
-#: ../src/command/app.cpp:158
-msgid "Language"
-msgstr ""
-
-#: ../src/command/app.cpp:159
-msgid "Select Aegisub interface language"
-msgstr ""
-
-#: ../src/command/app.cpp:182
-msgid "&Log window"
-msgstr ""
-
-#: ../src/command/app.cpp:183 ../src/dialog_log.cpp:99
-msgid "Log window"
-msgstr ""
-
-#: ../src/command/app.cpp:184
-msgid "View the event log"
-msgstr ""
-
-#: ../src/command/app.cpp:194
-msgid "New &Window"
-msgstr ""
-
-#: ../src/command/app.cpp:195
-msgid "New Window"
-msgstr ""
-
-#: ../src/command/app.cpp:196
-msgid "Open a new application window"
-msgstr ""
-
-#: ../src/command/app.cpp:206
-msgid "&Options..."
-msgstr ""
-
-#: ../src/command/app.cpp:208
-msgid "Configure Aegisub"
-msgstr ""
-
-#: ../src/command/app.cpp:222 ../src/command/app.cpp:223
-msgid "Toggle global hotkey overrides"
-msgstr ""
-
-#: ../src/command/app.cpp:224
-msgid "Toggle global hotkey overrides (Medusa Mode)"
-msgstr ""
-
-#: ../src/command/app.cpp:239
-msgid "Toggle the main toolbar"
-msgstr ""
-
-#: ../src/command/app.cpp:244
-msgid "Hide Toolbar"
-msgstr ""
-
-#: ../src/command/app.cpp:245
-msgid "Show Toolbar"
-msgstr ""
-
-#: ../src/command/app.cpp:260
-msgid "&Check for Updates..."
-msgstr ""
-
-#: ../src/command/app.cpp:261
-msgid "Check for Updates"
-msgstr ""
-
-#: ../src/command/app.cpp:262
-msgid "Check to see if there is a new version of Aegisub available"
+#: ../src/command/time.cpp:370
+msgid "Previous line or syllable"
 msgstr ""
 
 #: ../src/command/grid.cpp:53
@@ -2262,6 +3153,11 @@ msgstr ""
 
 #: ../src/command/grid.cpp:65
 msgid "Move to the next subtitle line, creating a new one if needed"
+msgstr ""
+
+#: ../src/command/grid.cpp:82 ../src/command/subtitle.cpp:128
+#: ../src/command/subtitle.cpp:162 ../src/command/subtitle.cpp:204
+msgid "line insertion"
 msgstr ""
 
 #: ../src/command/grid.cpp:92
@@ -2293,17 +3189,6 @@ msgstr ""
 msgid "Sort selected subtitles by their actor names"
 msgstr ""
 
-#: ../src/command/grid.cpp:133 ../src/command/grid.cpp:145
-#: ../src/dialog_search_replace.cpp:87
-msgid "&Effect"
-msgstr ""
-
-#: ../src/command/grid.cpp:134 ../src/command/grid.cpp:146
-#: ../src/dialog_paste_over.cpp:72 ../src/subs_edit_box.cpp:145
-#: ../src/grid_column.cpp:191 ../src/grid_column.cpp:192
-msgid "Effect"
-msgstr ""
-
 #: ../src/command/grid.cpp:135
 msgid "Sort all subtitles by their effects"
 msgstr ""
@@ -2314,11 +3199,6 @@ msgstr ""
 
 #: ../src/command/grid.cpp:157 ../src/command/grid.cpp:169
 msgid "&End Time"
-msgstr ""
-
-#: ../src/command/grid.cpp:158 ../src/command/grid.cpp:170
-#: ../src/dialog_paste_over.cpp:66 ../src/grid_column.cpp:147
-msgid "End Time"
 msgstr ""
 
 #: ../src/command/grid.cpp:159
@@ -2333,11 +3213,6 @@ msgstr ""
 msgid "&Layer"
 msgstr ""
 
-#: ../src/command/grid.cpp:182 ../src/command/grid.cpp:194
-#: ../src/dialog_paste_over.cpp:64 ../src/grid_column.cpp:107
-msgid "Layer"
-msgstr ""
-
 #: ../src/command/grid.cpp:183
 msgid "Sort all subtitles by their layer number"
 msgstr ""
@@ -2348,11 +3223,6 @@ msgstr ""
 
 #: ../src/command/grid.cpp:205 ../src/command/grid.cpp:217
 msgid "&Start Time"
-msgstr ""
-
-#: ../src/command/grid.cpp:206 ../src/command/grid.cpp:218
-#: ../src/dialog_paste_over.cpp:65 ../src/grid_column.cpp:129
-msgid "Start Time"
 msgstr ""
 
 #: ../src/command/grid.cpp:207
@@ -2368,7 +3238,7 @@ msgid "St&yle Name"
 msgstr ""
 
 #: ../src/command/grid.cpp:230 ../src/command/grid.cpp:242
-#: ../src/dialog_style_editor.cpp:177
+#: ../src/dialog_style_editor.cpp:178
 msgid "Style Name"
 msgstr ""
 
@@ -2469,535 +3339,279 @@ msgstr ""
 msgid "swap lines"
 msgstr ""
 
-#: ../src/command/automation.cpp:48
-msgid "&Reload Automation scripts"
+#: ../src/command/timecode.cpp:52 ../src/command/timecode.cpp:53
+msgid "Close Timecodes File"
 msgstr ""
 
-#: ../src/command/automation.cpp:49
-msgid "Reload Automation scripts"
+#: ../src/command/timecode.cpp:54
+msgid "Close the currently open timecodes file"
 msgstr ""
 
-#: ../src/command/automation.cpp:50
-msgid "Reload all Automation scripts and rescan the autoload folder"
+#: ../src/command/timecode.cpp:69
+msgid "Open Timecodes File..."
 msgstr ""
 
-#: ../src/command/automation.cpp:55
-msgid "Reloaded all Automation scripts"
+#: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
+msgid "Open Timecodes File"
 msgstr ""
 
-#: ../src/command/automation.cpp:61
-msgid "R&eload autoload Automation scripts"
+#: ../src/command/timecode.cpp:71
+msgid "Open a VFR timecodes v1 or v2 file"
 msgstr ""
 
-#: ../src/command/automation.cpp:62
-msgid "Reload autoload Automation scripts"
+#: ../src/command/timecode.cpp:84
+msgid "Save Timecodes File..."
 msgstr ""
 
-#: ../src/command/automation.cpp:63
-msgid "Rescan the Automation autoload folder"
+#: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
+msgid "Save Timecodes File"
 msgstr ""
 
-#: ../src/command/automation.cpp:67
-msgid "Reloaded autoload Automation scripts"
-msgstr ""
-
-#: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
-msgid "&Automation..."
-msgstr ""
-
-#: ../src/command/automation.cpp:75 ../src/command/automation.cpp:87
-#: ../src/preferences.cpp:314
-msgid "Automation"
-msgstr ""
-
-#: ../src/command/automation.cpp:76
-msgid "Open automation manager"
-msgstr ""
-
-#: ../src/command/automation.cpp:88
-msgid ""
-"Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
-"autoload folder and reload all automation scripts"
-msgstr ""
-
-#: ../src/command/time.cpp:99
-msgid "adjoin"
-msgstr ""
-
-#: ../src/command/time.cpp:104
-msgid "Change &End"
-msgstr ""
-
-#: ../src/command/time.cpp:105
-msgid "Change End"
-msgstr ""
-
-#: ../src/command/time.cpp:106
-msgid "Change end times of lines to the next line's start time"
-msgstr ""
-
-#: ../src/command/time.cpp:115
-msgid "Change &Start"
-msgstr ""
-
-#: ../src/command/time.cpp:116
-msgid "Change Start"
-msgstr ""
-
-#: ../src/command/time.cpp:117
-msgid "Change start times of lines to the previous line's end time"
-msgstr ""
-
-#: ../src/command/time.cpp:127
-msgid "Shift to &Current Frame"
-msgstr ""
-
-#: ../src/command/time.cpp:128
-msgid "Shift to Current Frame"
-msgstr ""
-
-#: ../src/command/time.cpp:129
-msgid "Shift selection so that the active line starts at current frame"
-msgstr ""
-
-#: ../src/command/time.cpp:145
-msgid "shift to frame"
-msgstr ""
-
-#: ../src/command/time.cpp:152
-msgid "S&hift Times..."
-msgstr ""
-
-#: ../src/command/time.cpp:154
-msgid "Shift subtitles by time or frames"
-msgstr ""
-
-#: ../src/command/time.cpp:175 ../src/audio_timing_dialogue.cpp:512
-#: ../src/audio_timing_dialogue.cpp:518
-msgid "timing"
-msgstr ""
-
-#: ../src/command/time.cpp:181
-msgid "Snap &End to Video"
-msgstr ""
-
-#: ../src/command/time.cpp:182
-msgid "Snap End to Video"
-msgstr ""
-
-#: ../src/command/time.cpp:183
-msgid "Set end of selected subtitles to current video frame"
-msgstr ""
-
-#: ../src/command/time.cpp:193
-msgid "Snap to S&cene"
-msgstr ""
-
-#: ../src/command/time.cpp:194
-msgid "Snap to Scene"
-msgstr ""
-
-#: ../src/command/time.cpp:195
-msgid ""
-"Set start and end of subtitles to the keyframes around current video frame"
-msgstr ""
-
-#: ../src/command/time.cpp:232
-msgid "snap to scene"
-msgstr ""
-
-#: ../src/command/time.cpp:238 ../src/command/time.cpp:239
-msgid "Add lead in and out"
-msgstr ""
-
-#: ../src/command/time.cpp:240
-msgid "Add both lead in and out to the selected lines"
-msgstr ""
-
-#: ../src/command/time.cpp:252 ../src/command/time.cpp:253
-msgid "Add lead in"
-msgstr ""
-
-#: ../src/command/time.cpp:254
-msgid "Add the lead in time to the selected lines"
-msgstr ""
-
-#: ../src/command/time.cpp:264 ../src/command/time.cpp:265
-msgid "Add lead out"
-msgstr ""
-
-#: ../src/command/time.cpp:266
-msgid "Add the lead out time to the selected lines"
-msgstr ""
-
-#: ../src/command/time.cpp:275 ../src/command/time.cpp:276
-msgid "Increase length"
-msgstr ""
-
-#: ../src/command/time.cpp:277
-msgid "Increase the length of the current timing unit"
-msgstr ""
-
-#: ../src/command/time.cpp:286 ../src/command/time.cpp:287
-msgid "Increase length and shift"
-msgstr ""
-
-#: ../src/command/time.cpp:288
-msgid ""
-"Increase the length of the current timing unit and shift the following items"
-msgstr ""
-
-#: ../src/command/time.cpp:297 ../src/command/time.cpp:298
-msgid "Decrease length"
-msgstr ""
-
-#: ../src/command/time.cpp:299
-msgid "Decrease the length of the current timing unit"
-msgstr ""
-
-#: ../src/command/time.cpp:308 ../src/command/time.cpp:309
-msgid "Decrease length and shift"
-msgstr ""
-
-#: ../src/command/time.cpp:310
-msgid ""
-"Decrease the length of the current timing unit and shift the following items"
-msgstr ""
-
-#: ../src/command/time.cpp:319 ../src/command/time.cpp:320
-msgid "Shift start time forward"
-msgstr ""
-
-#: ../src/command/time.cpp:321
-msgid "Shift the start time of the current timing unit forward"
-msgstr ""
-
-#: ../src/command/time.cpp:330 ../src/command/time.cpp:331
-msgid "Shift start time backward"
-msgstr ""
-
-#: ../src/command/time.cpp:332
-msgid "Shift the start time of the current timing unit backward"
-msgstr ""
-
-#: ../src/command/time.cpp:342
-msgid "Snap &Start to Video"
-msgstr ""
-
-#: ../src/command/time.cpp:343
-msgid "Snap Start to Video"
-msgstr ""
-
-#: ../src/command/time.cpp:344
-msgid "Set start of selected subtitles to current video frame"
-msgstr ""
-
-#: ../src/command/time.cpp:356
-msgid "Next line or syllable"
-msgstr ""
-
-#: ../src/command/time.cpp:368
-msgid "Previous line or syllable"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:56 ../src/command/vis_tool.cpp:57
-msgid "Standard"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:58
-msgid "Standard mode, double click sets position"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:64 ../src/command/vis_tool.cpp:65
-#: ../src/visual_tool_vector_clip.cpp:57
-msgid "Drag"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:66
-msgid "Drag subtitles"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:72 ../src/command/vis_tool.cpp:73
-msgid "Rotate Z"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:74
-msgid "Rotate subtitles on their Z axis"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:80 ../src/command/vis_tool.cpp:81
-msgid "Rotate XY"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:82
-msgid "Rotate subtitles on their X and Y axes"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:88 ../src/command/vis_tool.cpp:89
-msgid "Scale"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:90
-msgid "Scale subtitles on X and Y axes"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:96 ../src/command/vis_tool.cpp:97
-msgid "Clip"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:98
-msgid "Clip subtitles to a rectangle"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:104 ../src/command/vis_tool.cpp:105
-msgid "Vector Clip"
-msgstr ""
-
-#: ../src/command/vis_tool.cpp:106
-msgid "Clip subtitles to a vectorial area"
-msgstr ""
-
-#: ../src/command/audio.cpp:65
-msgid "&Close Audio"
+#: ../src/command/timecode.cpp:86
+msgid "Save a VFR timecodes v2 file"
 msgstr ""
 
 #: ../src/command/audio.cpp:66
-msgid "Close Audio"
+msgid "&Close Audio"
 msgstr ""
 
 #: ../src/command/audio.cpp:67
+msgid "Close Audio"
+msgstr ""
+
+#: ../src/command/audio.cpp:68
 msgid "Close the currently open audio file"
 msgstr ""
 
-#: ../src/command/audio.cpp:77
+#: ../src/command/audio.cpp:78
 msgid "&Open Audio File..."
 msgstr ""
 
-#: ../src/command/audio.cpp:78 ../src/command/audio.cpp:85
+#: ../src/command/audio.cpp:79 ../src/command/audio.cpp:86
 msgid "Open Audio File"
 msgstr ""
 
-#: ../src/command/audio.cpp:79
+#: ../src/command/audio.cpp:80
 msgid "Open an audio file"
 msgstr ""
 
-#: ../src/command/audio.cpp:82
+#: ../src/command/audio.cpp:83
 msgid "Audio Formats"
 msgstr ""
 
-#: ../src/command/audio.cpp:93 ../src/command/audio.cpp:94
+#: ../src/command/audio.cpp:94 ../src/command/audio.cpp:95
 msgid "Open 2h30 Blank Audio"
 msgstr ""
 
-#: ../src/command/audio.cpp:95
+#: ../src/command/audio.cpp:96
 msgid "Open a 150 minutes blank audio clip, for debugging"
 msgstr ""
 
-#: ../src/command/audio.cpp:104 ../src/command/audio.cpp:105
+#: ../src/command/audio.cpp:105 ../src/command/audio.cpp:106
 msgid "Open 2h30 Noise Audio"
 msgstr ""
 
-#: ../src/command/audio.cpp:106
+#: ../src/command/audio.cpp:107
 msgid "Open a 150 minutes noise-filled audio clip, for debugging"
 msgstr ""
 
-#: ../src/command/audio.cpp:116
+#: ../src/command/audio.cpp:117
 msgid "Open Audio from &Video"
 msgstr ""
 
-#: ../src/command/audio.cpp:117
+#: ../src/command/audio.cpp:118
 msgid "Open Audio from Video"
 msgstr ""
 
-#: ../src/command/audio.cpp:118
+#: ../src/command/audio.cpp:119
 msgid "Open the audio from the current video file"
 msgstr ""
 
-#: ../src/command/audio.cpp:132
+#: ../src/command/audio.cpp:133
 msgid "&Spectrum Display"
 msgstr ""
 
-#: ../src/command/audio.cpp:133
+#: ../src/command/audio.cpp:134
 msgid "Spectrum Display"
 msgstr ""
 
-#: ../src/command/audio.cpp:134
+#: ../src/command/audio.cpp:135
 msgid "Display audio as a frequency-power spectrograph"
 msgstr ""
 
-#: ../src/command/audio.cpp:148
+#: ../src/command/audio.cpp:149
 msgid "&Waveform Display"
 msgstr ""
 
-#: ../src/command/audio.cpp:149
+#: ../src/command/audio.cpp:150
 msgid "Waveform Display"
 msgstr ""
 
-#: ../src/command/audio.cpp:150
+#: ../src/command/audio.cpp:151
 msgid "Display audio as a linear amplitude graph"
 msgstr ""
 
-#: ../src/command/audio.cpp:187 ../src/command/audio.cpp:188
+#: ../src/command/audio.cpp:165 ../src/command/audio.cpp:166
 msgid "Create audio clip"
 msgstr ""
 
-#: ../src/command/audio.cpp:189
+#: ../src/command/audio.cpp:167
 msgid "Save an audio clip of the selected line"
 msgstr ""
 
-#: ../src/command/audio.cpp:200
+#: ../src/command/audio.cpp:178
 msgid "Save audio clip"
 msgstr ""
 
-#: ../src/command/audio.cpp:247 ../src/command/audio.cpp:248
+#: ../src/command/audio.cpp:193 ../src/command/audio.cpp:194
 msgid "Play current audio selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:249
+#: ../src/command/audio.cpp:195
 msgid "Play the current audio selection, ignoring changes made while playing"
 msgstr ""
 
-#: ../src/command/audio.cpp:262
+#: ../src/command/audio.cpp:208
 msgid "Play the audio for the current line"
 msgstr ""
 
-#: ../src/command/audio.cpp:275 ../src/command/audio.cpp:276
+#: ../src/command/audio.cpp:221 ../src/command/audio.cpp:222
 msgid "Play audio selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:277
+#: ../src/command/audio.cpp:223
 msgid "Play audio until the end of the selection is reached"
 msgstr ""
 
-#: ../src/command/audio.cpp:287 ../src/command/audio.cpp:288
+#: ../src/command/audio.cpp:233 ../src/command/audio.cpp:234
 msgid "Play audio selection or stop"
 msgstr ""
 
-#: ../src/command/audio.cpp:289
+#: ../src/command/audio.cpp:235
 msgid "Play selection, or stop playback if it's already playing"
 msgstr ""
 
-#: ../src/command/audio.cpp:304 ../src/command/audio.cpp:305
+#: ../src/command/audio.cpp:250 ../src/command/audio.cpp:251
 msgid "Stop playing"
 msgstr ""
 
-#: ../src/command/audio.cpp:306
+#: ../src/command/audio.cpp:252
 msgid "Stop audio and video playback"
 msgstr ""
 
-#: ../src/command/audio.cpp:322 ../src/command/audio.cpp:323
-#: ../src/command/audio.cpp:324
+#: ../src/command/audio.cpp:268 ../src/command/audio.cpp:269
+#: ../src/command/audio.cpp:270
 msgid "Play 500 ms before selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:336 ../src/command/audio.cpp:337
-#: ../src/command/audio.cpp:338
+#: ../src/command/audio.cpp:282 ../src/command/audio.cpp:283
+#: ../src/command/audio.cpp:284
 msgid "Play 500 ms after selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:350 ../src/command/audio.cpp:351
-#: ../src/command/audio.cpp:352
+#: ../src/command/audio.cpp:296 ../src/command/audio.cpp:297
+#: ../src/command/audio.cpp:298
 msgid "Play last 500 ms of selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:364 ../src/command/audio.cpp:365
-#: ../src/command/audio.cpp:366
+#: ../src/command/audio.cpp:310 ../src/command/audio.cpp:311
+#: ../src/command/audio.cpp:312
 msgid "Play first 500 ms of selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:380 ../src/command/audio.cpp:381
-#: ../src/command/audio.cpp:382
+#: ../src/command/audio.cpp:326 ../src/command/audio.cpp:327
+#: ../src/command/audio.cpp:328
 msgid "Play from selection start to end of file"
 msgstr ""
 
-#: ../src/command/audio.cpp:393 ../src/command/audio.cpp:394
+#: ../src/command/audio.cpp:339 ../src/command/audio.cpp:340
 msgid "Commit"
 msgstr ""
 
-#: ../src/command/audio.cpp:395
+#: ../src/command/audio.cpp:341
 msgid "Commit any pending audio timing changes"
 msgstr ""
 
-#: ../src/command/audio.cpp:409 ../src/command/audio.cpp:410
+#: ../src/command/audio.cpp:355 ../src/command/audio.cpp:356
 msgid "Commit and use default timing for next line"
 msgstr ""
 
-#: ../src/command/audio.cpp:411
+#: ../src/command/audio.cpp:357
 msgid ""
 "Commit any pending audio timing changes and reset the next line's times to "
 "the default"
 msgstr ""
 
-#: ../src/command/audio.cpp:424 ../src/command/audio.cpp:425
+#: ../src/command/audio.cpp:370 ../src/command/audio.cpp:371
 msgid "Commit and move to next line"
 msgstr ""
 
-#: ../src/command/audio.cpp:426
+#: ../src/command/audio.cpp:372
 msgid "Commit any pending audio timing changes and move to the next line"
 msgstr ""
 
-#: ../src/command/audio.cpp:439 ../src/command/audio.cpp:440
+#: ../src/command/audio.cpp:385 ../src/command/audio.cpp:386
 msgid "Commit and stay on current line"
 msgstr ""
 
-#: ../src/command/audio.cpp:441
+#: ../src/command/audio.cpp:387
 msgid "Commit any pending audio timing changes and stay on the current line"
 msgstr ""
 
-#: ../src/command/audio.cpp:452 ../src/command/audio.cpp:453
+#: ../src/command/audio.cpp:398 ../src/command/audio.cpp:399
 msgid "Go to selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:454
+#: ../src/command/audio.cpp:400
 msgid "Scroll the audio display to center on the current audio selection"
 msgstr ""
 
-#: ../src/command/audio.cpp:463 ../src/command/audio.cpp:464
+#: ../src/command/audio.cpp:409 ../src/command/audio.cpp:410
 msgid "Scroll left"
 msgstr ""
 
-#: ../src/command/audio.cpp:465
+#: ../src/command/audio.cpp:411
 msgid "Scroll the audio display left"
 msgstr ""
 
-#: ../src/command/audio.cpp:474 ../src/command/audio.cpp:475
+#: ../src/command/audio.cpp:420 ../src/command/audio.cpp:421
 msgid "Scroll right"
 msgstr ""
 
-#: ../src/command/audio.cpp:476
+#: ../src/command/audio.cpp:422
 msgid "Scroll the audio display right"
 msgstr ""
 
-#: ../src/command/audio.cpp:490 ../src/command/audio.cpp:491
-#: ../src/command/audio.cpp:492
+#: ../src/command/audio.cpp:436 ../src/command/audio.cpp:437
+#: ../src/command/audio.cpp:438
 msgid "Auto scroll audio display to selected line"
 msgstr ""
 
-#: ../src/command/audio.cpp:507 ../src/command/audio.cpp:508
-#: ../src/command/audio.cpp:509
+#: ../src/command/audio.cpp:453 ../src/command/audio.cpp:454
+#: ../src/command/audio.cpp:455
 msgid "Automatically commit all changes"
 msgstr ""
 
-#: ../src/command/audio.cpp:524 ../src/command/audio.cpp:525
+#: ../src/command/audio.cpp:470 ../src/command/audio.cpp:471
 msgid "Auto go to next line on commit"
 msgstr ""
 
-#: ../src/command/audio.cpp:526
+#: ../src/command/audio.cpp:472
 msgid "Automatically go to next line on commit"
 msgstr ""
 
-#: ../src/command/audio.cpp:541 ../src/command/audio.cpp:542
-#: ../src/command/audio.cpp:543
+#: ../src/command/audio.cpp:487 ../src/command/audio.cpp:488
+#: ../src/command/audio.cpp:489
 msgid "Spectrum analyzer mode"
 msgstr ""
 
-#: ../src/command/audio.cpp:558 ../src/command/audio.cpp:559
-#: ../src/command/audio.cpp:560
+#: ../src/command/audio.cpp:504 ../src/command/audio.cpp:505
+#: ../src/command/audio.cpp:506
 msgid "Link vertical zoom and volume sliders"
 msgstr ""
 
-#: ../src/command/audio.cpp:575 ../src/command/audio.cpp:576
-#: ../src/command/audio.cpp:577
+#: ../src/command/audio.cpp:521 ../src/command/audio.cpp:522
+#: ../src/command/audio.cpp:523
 msgid "Toggle karaoke mode"
 msgstr ""
 
@@ -3026,1746 +3640,1141 @@ msgid "Help topics"
 msgstr ""
 
 #: ../src/command/help.cpp:81
-msgid "&Forums"
-msgstr ""
-
-#: ../src/command/help.cpp:82
-msgid "Forums"
-msgstr ""
-
-#: ../src/command/help.cpp:83
-msgid "Visit Aegisub's forums"
-msgstr ""
-
-#: ../src/command/help.cpp:93
 msgid "&IRC Channel"
 msgstr ""
 
-#: ../src/command/help.cpp:94
+#: ../src/command/help.cpp:82
 msgid "IRC Channel"
 msgstr ""
 
-#: ../src/command/help.cpp:95
+#: ../src/command/help.cpp:83
 msgid "Visit Aegisub's official IRC channel"
 msgstr ""
 
-#: ../src/command/help.cpp:105
+#: ../src/command/help.cpp:93
 msgid "&Visual Typesetting"
 msgstr ""
 
-#: ../src/command/help.cpp:106
+#: ../src/command/help.cpp:94
 msgid "Visual Typesetting"
 msgstr ""
 
-#: ../src/command/help.cpp:107
+#: ../src/command/help.cpp:95
 msgid "Open the manual page for Visual Typesetting"
 msgstr ""
 
-#: ../src/command/help.cpp:117
+#: ../src/command/help.cpp:105
 msgid "&Website"
 msgstr ""
 
-#: ../src/command/help.cpp:118
+#: ../src/command/help.cpp:106
 msgid "Website"
 msgstr ""
 
-#: ../src/command/help.cpp:119
+#: ../src/command/help.cpp:107
 msgid "Visit Aegisub's official website"
 msgstr ""
 
-#: ../src/command/keyframe.cpp:49 ../src/command/keyframe.cpp:50
-msgid "Close Keyframes"
+#: ../src/command/edit.cpp:134 ../src/command/edit.cpp:842
+msgid "paste"
 msgstr ""
 
-#: ../src/command/keyframe.cpp:51
+#: ../src/command/edit.cpp:375
+msgid "set color"
+msgstr ""
+
+#: ../src/command/edit.cpp:389
+msgid "Primary Color..."
+msgstr ""
+
+#: ../src/command/edit.cpp:390
+msgid "Primary Color"
+msgstr ""
+
+#: ../src/command/edit.cpp:391
+msgid "Set the primary fill color (\\c) at the cursor position"
+msgstr ""
+
+#: ../src/command/edit.cpp:401
+msgid "Secondary Color..."
+msgstr ""
+
+#: ../src/command/edit.cpp:402
+msgid "Secondary Color"
+msgstr ""
+
+#: ../src/command/edit.cpp:403
+msgid "Set the secondary (karaoke) fill color (\\2c) at the cursor position"
+msgstr ""
+
+#: ../src/command/edit.cpp:413
+msgid "Outline Color..."
+msgstr ""
+
+#: ../src/command/edit.cpp:414
+msgid "Outline Color"
+msgstr ""
+
+#: ../src/command/edit.cpp:415
+msgid "Set the outline color (\\3c) at the cursor position"
+msgstr ""
+
+#: ../src/command/edit.cpp:425
+msgid "Shadow Color..."
+msgstr ""
+
+#: ../src/command/edit.cpp:426
+msgid "Shadow Color"
+msgstr ""
+
+#: ../src/command/edit.cpp:427
+msgid "Set the shadow color (\\4c) at the cursor position"
+msgstr ""
+
+#: ../src/command/edit.cpp:437 ../src/command/edit.cpp:438
+msgid "Toggle Bold"
+msgstr ""
+
+#: ../src/command/edit.cpp:439
 msgid ""
-"Discard the currently loaded keyframes and use those from the video, if any"
+"Toggle bold (\\b) for the current selection or at the current cursor position"
 msgstr ""
 
-#: ../src/command/keyframe.cpp:66
-msgid "Open Keyframes..."
+#: ../src/command/edit.cpp:442
+msgid "toggle bold"
 msgstr ""
 
-#: ../src/command/keyframe.cpp:67
-msgid "Open Keyframes"
+#: ../src/command/edit.cpp:449 ../src/command/edit.cpp:450
+msgid "Toggle Italics"
 msgstr ""
 
-#: ../src/command/keyframe.cpp:68
-msgid "Open a keyframe list file"
-msgstr ""
-
-#: ../src/command/keyframe.cpp:72
-msgid "Open keyframes file"
-msgstr ""
-
-#: ../src/command/keyframe.cpp:85
-msgid "Save Keyframes..."
-msgstr ""
-
-#: ../src/command/keyframe.cpp:86
-msgid "Save Keyframes"
-msgstr ""
-
-#: ../src/command/keyframe.cpp:87
-msgid "Save the current list of keyframes to a file"
-msgstr ""
-
-#: ../src/command/keyframe.cpp:95
-msgid "Save keyframes file"
-msgstr ""
-
-#: ../src/dialog_selected_choices.cpp:33 ../src/dialog_export.cpp:126
-msgid "Select &None"
-msgstr ""
-
-#: ../src/subtitles_provider_libass.cpp:112
-msgid "Updating font index"
-msgstr ""
-
-#: ../src/subtitles_provider_libass.cpp:113
-msgid "This may take several minutes"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:125
-msgid "Misspelled word:"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:127 ../src/dialog_search_replace.cpp:73
-msgid "Replace with:"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:182 ../src/dialog_search_replace.cpp:80
-msgid "&Skip Comments"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:183
-msgid "Ignore &UPPERCASE words"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:187
-msgid "&Replace"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:190 ../src/dialog_search_replace.cpp:95
-msgid "Replace &all"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:197
-msgid "&Ignore"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:200
-msgid "Ignore a&ll"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:206
-msgid "Add to &dictionary"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:212
-msgid "Remove fro&m dictionary"
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:279
-msgid "Aegisub has finished checking spelling of this script."
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
-msgid "Spell checking complete."
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:283
-msgid "Aegisub has found no spelling mistakes in this script."
-msgstr ""
-
-#: ../src/dialog_spellchecker.cpp:329 ../src/dialog_spellchecker.cpp:343
-msgid "spell check replace"
-msgstr ""
-
-#: ../src/preferences_base.cpp:63
-msgid "Please choose the folder:"
-msgstr ""
-
-#: ../src/preferences_base.cpp:209
-msgid "Browse..."
-msgstr ""
-
-#: ../src/preferences_base.cpp:244
-msgid "Choose..."
-msgstr ""
-
-#: ../src/preferences_base.cpp:252
-msgid "Font Size"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:89
-msgid "Script Properties"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:95
-msgid "Script"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:98
-msgid "Title:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:99
-msgid "Original script:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:100
-msgid "Translation:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:101
-msgid "Editing:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:102
-msgid "Timing:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:103
-msgid "Synch point:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:104
-msgid "Updated by:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:105
-msgid "Update details:"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:114 ../src/export_framerate.cpp:70
-#: ../src/dialog_resample.cpp:141
-msgid "From &video"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:133
-msgid "Resolution"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:141
-msgid "0: Smart wrapping, top line is wider"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:142
-msgid "1: End-of-line word wrapping, only \\N breaks"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:143
-msgid "2: No word wrapping, both \\n and \\N break"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:144
-msgid "3: Smart wrapping, bottom line is wider"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:148
-msgid "Wrap Style: "
-msgstr ""
-
-#: ../src/dialog_properties.cpp:151
-msgid "Scale Border and Shadow"
-msgstr ""
-
-#: ../src/dialog_properties.cpp:152
+#: ../src/command/edit.cpp:451
 msgid ""
-"Scale border and shadow together with script/render resolution. If this is "
-"unchecked, relative border and shadow size will depend on renderer."
+"Toggle italics (\\i) for the current selection or at the current cursor "
+"position"
 msgstr ""
 
-#: ../src/dialog_properties.cpp:193
-msgid "property changes"
+#: ../src/command/edit.cpp:454
+msgid "toggle italic"
 msgstr ""
 
-#: ../src/dialog_fonts_collector.cpp:107
-msgid "Symlinking fonts to folder...\n"
+#: ../src/command/edit.cpp:461 ../src/command/edit.cpp:462
+msgid "Toggle Underline"
 msgstr ""
 
-#: ../src/dialog_fonts_collector.cpp:111
-msgid "Copying fonts to folder...\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:114
-msgid "Copying fonts to archive...\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:126
-#, c-format
-msgid "* Failed to create directory '%s': %s.\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:137
-#, c-format
-msgid "* Failed to open %s.\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:192
-#, c-format
-msgid "* Copied %s.\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:194
-#, c-format
-msgid "* %s already exists on destination.\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:196
-#, c-format
-msgid "* Symlinked %s.\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:198
-#, c-format
-msgid "* Failed to copy %s.\n"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:204
-msgid "Done. All fonts copied."
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:206
-msgid "Done. Some fonts could not be copied."
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:209
+#: ../src/command/edit.cpp:463
 msgid ""
-"\n"
-"Over 32 MB of fonts were copied. Some of the fonts may not be loaded by the "
-"player if they are all attached to a Matroska file."
+"Toggle underline (\\u) for the current selection or at the current cursor "
+"position"
 msgstr ""
 
-#: ../src/dialog_fonts_collector.cpp:224
-msgid "Check fonts for availability"
+#: ../src/command/edit.cpp:466
+msgid "toggle underline"
 msgstr ""
 
-#: ../src/dialog_fonts_collector.cpp:225
-msgid "Copy fonts to folder"
+#: ../src/command/edit.cpp:473 ../src/command/edit.cpp:474
+msgid "Toggle Strikeout"
 msgstr ""
 
-#: ../src/dialog_fonts_collector.cpp:226
-msgid "Copy fonts to subtitle file's folder"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:227
-msgid "Copy fonts to zipped archive"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:229
-msgid "Symlink fonts to folder"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:232 ../src/dialog_selection.cpp:150
-msgid "Action"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:238
-msgid "Destination"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:242
-msgid "&Browse..."
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:251
-msgid "Log"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:264
-msgid "&Start!"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:301
-msgid "Invalid destination."
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:301 ../src/dialog_fonts_collector.cpp:306
-#: ../src/dialog_fonts_collector.cpp:311 ../src/preferences.cpp:257
-#: ../src/dialog_kara_timing_copy.cpp:574
-#: ../src/dialog_kara_timing_copy.cpp:576
-#: ../src/dialog_kara_timing_copy.cpp:626
-msgid "Error"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:306
-msgid "Could not create destination folder."
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:311
-msgid "Invalid path for .zip file."
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:335
-msgid "Select archive file name"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:342
-msgid "Select folder to save fonts on"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:356
-msgid "N/A"
-msgstr ""
-
-#: ../src/dialog_fonts_collector.cpp:364
+#: ../src/command/edit.cpp:475
 msgid ""
-"Choose the folder where the fonts will be collected to. It will be created "
-"if it doesn't exist."
+"Toggle strikeout (\\s) for the current selection or at the current cursor "
+"position"
 msgstr ""
 
-#: ../src/dialog_fonts_collector.cpp:371
+#: ../src/command/edit.cpp:478
+msgid "toggle strikeout"
+msgstr ""
+
+#: ../src/command/edit.cpp:485
+msgid "Font Face..."
+msgstr ""
+
+#: ../src/command/edit.cpp:486 ../src/preferences_base.cpp:251
+msgid "Font Face"
+msgstr ""
+
+#: ../src/command/edit.cpp:487
+msgid "Select a font face and size"
+msgstr ""
+
+#: ../src/command/edit.cpp:514
+msgid "set font"
+msgstr ""
+
+#: ../src/command/edit.cpp:541
+msgid "Find and R&eplace..."
+msgstr ""
+
+#: ../src/command/edit.cpp:542
+msgid "Find and Replace"
+msgstr ""
+
+#: ../src/command/edit.cpp:543
+msgid "Find and replace words in subtitles"
+msgstr ""
+
+#: ../src/command/edit.cpp:604
+msgid "&Copy Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:605
+msgid "Copy Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:606
+msgid "Copy subtitles to the clipboard"
+msgstr ""
+
+#: ../src/command/edit.cpp:627
+msgid "Cu&t Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:628
+msgid "Cut Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:629
+msgid "Cut subtitles"
+msgstr ""
+
+#: ../src/command/edit.cpp:636
+msgid "cut lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:644
+msgid "De&lete Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:645
+msgid "Delete Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:646
+msgid "Delete currently selected lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:649
+msgid "delete lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:714 ../src/command/edit.cpp:1108
+msgid "split"
+msgstr ""
+
+#: ../src/command/edit.cpp:714
+msgid "duplicate lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:721
+msgid "&Duplicate Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:722
+msgid "Duplicate Lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:723
+msgid "Duplicate the selected lines"
+msgstr ""
+
+#: ../src/command/edit.cpp:732 ../src/command/edit.cpp:733
+msgid "Split lines after current frame"
+msgstr ""
+
+#: ../src/command/edit.cpp:734
 msgid ""
-"Enter the name of the destination zip file to collect the fonts to. If a "
-"folder is entered, a default name will be used."
+"Split the current line into a line which ends on the current frame and a "
+"line which starts on the next frame"
 msgstr ""
 
-#: ../src/audio_renderer_waveform.cpp:154
-msgid "Maximum"
+#: ../src/command/edit.cpp:744 ../src/command/edit.cpp:745
+msgid "Split lines before current frame"
 msgstr ""
 
-#: ../src/audio_renderer_waveform.cpp:155
-msgid "Maximum + Average"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:103
-msgid "Dummy video options"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:115
-msgid "Checkerboard &pattern"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:118
-msgid "Video resolution:"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:120
-msgid "Color:"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:121
-msgid "Frame rate (fps):"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:122
-msgid "Duration (frames):"
-msgstr ""
-
-#: ../src/dialog_dummy_video.cpp:164
-#, c-format
-msgid "Resulting duration: %s"
-msgstr ""
-
-#: ../src/preferences.cpp:61 ../src/preferences.cpp:63
-#: ../src/preferences.cpp:316 ../src/preferences.cpp:341
-msgid "General"
-msgstr ""
-
-#: ../src/preferences.cpp:64
-msgid "Check for updates on startup"
-msgstr ""
-
-#: ../src/preferences.cpp:65
-msgid "Show main toolbar"
-msgstr ""
-
-#: ../src/preferences.cpp:66
-msgid "Save UI state in subtitles files"
-msgstr ""
-
-#: ../src/preferences.cpp:69
-msgid "Toolbar Icon Size"
-msgstr ""
-
-#: ../src/preferences.cpp:70 ../src/preferences.cpp:195
-msgid "Never"
-msgstr ""
-
-#: ../src/preferences.cpp:70
-msgid "Always"
-msgstr ""
-
-#: ../src/preferences.cpp:70 ../src/preferences.cpp:195
-msgid "Ask"
-msgstr ""
-
-#: ../src/preferences.cpp:72
-msgid "Automatically load linked files"
-msgstr ""
-
-#: ../src/preferences.cpp:73
-msgid "Undo Levels"
-msgstr ""
-
-#: ../src/preferences.cpp:75
-msgid "Recently Used Lists"
-msgstr ""
-
-#: ../src/preferences.cpp:76 ../src/dialog_autosave.cpp:70
-msgid "Files"
-msgstr ""
-
-#: ../src/preferences.cpp:77
-msgid "Find/Replace"
-msgstr ""
-
-#: ../src/preferences.cpp:83
-msgid "Default styles"
-msgstr ""
-
-#: ../src/preferences.cpp:85
-msgid "Default style catalogs"
-msgstr ""
-
-#: ../src/preferences.cpp:89
+#: ../src/command/edit.cpp:746
 msgid ""
-"The chosen style catalogs will be loaded when you start a new file or import "
-"files in the various formats.\n"
-"\n"
-"You can set up style catalogs in the Style Manager."
+"Split the current line into a line which ends on the previous frame and a "
+"line which starts on the current frame"
 msgstr ""
 
-#: ../src/preferences.cpp:114
-msgid "New files"
+#: ../src/command/edit.cpp:786
+msgid "As &Karaoke"
 msgstr ""
 
-#: ../src/preferences.cpp:115
-msgid "MicroDVD import"
+#: ../src/command/edit.cpp:787
+msgid "As Karaoke"
 msgstr ""
 
-#: ../src/preferences.cpp:116
-msgid "SRT import"
+#: ../src/command/edit.cpp:788
+msgid "Join selected lines in a single one, as karaoke"
 msgstr ""
 
-#: ../src/preferences.cpp:117
-msgid "TTXT import"
+#: ../src/command/edit.cpp:791
+msgid "join as karaoke"
 msgstr ""
 
-#: ../src/preferences.cpp:118
-msgid "Plain text import"
+#: ../src/command/edit.cpp:797
+msgid "&Concatenate"
 msgstr ""
 
-#: ../src/preferences.cpp:125 ../src/preferences.cpp:354
-msgid "Audio"
+#: ../src/command/edit.cpp:798
+msgid "Concatenate"
 msgstr ""
 
-#: ../src/preferences.cpp:128
-msgid "Default mouse wheel to zoom"
+#: ../src/command/edit.cpp:799
+msgid "Join selected lines in a single one, concatenating text together"
 msgstr ""
 
-#: ../src/preferences.cpp:129
-msgid "Lock scroll on cursor"
+#: ../src/command/edit.cpp:802 ../src/command/edit.cpp:813
+msgid "join lines"
 msgstr ""
 
-#: ../src/preferences.cpp:130
-msgid "Snap markers by default"
+#: ../src/command/edit.cpp:808
+msgid "Keep &First"
 msgstr ""
 
-#: ../src/preferences.cpp:131
-msgid "Auto-focus on mouse over"
+#: ../src/command/edit.cpp:809
+msgid "Keep First"
 msgstr ""
 
-#: ../src/preferences.cpp:132
-msgid "Play audio when stepping in video"
-msgstr ""
-
-#: ../src/preferences.cpp:133
-msgid "Left-click-drag moves end marker"
-msgstr ""
-
-#: ../src/preferences.cpp:134
-msgid "Default timing length (ms)"
-msgstr ""
-
-#: ../src/preferences.cpp:135
-msgid "Default lead-in length (ms)"
-msgstr ""
-
-#: ../src/preferences.cpp:136
-msgid "Default lead-out length (ms)"
-msgstr ""
-
-#: ../src/preferences.cpp:138
-msgid "Marker drag-start sensitivity (px)"
-msgstr ""
-
-#: ../src/preferences.cpp:139
-msgid "Line boundary thickness (px)"
-msgstr ""
-
-#: ../src/preferences.cpp:140
-msgid "Maximum snap distance (px)"
-msgstr ""
-
-#: ../src/preferences.cpp:142
-msgid "Don't show"
-msgstr ""
-
-#: ../src/preferences.cpp:142
-msgid "Show previous"
-msgstr ""
-
-#: ../src/preferences.cpp:142
-msgid "Show previous and next"
-msgstr ""
-
-#: ../src/preferences.cpp:142
-msgid "Show all"
-msgstr ""
-
-#: ../src/preferences.cpp:144
-msgid "Show inactive lines"
-msgstr ""
-
-#: ../src/preferences.cpp:146
-msgid "Include commented inactive lines"
-msgstr ""
-
-#: ../src/preferences.cpp:148
-msgid "Display Visual Options"
-msgstr ""
-
-#: ../src/preferences.cpp:149
-msgid "Keyframes in dialogue mode"
-msgstr ""
-
-#: ../src/preferences.cpp:150
-msgid "Keyframes in karaoke mode"
-msgstr ""
-
-#: ../src/preferences.cpp:151
-msgid "Cursor time"
-msgstr ""
-
-#: ../src/preferences.cpp:152
-msgid "Video position"
-msgstr ""
-
-#: ../src/preferences.cpp:153 ../src/preferences.cpp:246
-msgid "Seconds boundaries"
-msgstr ""
-
-#: ../src/preferences.cpp:155
-msgid "Waveform Style"
-msgstr ""
-
-#: ../src/preferences.cpp:157
-msgid "Audio labels"
-msgstr ""
-
-#: ../src/preferences.cpp:168
-msgid "Show keyframes in slider"
-msgstr ""
-
-#: ../src/preferences.cpp:170
-msgid "Only show visual tools when mouse is over video"
-msgstr ""
-
-#: ../src/preferences.cpp:172
-msgid "Seek video to line start on selection change"
-msgstr ""
-
-#: ../src/preferences.cpp:174
-msgid "Automatically open audio when opening video"
-msgstr ""
-
-#: ../src/preferences.cpp:179
-msgid "Default Zoom"
-msgstr ""
-
-#: ../src/preferences.cpp:181
-msgid "Fast jump step in frames"
-msgstr ""
-
-#: ../src/preferences.cpp:185
-msgid "Screenshot save path"
-msgstr ""
-
-#: ../src/preferences.cpp:187
-msgid "Script Resolution"
-msgstr ""
-
-#: ../src/preferences.cpp:188
-msgid "Use resolution of first video opened"
-msgstr ""
-
-#: ../src/preferences.cpp:191
-msgid "Default width"
-msgstr ""
-
-#: ../src/preferences.cpp:193
-msgid "Default height"
-msgstr ""
-
-#: ../src/preferences.cpp:195
-msgid "Always set"
-msgstr ""
-
-#: ../src/preferences.cpp:195
-msgid "Always resample"
-msgstr ""
-
-#: ../src/preferences.cpp:197
-msgid "Match video resolution on open"
-msgstr ""
-
-#: ../src/preferences.cpp:204
-msgid "Interface"
-msgstr ""
-
-#: ../src/preferences.cpp:206
-msgid "Edit Box"
-msgstr ""
-
-#: ../src/preferences.cpp:207
-msgid "Enable call tips"
-msgstr ""
-
-#: ../src/preferences.cpp:208
-msgid "Overwrite in time boxes"
-msgstr ""
-
-#: ../src/preferences.cpp:210
-msgid "Enable syntax highlighting"
-msgstr ""
-
-#: ../src/preferences.cpp:211
-msgid "Dictionaries path"
-msgstr ""
-
-#: ../src/preferences.cpp:214
-msgid "Character Counter"
-msgstr ""
-
-#: ../src/preferences.cpp:215
-msgid "Maximum characters per line"
-msgstr ""
-
-#: ../src/preferences.cpp:216
-msgid "Characters Per Second Warning Threshold"
-msgstr ""
-
-#: ../src/preferences.cpp:217
-msgid "Characters Per Second Error Threshold"
-msgstr ""
-
-#: ../src/preferences.cpp:218
-msgid "Ignore whitespace"
-msgstr ""
-
-#: ../src/preferences.cpp:219
-msgid "Ignore punctuation"
-msgstr ""
-
-#: ../src/preferences.cpp:221
-msgid "Grid"
-msgstr ""
-
-#: ../src/preferences.cpp:222
-msgid "Focus grid on click"
-msgstr ""
-
-#: ../src/preferences.cpp:223
-msgid "Highlight visible subtitles"
-msgstr ""
-
-#: ../src/preferences.cpp:224
-msgid "Hide overrides symbol"
-msgstr ""
-
-#: ../src/preferences.cpp:232 ../src/dialog_style_editor.cpp:179
-msgid "Colors"
-msgstr ""
-
-#: ../src/preferences.cpp:240
-msgid "Audio Display"
-msgstr ""
-
-#: ../src/preferences.cpp:241
-msgid "Play cursor"
-msgstr ""
-
-#: ../src/preferences.cpp:242
-msgid "Line boundary start"
-msgstr ""
-
-#: ../src/preferences.cpp:243
-msgid "Line boundary end"
-msgstr ""
-
-#: ../src/preferences.cpp:244
-msgid "Line boundary inactive line"
-msgstr ""
-
-#: ../src/preferences.cpp:245
-msgid "Syllable boundaries"
-msgstr ""
-
-#: ../src/preferences.cpp:248
-msgid "Syntax Highlighting"
-msgstr ""
-
-#: ../src/preferences.cpp:249
-msgid "Background"
-msgstr ""
-
-#: ../src/preferences.cpp:250 ../src/preferences.cpp:326
-msgid "Normal"
-msgstr ""
-
-#: ../src/preferences.cpp:251
-msgid "Comments"
-msgstr ""
-
-#: ../src/preferences.cpp:252
-msgid "Drawings"
-msgstr ""
-
-#: ../src/preferences.cpp:253
-msgid "Brackets"
-msgstr ""
-
-#: ../src/preferences.cpp:254
-msgid "Slashes and Parentheses"
-msgstr ""
-
-#: ../src/preferences.cpp:255
-msgid "Tags"
-msgstr ""
-
-#: ../src/preferences.cpp:256
-msgid "Parameters"
-msgstr ""
-
-#: ../src/preferences.cpp:258
-msgid "Error Background"
-msgstr ""
-
-#: ../src/preferences.cpp:259
-msgid "Line Break"
-msgstr ""
-
-#: ../src/preferences.cpp:260
-msgid "Karaoke templates"
-msgstr ""
-
-#: ../src/preferences.cpp:261
-msgid "Karaoke variables"
-msgstr ""
-
-#: ../src/preferences.cpp:267
-msgid "Audio Color Schemes"
-msgstr ""
-
-#: ../src/preferences.cpp:269 ../src/preferences.cpp:370
-msgid "Spectrum"
-msgstr ""
-
-#: ../src/preferences.cpp:270
-msgid "Waveform"
-msgstr ""
-
-#: ../src/preferences.cpp:272
-msgid "Subtitle Grid"
-msgstr ""
-
-#: ../src/preferences.cpp:273
-msgid "Standard foreground"
-msgstr ""
-
-#: ../src/preferences.cpp:274
-msgid "Standard background"
-msgstr ""
-
-#: ../src/preferences.cpp:275
-msgid "Selection foreground"
-msgstr ""
-
-#: ../src/preferences.cpp:276
-msgid "Selection background"
-msgstr ""
-
-#: ../src/preferences.cpp:277
-msgid "Collision foreground"
-msgstr ""
-
-#: ../src/preferences.cpp:278
-msgid "In frame background"
-msgstr ""
-
-#: ../src/preferences.cpp:279
-msgid "Comment background"
-msgstr ""
-
-#: ../src/preferences.cpp:280
-msgid "Selected comment background"
-msgstr ""
-
-#: ../src/preferences.cpp:281
-msgid "Header background"
-msgstr ""
-
-#: ../src/preferences.cpp:282
-msgid "Left Column"
-msgstr ""
-
-#: ../src/preferences.cpp:283
-msgid "Active Line Border"
-msgstr ""
-
-#: ../src/preferences.cpp:284
-msgid "Lines"
-msgstr ""
-
-#: ../src/preferences.cpp:285
-msgid "CPS Error"
-msgstr ""
-
-#: ../src/preferences.cpp:294
-msgid "Backup"
-msgstr ""
-
-#: ../src/preferences.cpp:296
-msgid "Automatic Save"
-msgstr ""
-
-#: ../src/preferences.cpp:297 ../src/preferences.cpp:305
-msgid "Enable"
-msgstr ""
-
-#: ../src/preferences.cpp:300
-msgid "Interval in seconds"
-msgstr ""
-
-#: ../src/preferences.cpp:301 ../src/preferences.cpp:307
-#: ../src/preferences.cpp:368
-msgid "Path"
-msgstr ""
-
-#: ../src/preferences.cpp:302
-msgid "Autosave after every change"
-msgstr ""
-
-#: ../src/preferences.cpp:304
-msgid "Automatic Backup"
-msgstr ""
-
-#: ../src/preferences.cpp:318
-msgid "Base path"
-msgstr ""
-
-#: ../src/preferences.cpp:319
-msgid "Include path"
-msgstr ""
-
-#: ../src/preferences.cpp:320
-msgid "Auto-load path"
-msgstr ""
-
-#: ../src/preferences.cpp:322
-msgid "0: Fatal"
-msgstr ""
-
-#: ../src/preferences.cpp:322
-msgid "1: Error"
-msgstr ""
-
-#: ../src/preferences.cpp:322
-msgid "2: Warning"
-msgstr ""
-
-#: ../src/preferences.cpp:322
-msgid "3: Hint"
-msgstr ""
-
-#: ../src/preferences.cpp:322
-msgid "4: Debug"
-msgstr ""
-
-#: ../src/preferences.cpp:322
-msgid "5: Trace"
-msgstr ""
-
-#: ../src/preferences.cpp:324
-msgid "Trace level"
-msgstr ""
-
-#: ../src/preferences.cpp:326
-msgid "Below Normal (recommended)"
-msgstr ""
-
-#: ../src/preferences.cpp:326
-msgid "Lowest"
-msgstr ""
-
-#: ../src/preferences.cpp:328
-msgid "Thread priority"
-msgstr ""
-
-#: ../src/preferences.cpp:330
-msgid "No scripts"
-msgstr ""
-
-#: ../src/preferences.cpp:330
-msgid "Subtitle-local scripts"
-msgstr ""
-
-#: ../src/preferences.cpp:330
-msgid "Global autoload scripts"
-msgstr ""
-
-#: ../src/preferences.cpp:330
-msgid "All scripts"
-msgstr ""
-
-#: ../src/preferences.cpp:332
-msgid "Autoreload on Export"
-msgstr ""
-
-#: ../src/preferences.cpp:339
-msgid "Advanced"
-msgstr ""
-
-#: ../src/preferences.cpp:343
+#: ../src/command/edit.cpp:810
 msgid ""
-"Changing these settings might result in bugs and/or crashes.  Do not touch "
-"these unless you know what you're doing."
+"Join selected lines in a single one, keeping text of first and discarding "
+"remaining"
 msgstr ""
 
-#: ../src/preferences.cpp:356 ../src/preferences.cpp:419
-msgid "Expert"
+#: ../src/command/edit.cpp:851
+msgid "&Paste Lines"
 msgstr ""
 
-#: ../src/preferences.cpp:359
-msgid "Audio provider"
+#: ../src/command/edit.cpp:852
+msgid "Paste Lines"
 msgstr ""
 
-#: ../src/preferences.cpp:362
-msgid "Audio player"
+#: ../src/command/edit.cpp:853
+msgid "Paste subtitles"
 msgstr ""
 
-#: ../src/preferences.cpp:364
-msgid "Cache"
+#: ../src/command/edit.cpp:882
+msgid "Paste Lines &Over..."
 msgstr ""
 
-#: ../src/preferences.cpp:365
-msgid "None (NOT RECOMMENDED)"
+#: ../src/command/edit.cpp:883
+msgid "Paste Lines Over"
 msgstr ""
 
-#: ../src/preferences.cpp:365
-msgid "RAM"
+#: ../src/command/edit.cpp:884
+msgid "Paste subtitles over others"
 msgstr ""
 
-#: ../src/preferences.cpp:365
-msgid "Hard Disk"
+#: ../src/command/edit.cpp:967
+msgid "Recom&bine Lines"
 msgstr ""
 
-#: ../src/preferences.cpp:367
-msgid "Cache type"
+#: ../src/command/edit.cpp:968
+msgid "Recombine Lines"
 msgstr ""
 
-#: ../src/preferences.cpp:372
-msgid "Regular quality"
+#: ../src/command/edit.cpp:969
+msgid "Recombine subtitles which have been split and merged"
 msgstr ""
 
-#: ../src/preferences.cpp:372
-msgid "Better quality"
+#: ../src/command/edit.cpp:1039
+msgid "combining"
 msgstr ""
 
-#: ../src/preferences.cpp:372
-msgid "High quality"
+#: ../src/command/edit.cpp:1045 ../src/command/edit.cpp:1046
+msgid "Split Lines (by karaoke)"
 msgstr ""
 
-#: ../src/preferences.cpp:372
-msgid "Insane quality"
+#: ../src/command/edit.cpp:1047
+msgid "Use karaoke timing to split line into multiple smaller lines"
 msgstr ""
 
-#: ../src/preferences.cpp:374
-msgid "Quality"
+#: ../src/command/edit.cpp:1081
+msgid "splitting"
 msgstr ""
 
-#: ../src/preferences.cpp:376
-msgid "Cache memory max (MB)"
+#: ../src/command/edit.cpp:1113 ../src/command/edit.cpp:1114
+#: ../src/subs_edit_ctrl.cpp:397
+msgid "Split at cursor (estimate times)"
 msgstr ""
 
-#: ../src/preferences.cpp:382
-msgid "Avisynth down-mixer"
-msgstr ""
-
-#: ../src/preferences.cpp:383
-msgid "Force sample rate"
-msgstr ""
-
-#: ../src/preferences.cpp:389
-msgid "Ignore"
-msgstr ""
-
-#: ../src/preferences.cpp:389
-msgid "Stop"
-msgstr ""
-
-#: ../src/preferences.cpp:389
-msgid "Abort"
-msgstr ""
-
-#: ../src/preferences.cpp:391
-msgid "Audio indexing error handling mode"
-msgstr ""
-
-#: ../src/preferences.cpp:393
-msgid "Always index all audio tracks"
-msgstr ""
-
-#: ../src/preferences.cpp:398
-msgid "Portaudio device"
-msgstr ""
-
-#: ../src/preferences.cpp:403
-msgid "OSS Device"
-msgstr ""
-
-#: ../src/preferences.cpp:408
-msgid "Buffer latency"
-msgstr ""
-
-#: ../src/preferences.cpp:409
-msgid "Buffer length"
-msgstr ""
-
-#: ../src/preferences.cpp:422
-msgid "Video provider"
-msgstr ""
-
-#: ../src/preferences.cpp:425
-msgid "Subtitles provider"
-msgstr ""
-
-#: ../src/preferences.cpp:428
-msgid "Force BT.601"
-msgstr ""
-
-#: ../src/preferences.cpp:432
-msgid "Allow pre-2.56a Avisynth"
-msgstr ""
-
-#: ../src/preferences.cpp:434
-msgid "Avisynth memory limit"
-msgstr ""
-
-#: ../src/preferences.cpp:442
-msgid "Debug log verbosity"
-msgstr ""
-
-#: ../src/preferences.cpp:444
-msgid "Decoding threads"
-msgstr ""
-
-#: ../src/preferences.cpp:445
-msgid "Enable unsafe seeking"
-msgstr ""
-
-#: ../src/preferences.cpp:574
-msgid "Hotkeys"
-msgstr ""
-
-#: ../src/preferences.cpp:672
+#: ../src/command/edit.cpp:1115
 msgid ""
-"Are you sure that you want to restore the defaults? All your settings will "
-"be overridden."
+"Split the current line at the cursor, dividing the original line's duration "
+"between the new ones"
 msgstr ""
 
-#: ../src/preferences.cpp:672
-msgid "Restore defaults?"
+#: ../src/command/edit.cpp:1129 ../src/command/edit.cpp:1130
+#: ../src/subs_edit_ctrl.cpp:396
+msgid "Split at cursor (preserve times)"
 msgstr ""
 
-#: ../src/preferences.cpp:690
-msgid "Preferences"
+#: ../src/command/edit.cpp:1131
+msgid ""
+"Split the current line at the cursor, setting both lines to the original "
+"line's times"
 msgstr ""
 
-#: ../src/preferences.cpp:718
-msgid "&Restore Defaults"
+#: ../src/command/edit.cpp:1140 ../src/command/edit.cpp:1141
+msgid "Split at cursor (at video frame)"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:356
-msgid "Spell checker language"
+#: ../src/command/edit.cpp:1142
+msgid ""
+"Split the current line at the cursor, dividing the line's duration at the "
+"current video frame"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:365
-msgid "Cu&t"
+#: ../src/command/edit.cpp:1158
+msgid "Redo last undone action"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:402
+#: ../src/command/edit.cpp:1163
+msgid "Nothing to &redo"
+msgstr ""
+
+#: ../src/command/edit.cpp:1164
 #, c-format
-msgid "Remove \"%s\" from dictionary"
+msgid "&Redo %s"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:407
-msgid "No spell checker suggestions"
+#: ../src/command/edit.cpp:1168
+msgid "Nothing to redo"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:413
+#: ../src/command/edit.cpp:1169
 #, c-format
-msgid "Spell checker suggestions for \"%s\""
+msgid "Redo %s"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:418
-msgid "No correction suggestions"
+#: ../src/command/edit.cpp:1184
+msgid "Undo last action"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:424
+#: ../src/command/edit.cpp:1189
+msgid "Nothing to &undo"
+msgstr ""
+
+#: ../src/command/edit.cpp:1190
 #, c-format
-msgid "Add \"%s\" to dictionary"
+msgid "&Undo %s"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:459
+#: ../src/command/edit.cpp:1194
+msgid "Nothing to undo"
+msgstr ""
+
+#: ../src/command/edit.cpp:1195
 #, c-format
-msgid "Thesaurus suggestions for \"%s\""
+msgid "Undo %s"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:462
-msgid "No thesaurus suggestions"
+#: ../src/command/edit.cpp:1209 ../src/command/edit.cpp:1210
+msgid "Revert"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:465
-msgid "Thesaurus language"
+#: ../src/command/edit.cpp:1211
+msgid "Revert the active line to its initial state (shown in the upper editor)"
 msgstr ""
 
-#: ../src/subs_edit_ctrl.cpp:474
-msgid "Disable"
+#: ../src/command/edit.cpp:1216
+msgid "revert line"
 msgstr ""
 
-#: ../src/menu.cpp:94
-msgid "Empty"
+#: ../src/command/edit.cpp:1224
+msgid "Clear the current line's text"
 msgstr ""
 
-#: ../src/menu.cpp:227
-msgid "&Recent"
+#: ../src/command/edit.cpp:1229 ../src/command/edit.cpp:1248
+msgid "clear line"
 msgstr ""
 
-#: ../src/menu.cpp:410
-msgid "No Automation macros loaded"
+#: ../src/command/edit.cpp:1236 ../src/command/edit.cpp:1237
+msgid "Clear Text"
+msgstr ""
+
+#: ../src/command/edit.cpp:1238
+msgid "Clear the current line's text, leaving override tags"
+msgstr ""
+
+#: ../src/command/edit.cpp:1256
+msgid "Insert the original line text at the cursor"
+msgstr ""
+
+#: ../src/command/edit.cpp:1264
+msgid "insert original"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:80
+msgid "A&ttachments..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:81
+msgid "Attachments"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:82
+msgid "Open the attachment manager dialog"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:93
+msgid "&Find..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:95
+msgid "Search for text in the subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:106
+msgid "Find &Next"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:107
+msgid "Find Next"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:108
+msgid "Find next match of last search"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:135
+msgid "&After Current"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:136
+msgid "After Current"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:137
+msgid "Insert a new line after the current one"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:169 ../src/command/subtitle.cpp:170
+msgid "After Current, at Video Time"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:171
+msgid "Insert a new line after the current one, starting at video time"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:180
+msgid "&Before Current"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:181
+msgid "Before Current"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:182
+msgid "Insert a new line before the current one"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:211 ../src/command/subtitle.cpp:212
+msgid "Before Current, at Video Time"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:213
+msgid "Insert a new line before the current one, starting at video time"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:239
+msgid "&New Subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:240
+msgid "New Subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:241
+msgid "New subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:268
+msgid "&Open Subtitles..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:269
+msgid "Open Subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:270
+msgid "Open a subtitles file"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:283
+msgid "Open A&utosaved Subtitles..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:284
+msgid "Open Autosaved Subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:285
+msgid "Open a previous version of a file which was autosaved by Aegisub"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:298
+msgid "Open Subtitles with &Charset..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:299
+msgid "Open Subtitles with Charset"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:300
+msgid "Open a subtitles file with a specific file encoding"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:308
+msgid "Choose charset code:"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:308
+msgid "Charset"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:317
+msgid "Open Subtitles from &Video"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:318
+msgid "Open Subtitles from Video"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:319
+msgid "Open the subtitles from the current video file"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:335
+msgid "&Properties..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:336
+msgid "Properties"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:337
+msgid "Open script properties window"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:348
+msgid "Save subtitles file"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:368
+msgid "&Save Subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:369
+msgid "Save Subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:370
+msgid "Save the current subtitles"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:385
+msgid "Save Subtitles &as..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:386
+msgid "Save Subtitles as"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:387
+msgid "Save subtitles with another name"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:397
+msgid "Select All"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:398
+msgid "Select all dialogue lines"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:410 ../src/command/subtitle.cpp:411
+msgid "Select Visible"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:412
+msgid "Select all dialogue lines that are visible on the current video frame"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:442
+msgid "Spell &Checker..."
+msgstr ""
+
+#: ../src/command/subtitle.cpp:443 ../src/dialog_spellchecker.cpp:103
+msgid "Spell Checker"
+msgstr ""
+
+#: ../src/command/subtitle.cpp:444
+msgid "Open spell checker"
+msgstr ""
+
+#: ../src/timeedit_ctrl.cpp:209 ../src/subs_edit_ctrl.cpp:389
+msgid "&Paste"
+msgstr ""
+
+#: ../src/font_file_lister_fontconfig.cpp:56
+#: ../src/font_file_lister_gdi.cpp:139
+msgid "Updating font cache\n"
+msgstr ""
+
+#: ../src/dialog_video_details.cpp:45
+msgid "Video Details"
+msgstr ""
+
+#: ../src/dialog_video_details.cpp:59
+msgid "File name:"
+msgstr ""
+
+#: ../src/dialog_video_details.cpp:60
+msgid "FPS:"
+msgstr ""
+
+#: ../src/dialog_video_details.cpp:61
+msgid "Resolution:"
+msgstr ""
+
+#: ../src/dialog_video_details.cpp:62
+msgid "Length:"
+msgstr ""
+
+#: ../src/dialog_video_details.cpp:62
+#, c-format
+msgid "1 frame"
+msgid_plural "%d frames (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/dialog_video_details.cpp:64
+msgid "Decoder:"
+msgstr ""
+
+#: ../src/dialog_progress.cpp:197
+msgid "Cancel"
+msgstr ""
+
+#: ../src/dialog_progress.cpp:245
+msgid "Cancelling..."
 msgstr ""
 
 #: ../src/dialog_about.cpp:46
 msgid "Translated into LANGUAGE by PERSON\n"
 msgstr ""
 
-#: ../src/dialog_about.cpp:122
+#: ../src/dialog_about.cpp:124
 msgid ""
 "\n"
 "See the help file for full credits.\n"
 msgstr ""
 
-#: ../src/dialog_about.cpp:123
+#: ../src/dialog_about.cpp:126
 #, c-format
 msgid "Built by %s on %s."
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:57
-msgid "Source: "
+#: ../src/audio_renderer_waveform.cpp:155
+msgid "Maximum"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:58
-msgid "Dest: "
+#: ../src/audio_renderer_waveform.cpp:156
+msgid "Maximum + Average"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:470
-msgid "Kanji timing"
+#: ../src/audio_timing_karaoke.cpp:241
+msgid "karaoke timing"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:475 ../src/dialog_paste_over.cpp:73
-#: ../src/grid_column.cpp:334 ../src/grid_column.cpp:335
-msgid "Text"
+#: ../src/ass_style.cpp:195
+msgid "ANSI"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:476
-msgid "Styles"
+#: ../src/ass_style.cpp:197
+msgid "Symbol"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:478
-msgid "Shortcut Keys"
+#: ../src/ass_style.cpp:198
+msgid "Mac"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:479
-msgid "Commands"
+#: ../src/ass_style.cpp:199
+msgid "Shift_JIS"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:487
-msgid "Attempt to &interpolate kanji."
+#: ../src/ass_style.cpp:200
+msgid "Hangeul"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:494
-msgid ""
-"When the destination textbox has focus, use the following keys:\n"
-"\n"
-"Right Arrow: Increase dest. selection length\n"
-"Left Arrow: Decrease dest. selection length\n"
-"Up Arrow: Increase source selection length\n"
-"Down Arrow: Decrease source selection length\n"
-"Enter: Link, accept line when done\n"
-"Backspace: Unlink last"
+#: ../src/ass_style.cpp:201
+msgid "Johab"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:497
-msgid "S&tart!"
+#: ../src/ass_style.cpp:202
+msgid "GB2312"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:498
-msgid "&Link"
+#: ../src/ass_style.cpp:203
+msgid "Chinese BIG5"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:499
-msgid "&Unlink"
+#: ../src/ass_style.cpp:204
+msgid "Greek"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:500
-msgid "Skip &Source Line"
+#: ../src/ass_style.cpp:205
+msgid "Turkish"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:501
-msgid "Skip &Dest Line"
+#: ../src/ass_style.cpp:206
+msgid "Vietnamese"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:502
-msgid "&Go Back a Line"
+#: ../src/ass_style.cpp:207
+msgid "Hebrew"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:503
-msgid "&Accept Line"
+#: ../src/ass_style.cpp:208
+msgid "Arabic"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:504 ../src/dialog_automation.cpp:122
-#: ../src/dialog_attachments.cpp:89 ../src/dialog_version_check.cpp:126
-msgid "&Close"
+#: ../src/ass_style.cpp:209
+msgid "Baltic"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:566
-msgid "kanji timing"
+#: ../src/ass_style.cpp:210
+msgid "Russian"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:574
-msgid "Select source and destination styles first."
+#: ../src/ass_style.cpp:211
+msgid "Thai"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:576
-msgid "The source and destination styles must be different."
+#: ../src/ass_style.cpp:212
+msgid "East European"
 msgstr ""
 
-#: ../src/dialog_kara_timing_copy.cpp:626
-msgid "Group all of the source text."
+#: ../src/ass_style.cpp:213
+msgid "OEM"
 msgstr ""
 
-#: ../src/hotkey.cpp:175
-msgid "Invalid command name for hotkey"
+#: ../src/subs_edit_ctrl.cpp:377
+msgid "Spell checker language"
 msgstr ""
 
-#: ../src/dialog_paste_over.cpp:55
-msgid "Select Fields to Paste Over"
+#: ../src/subs_edit_ctrl.cpp:387
+msgid "Cu&t"
 msgstr ""
 
-#: ../src/dialog_paste_over.cpp:58
-msgid "Fields"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:59
-msgid "Please select the fields that you want to paste over:"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:63
-msgid "Comment"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:67 ../src/grid_column.cpp:177
-#: ../src/grid_column.cpp:178
-msgid "Style"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:68 ../src/subs_edit_box.cpp:140
-#: ../src/grid_column.cpp:205 ../src/grid_column.cpp:206
-msgid "Actor"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:69
-msgid "Margin Left"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:70
-msgid "Margin Right"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:71
-msgid "Margin Vertical"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:92
-msgid "&Times"
-msgstr ""
-
-#: ../src/dialog_paste_over.cpp:94
-msgid "T&ext"
-msgstr ""
-
-#: ../src/main.cpp:274
+#: ../src/subs_edit_ctrl.cpp:424
 #, c-format
-msgid ""
-"Oops, Aegisub has crashed!\n"
-"\n"
-"An attempt has been made to save a copy of your file to:\n"
-"\n"
-"%s\n"
-"\n"
-"Aegisub will now close."
+msgid "Remove \"%s\" from dictionary"
 msgstr ""
 
-#: ../src/main.cpp:302
-msgid ""
-"Do you want Aegisub to check for updates whenever it starts? You can still "
-"do it manually via the Help menu."
+#: ../src/subs_edit_ctrl.cpp:429
+msgid "No spell checker suggestions"
 msgstr ""
 
-#: ../src/main.cpp:302
-msgid "Check for updates?"
-msgstr ""
-
-#: ../src/main.cpp:387 ../src/main.cpp:392
-msgid "Program error"
-msgstr ""
-
-#: ../src/main.cpp:406
+#: ../src/subs_edit_ctrl.cpp:435
 #, c-format
-msgid ""
-"An unexpected error has occurred. Please save your work and restart "
-"Aegisub.\n"
-"\n"
-"Error Message: %s"
+msgid "Spell checker suggestions for \"%s\""
 msgstr ""
 
-#: ../src/subs_edit_box.cpp:119
-msgid "&Comment"
+#: ../src/subs_edit_ctrl.cpp:440
+msgid "No correction suggestions"
 msgstr ""
 
-#: ../src/subs_edit_box.cpp:120
-msgid "Comment this line out. Commented lines don't show up on screen."
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:127
-msgid "Style for this line"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:129 ../src/subs_edit_box.cpp:130
-msgid "Edit"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:140
-msgid ""
-"Actor name for this speech. This is only for reference, and is mainly "
-"useless."
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:145
-msgid ""
-"Effect for this line. This can be used to store extra information for "
-"karaoke scripts, or for the effects supported by the renderer."
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:151
-msgid "Number of characters in the longest line of this subtitle."
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:158
-msgid "Layer number"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:162
-msgid "Start time"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:163
-msgid "End time"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:165
-msgid "Line duration"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:168
-msgid "Left Margin (0 = default from style)"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:168
-msgid "left margin change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:169
-msgid "Right Margin (0 = default from style)"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:169
-msgid "right margin change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:170
-msgid "Vertical Margin (0 = default from style)"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:170
-msgid "vertical margin change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:189
-msgid "T&ime"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:189
-msgid "Time by h:mm:ss.cs"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:190
-msgid "F&rame"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:190
-msgid "Time by frame number"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:193
-msgid "Show Original"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:194
-msgid ""
-"Show the contents of the subtitle line when it was first selected above the "
-"edit box. This is sometimes useful when editing subtitles or translating "
-"subtitles into another language."
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:441
-msgid "modify text"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:516
-msgid "modify times"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:590 ../src/dialog_style_editor.cpp:453
-msgid "style change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:596
-msgid "actor change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:601
-msgid "layer change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:606
-msgid "effect change"
-msgstr ""
-
-#: ../src/subs_edit_box.cpp:611
-msgid "comment change"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:106
-msgid "Select"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:117
-msgid "Match"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:121
-msgid "&Matches"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:122
-msgid "&Doesn't Match"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:123
-msgid "Match c&ase"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:132
-msgid "&Exact match"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:132
-msgid "&Contains"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:132
-msgid "&Regular Expression match"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:133
-msgid "Mode"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:137 ../src/dialog_search_replace.cpp:87
-msgid "&Text"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:137
-msgid "&Style"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:137
-msgid "Act&or"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:137
-msgid "E&ffect"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:138 ../src/dialog_search_replace.cpp:90
-msgid "In Field"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:142
-msgid "Match dialogues/comments"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:143
-msgid "D&ialogues"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:144
-msgid "Comme&nts"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:149
-msgid "Set se&lection"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:149
-msgid "&Add to selection"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:149
-msgid "S&ubtract from selection"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:149
-msgid "Intersect &with selection"
-msgstr ""
-
-#: ../src/dialog_selection.cpp:211
+#: ../src/subs_edit_ctrl.cpp:446
 #, c-format
-msgid "Selection was set to one line"
-msgid_plural "Selection was set to %u lines"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../src/dialog_selection.cpp:212
-msgid "Selection was set to no lines"
+msgid "Add \"%s\" to dictionary"
 msgstr ""
 
-#: ../src/dialog_selection.cpp:218
+#: ../src/subs_edit_ctrl.cpp:481
 #, c-format
-msgid "One line was added to selection"
-msgid_plural "%u lines were added to selection"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../src/dialog_selection.cpp:219
-msgid "No lines were added to selection"
+msgid "Thesaurus suggestions for \"%s\""
 msgstr ""
 
-#: ../src/dialog_selection.cpp:230
+#: ../src/subs_edit_ctrl.cpp:484
+msgid "No thesaurus suggestions"
+msgstr ""
+
+#: ../src/subs_edit_ctrl.cpp:487
+msgid "Thesaurus language"
+msgstr ""
+
+#: ../src/subs_edit_ctrl.cpp:496
+msgid "Disable"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:58
+msgid "Drag control points"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:59
+msgid "Line"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:59
+msgid "Appends a line"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:60
+msgid "Bicubic"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:60
+msgid "Appends a bezier bicubic curve"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:62
+msgid "Convert"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:62
+msgid "Converts a segment between line and bicubic"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:63
+msgid "Insert"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:63
+msgid "Inserts a control point"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:64
+msgid "Remove"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:64
+msgid "Removes a control point"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:66
+msgid "Freehand"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:66
+msgid "Draws a freehand shape"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:67
+msgid "Freehand smooth"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:67
+msgid "Draws a smoothed freehand shape"
+msgstr ""
+
+#: ../src/visual_tool_vector_clip.cpp:272
+msgid "delete control point"
+msgstr ""
+
+#: ../src/dialog_autosave.cpp:66
+msgid "Open autosave file"
+msgstr ""
+
+#: ../src/dialog_autosave.cpp:75
+msgid "Versions"
+msgstr ""
+
+#: ../src/dialog_autosave.cpp:85
+msgid "Open"
+msgstr ""
+
+#: ../src/dialog_autosave.cpp:94
 #, c-format
-msgid "One line was removed from selection"
-msgid_plural "%u lines were removed from selection"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../src/dialog_selection.cpp:231
-msgid "No lines were removed from selection"
+msgid "%s [ORIGINAL BACKUP]"
 msgstr ""
 
-#: ../src/dialog_selection.cpp:236
-msgid "Selection"
+#: ../src/dialog_autosave.cpp:95
+#, c-format
+msgid "%s [RECOVERED]"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:72
+#: ../src/dialog_properties.cpp:89
+msgid "Script Properties"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:103
+msgid "Script"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:106
+msgid "Title:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:107
+msgid "Original script:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:108
+msgid "Translation:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:109
+msgid "Editing:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:110
+msgid "Timing:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:111
+msgid "Synch point:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:112
+msgid "Updated by:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:113
+msgid "Update details:"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:122 ../src/export_framerate.cpp:70
+#: ../src/dialog_resample.cpp:141
+msgid "From &video"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:141
+msgid "Resolution"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:149
+msgid "0: Smart wrapping, top line is wider"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:150
+msgid "1: End-of-line word wrapping, only \\N breaks"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:151
+msgid "2: No word wrapping, both \\n and \\N break"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:152
+msgid "3: Smart wrapping, bottom line is wider"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:156
+msgid "Wrap Style: "
+msgstr ""
+
+#: ../src/dialog_properties.cpp:159
+msgid "Scale Border and Shadow"
+msgstr ""
+
+#: ../src/dialog_properties.cpp:160
+msgid ""
+"Scale border and shadow together with script/render resolution. If this is "
+"unchecked, relative border and shadow size will depend on renderer."
+msgstr ""
+
+#: ../src/dialog_properties.cpp:196
+msgid "property changes"
+msgstr ""
+
+#: ../src/audio_box.cpp:73
+msgid "Horizontal zoom"
+msgstr ""
+
+#: ../src/audio_box.cpp:74
+msgid "Vertical zoom"
+msgstr ""
+
+#: ../src/audio_box.cpp:75
+msgid "Audio Volume"
+msgstr ""
+
+#: ../src/font_file_lister.cpp:67
 #, c-format
 msgid "Style '%s' does not exist\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:138
+#: ../src/font_file_lister.cpp:154
 #, c-format
 msgid "Could not find font '%s'\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:145
+#: ../src/font_file_lister.cpp:162
 #, c-format
 msgid "Found '%s' at '%s'\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:149
+#: ../src/font_file_lister.cpp:168
 #, c-format
 msgid "'%s' does not have a bold variant.\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:151
+#: ../src/font_file_lister.cpp:170
 #, c-format
 msgid "'%s' does not have an italic variant.\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:155
+#: ../src/font_file_lister.cpp:174
 #, c-format
 msgid "'%s' is missing %d glyphs used.\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:157
+#: ../src/font_file_lister.cpp:176
 #, c-format
 msgid "'%s' is missing the following glyphs used: %s\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:168
+#: ../src/font_file_lister.cpp:187
 msgid "Used in styles:\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:174
+#: ../src/font_file_lister.cpp:193
 msgid "Used on lines:"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:186
+#: ../src/font_file_lister.cpp:205
 msgid "Parsing file\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:200
+#: ../src/font_file_lister.cpp:219
 msgid "Searching for font files\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:202
+#: ../src/font_file_lister.cpp:221
 msgid ""
 "Done\n"
 "\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:209
+#: ../src/font_file_lister.cpp:228
 msgid "All fonts found.\n"
 msgstr ""
 
-#: ../src/font_file_lister.cpp:211
+#: ../src/font_file_lister.cpp:230
 #, c-format
 msgid "One font could not be found\n"
 msgid_plural "%d fonts could not be found.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/font_file_lister.cpp:214
+#: ../src/font_file_lister.cpp:233
 #, c-format
 msgid "One font was found, but was missing glyphs used in the script.\n"
 msgid_plural ""
 "%d fonts were found, but were missing glyphs used in the script.\n"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ../src/resolution_resampler.cpp:289
+msgid "resolution resampling"
+msgstr ""
+
+#: ../src/visual_tool.cpp:122
+msgid "visual typesetting"
+msgstr ""
 
 #: ../src/export_framerate.cpp:52
 msgid "Transform Framerate"
@@ -4802,617 +4811,551 @@ msgstr ""
 msgid "Output: "
 msgstr ""
 
-#: ../src/audio_display.cpp:677
-#, c-format
-msgid "%d%%, %d pixel/second"
+#: ../src/dialog_spellchecker.cpp:125
+msgid "Misspelled word:"
 msgstr ""
 
-#: ../src/dialog_progress.cpp:197
-msgid "Cancel"
+#: ../src/dialog_spellchecker.cpp:183
+msgid "Ignore &UPPERCASE words"
 msgstr ""
 
-#: ../src/dialog_progress.cpp:245
-msgid "Cancelling..."
+#: ../src/dialog_spellchecker.cpp:187
+msgid "&Replace"
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:57
-msgid "Drag control points"
+#: ../src/dialog_spellchecker.cpp:197
+msgid "&Ignore"
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:58
-msgid "Line"
+#: ../src/dialog_spellchecker.cpp:200
+msgid "Ignore a&ll"
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:58
-msgid "Appends a line"
+#: ../src/dialog_spellchecker.cpp:206
+msgid "Add to &dictionary"
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:59
-msgid "Bicubic"
+#: ../src/dialog_spellchecker.cpp:212
+msgid "Remove fro&m dictionary"
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:59
-msgid "Appends a bezier bicubic curve"
+#: ../src/dialog_spellchecker.cpp:279
+msgid "Aegisub has finished checking spelling of this script."
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:61
-msgid "Convert"
+#: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
+msgid "Spell checking complete."
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:61
-msgid "Converts a segment between line and bicubic"
+#: ../src/dialog_spellchecker.cpp:283
+msgid "Aegisub has found no spelling mistakes in this script."
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:62
-msgid "Insert"
+#: ../src/dialog_spellchecker.cpp:329 ../src/dialog_spellchecker.cpp:343
+msgid "spell check replace"
 msgstr ""
 
-#: ../src/visual_tool_vector_clip.cpp:62
-msgid "Inserts a control point"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:63
-msgid "Remove"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:63
-msgid "Removes a control point"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:65
-msgid "Freehand"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:65
-msgid "Draws a freehand shape"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:66
-msgid "Freehand smooth"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:66
-msgid "Draws a smoothed freehand shape"
-msgstr ""
-
-#: ../src/visual_tool_vector_clip.cpp:265
-msgid "delete control point"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:106
-msgid "Automation Manager"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:117
-msgid "&Add"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:118
-msgid "&Remove"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:119
-msgid "Re&load"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:120
-msgid "Show &Info"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:121
-msgid "Re&scan Autoload Dir"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:134
-msgid "Name"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:135
-msgid "Filename"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:136
-msgid "Description"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:222
-msgid "Add Automation script"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:277
-#, c-format
-msgid ""
-"Total scripts loaded: %d\n"
-"Global scripts loaded: %d\n"
-"Local scripts loaded: %d\n"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:282
-msgid "Scripting engines installed:"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:295
-msgid "Correctly loaded"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:295
-msgid "Failed to load"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:289
-#, c-format
-msgid ""
-"\n"
-"Script info:\n"
-"Name: %s\n"
-"Description: %s\n"
-"Author: %s\n"
-"Version: %s\n"
-"Full path: %s\n"
-"State: %s\n"
-"\n"
-"Features provided by script:"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:298
-#, c-format
-msgid "    Macro: %s (%s)"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:301
-#, c-format
-msgid "    Export filter: %s"
-msgstr ""
-
-#: ../src/dialog_automation.cpp:305
-msgid "Automation Script Info"
-msgstr ""
-
-#: ../src/dialog_export.cpp:102
-msgid "Export"
-msgstr ""
-
-#: ../src/dialog_export.cpp:123
-msgid "Move &Up"
-msgstr ""
-
-#: ../src/dialog_export.cpp:124
-msgid "Move &Down"
-msgstr ""
-
-#: ../src/dialog_export.cpp:142
-msgid "Text encoding:"
-msgstr ""
-
-#: ../src/dialog_export.cpp:150
-msgid "Filters"
-msgstr ""
-
-#: ../src/dialog_export.cpp:157
-msgid "Export..."
-msgstr ""
-
-#: ../src/dialog_export.cpp:189
-msgid "Export subtitles file"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:46
-msgid "Replace"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:67
-msgid "Find what:"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:78
-msgid "&Match case"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:79
-msgid "&Use regular expressions"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:81
-msgid "S&kip Override Tags"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:87
-msgid "St&yle"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:87
-msgid "A&ctor"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:88
-msgid "A&ll rows"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:91
-msgid "Limit to"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:93
-msgid "&Find next"
-msgstr ""
-
-#: ../src/dialog_search_replace.cpp:94
-msgid "Replace &next"
-msgstr ""
-
-#: ../src/dialog_autosave.cpp:66
-msgid "Open autosave file"
-msgstr ""
-
-#: ../src/dialog_autosave.cpp:75
-msgid "Versions"
-msgstr ""
-
-#: ../src/dialog_autosave.cpp:85
-msgid "Open"
-msgstr ""
-
-#: ../src/dialog_autosave.cpp:94
-#, c-format
-msgid "%s [ORIGINAL BACKUP]"
-msgstr ""
-
-#: ../src/dialog_autosave.cpp:95
-#, c-format
-msgid "%s [RECOVERED]"
-msgstr ""
-
-#: ../src/audio_box.cpp:73
-msgid "Horizontal zoom"
-msgstr ""
-
-#: ../src/audio_box.cpp:74
-msgid "Vertical zoom"
-msgstr ""
-
-#: ../src/audio_box.cpp:75
-msgid "Audio Volume"
-msgstr ""
-
-#: ../src/grid_column.cpp:82
-msgid "#"
-msgstr ""
-
-#: ../src/grid_column.cpp:83
-msgid "Line Number"
-msgstr ""
-
-#: ../src/grid_column.cpp:106
-msgid "L"
-msgstr ""
-
-#: ../src/grid_column.cpp:128
-msgid "Start"
-msgstr ""
-
-#: ../src/grid_column.cpp:146
-msgid "End"
-msgstr ""
-
-#: ../src/grid_column.cpp:237 ../src/dialog_style_editor.cpp:288
-msgid "Left"
-msgstr ""
-
-#: ../src/grid_column.cpp:238
-msgid "Left Margin"
-msgstr ""
-
-#: ../src/grid_column.cpp:242 ../src/dialog_style_editor.cpp:288
-msgid "Right"
-msgstr ""
-
-#: ../src/grid_column.cpp:243
-msgid "Right Margin"
-msgstr ""
-
-#: ../src/grid_column.cpp:247 ../src/dialog_style_editor.cpp:288
-msgid "Vert"
-msgstr ""
-
-#: ../src/grid_column.cpp:248
-msgid "Vertical Margin"
-msgstr ""
-
-#: ../src/grid_column.cpp:266
-msgid "CPS"
-msgstr ""
-
-#: ../src/grid_column.cpp:267
-msgid "Characters Per Second"
-msgstr ""
-
-#: ../src/dialog_text_import.cpp:47
-msgid "Text import options"
-msgstr ""
-
-#: ../src/dialog_text_import.cpp:54
-msgid "Actor separator:"
-msgstr ""
-
-#: ../src/dialog_text_import.cpp:56
-msgid "Comment starter:"
-msgstr ""
-
-#: ../src/dialog_text_import.cpp:61
-msgid "Include blank lines"
-msgstr ""
-
-#: ../src/video_box.cpp:57
-msgid "Seek video"
-msgstr ""
-
-#: ../src/video_box.cpp:62
-msgid "Current frame time and number"
-msgstr ""
-
-#: ../src/video_box.cpp:65
-msgid "Time of this frame relative to start and end of current subs"
-msgstr ""
-
-#: ../src/ass_style.cpp:193
-msgid "ANSI"
-msgstr ""
-
-#: ../src/ass_style.cpp:195
-msgid "Symbol"
-msgstr ""
-
-#: ../src/ass_style.cpp:196
-msgid "Mac"
-msgstr ""
-
-#: ../src/ass_style.cpp:197
-msgid "Shift_JIS"
-msgstr ""
-
-#: ../src/ass_style.cpp:198
-msgid "Hangeul"
-msgstr ""
-
-#: ../src/ass_style.cpp:199
-msgid "Johab"
-msgstr ""
-
-#: ../src/ass_style.cpp:200
-msgid "GB2312"
-msgstr ""
-
-#: ../src/ass_style.cpp:201
-msgid "Chinese BIG5"
-msgstr ""
-
-#: ../src/ass_style.cpp:202
-msgid "Greek"
-msgstr ""
-
-#: ../src/ass_style.cpp:203
-msgid "Turkish"
-msgstr ""
-
-#: ../src/ass_style.cpp:204
-msgid "Vietnamese"
-msgstr ""
-
-#: ../src/ass_style.cpp:205
-msgid "Hebrew"
-msgstr ""
-
-#: ../src/ass_style.cpp:206
-msgid "Arabic"
-msgstr ""
-
-#: ../src/ass_style.cpp:207
-msgid "Baltic"
-msgstr ""
-
-#: ../src/ass_style.cpp:208
-msgid "Russian"
-msgstr ""
-
-#: ../src/ass_style.cpp:209
-msgid "Thai"
-msgstr ""
-
-#: ../src/ass_style.cpp:210
-msgid "East European"
-msgstr ""
-
-#: ../src/ass_style.cpp:211
-msgid "OEM"
-msgstr ""
-
-#: ../src/dialog_colorpicker.cpp:542
+#: ../src/dialog_colorpicker.cpp:539
 msgid "Select Color"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:556
+#: ../src/dialog_colorpicker.cpp:553
 msgid "Color spectrum"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "RGB/R"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "RGB/G"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "RGB/B"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "HSL/L"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "HSV/H"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:567
+#: ../src/dialog_colorpicker.cpp:564
 msgid "RGB color"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:568
+#: ../src/dialog_colorpicker.cpp:565
 msgid "HSL color"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:569
+#: ../src/dialog_colorpicker.cpp:566
 msgid "HSV color"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:594
+#: ../src/dialog_colorpicker.cpp:591
 msgid "Spectrum mode:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:611
+#: ../src/dialog_colorpicker.cpp:608
 msgid "Red:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:611
+#: ../src/dialog_colorpicker.cpp:608
 msgid "Green:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:611
+#: ../src/dialog_colorpicker.cpp:608
 msgid "Blue:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:614
+#: ../src/dialog_colorpicker.cpp:611
 msgid "Alpha:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:621 ../src/dialog_colorpicker.cpp:624
+#: ../src/dialog_colorpicker.cpp:618 ../src/dialog_colorpicker.cpp:621
 msgid "Hue:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:621 ../src/dialog_colorpicker.cpp:624
+#: ../src/dialog_colorpicker.cpp:618 ../src/dialog_colorpicker.cpp:621
 msgid "Sat.:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:621
+#: ../src/dialog_colorpicker.cpp:618
 msgid "Lum.:"
 msgstr ""
 
-#: ../src/dialog_colorpicker.cpp:624
+#: ../src/dialog_colorpicker.cpp:621
 msgid "Value:"
 msgstr ""
 
-#: ../src/charset_detect.cpp:80
+#: ../src/dialog_styling_assistant.cpp:65
+#: ../src/dialog_styling_assistant.cpp:66
+msgid "Current line"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:72
+msgid "Styles available"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:80
+msgid "Set style"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:87 ../src/dialog_translation.cpp:110
+msgid "Keys"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:92 ../src/dialog_translation.cpp:115
+msgid "Previous line"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:93 ../src/dialog_translation.cpp:116
+msgid "Next line"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:94 ../src/dialog_translation.cpp:118
+msgid "Play video"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:95 ../src/dialog_translation.cpp:119
+msgid "Play audio"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:96
+msgid "Click on list"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:97
+msgid "Select style"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:101
+msgid "&Seek video to line start time"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:110 ../src/dialog_translation.cpp:131
+msgid "Actions"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:113 ../src/dialog_translation.cpp:133
+msgid "Play &Audio"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:117 ../src/dialog_translation.cpp:138
+msgid "Play &Video"
+msgstr ""
+
+#: ../src/dialog_styling_assistant.cpp:175
+msgid "styling assistant"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:128
+msgid "Style Editor"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:179
+msgid "Font"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:181
+msgid "Margins"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:182 ../src/dialog_style_editor.cpp:278
+msgid "Outline"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:183
+msgid "Miscellaneous"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:184
+msgid "Preview"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:190
+msgid "&Bold"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:191
+msgid "&Italic"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:192
+msgid "&Underline"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:193
+msgid "&Strikeout"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:205
+msgid "Alignment"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:208
+msgid "&Opaque box"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:216
+msgid "Style name"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:217
+msgid "Font face"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:218
+msgid "Font size"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:219
+msgid "Choose primary color"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:220
+msgid "Choose secondary color"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:221
+msgid "Choose outline color"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:222
+msgid "Choose shadow color"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:223
+msgid "Distance from left edge, in pixels"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:224
+msgid "Distance from right edge, in pixels"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:225
+msgid "Distance from top/bottom edge, in pixels"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:226
 msgid ""
-"Aegisub could not narrow down the character set to a single one.\n"
-"Please pick one below:"
+"When selected, display an opaque box behind the subtitles instead of an "
+"outline around the text"
 msgstr ""
 
-#: ../src/charset_detect.cpp:81
-msgid "Choose character set"
+#: ../src/dialog_style_editor.cpp:227
+msgid "Outline width, in pixels"
 msgstr ""
 
-#: ../src/dialog_detached_video.cpp:66 ../src/dialog_detached_video.cpp:134
-#, c-format
-msgid "Video: %s"
+#: ../src/dialog_style_editor.cpp:228
+msgid "Shadow distance, in pixels"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:100
-#, c-format
-msgid "From video (%g)"
+#: ../src/dialog_style_editor.cpp:229
+msgid "Scale X, in percentage"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:102
-msgid "From video (VFR)"
+#: ../src/dialog_style_editor.cpp:230
+msgid "Scale Y, in percentage"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:108
-msgid "15.000 FPS"
+#: ../src/dialog_style_editor.cpp:231
+msgid "Angle to rotate in Z axis, in degrees"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:109
-msgid "23.976 FPS (Decimated NTSC)"
+#: ../src/dialog_style_editor.cpp:232
+msgid ""
+"Encoding, only useful in unicode if the font doesn't have the proper unicode "
+"mapping"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:110
-msgid "24.000 FPS (FILM)"
+#: ../src/dialog_style_editor.cpp:233
+msgid "Character spacing, in pixels"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:111
-msgid "25.000 FPS (PAL)"
+#: ../src/dialog_style_editor.cpp:234
+msgid "Alignment in screen, in numpad style"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:112
-msgid "29.970 FPS (NTSC)"
+#: ../src/dialog_style_editor.cpp:278
+msgid "Primary"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:114
-msgid "29.970 FPS (NTSC with SMPTE dropframe)"
+#: ../src/dialog_style_editor.cpp:278
+msgid "Secondary"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:115
-msgid "30.000 FPS"
+#: ../src/dialog_style_editor.cpp:278
+msgid "Shadow"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:116
-msgid "50.000 FPS (PAL x2)"
+#: ../src/dialog_style_editor.cpp:307
+msgid "Outline:"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:117
-msgid "59.940 FPS (NTSC x2)"
+#: ../src/dialog_style_editor.cpp:308
+msgid "Shadow:"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:118
-msgid "60.000 FPS"
+#: ../src/dialog_style_editor.cpp:313
+msgid "Scale X%:"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:119
-msgid "119.880 FPS (NTSC x4)"
+#: ../src/dialog_style_editor.cpp:314
+msgid "Scale Y%:"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:120
-msgid "120.000 FPS"
+#: ../src/dialog_style_editor.cpp:315
+msgid "Rotation:"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:124
-msgid "Please choose the appropriate FPS for the subtitles:"
+#: ../src/dialog_style_editor.cpp:316
+msgid "Spacing:"
 msgstr ""
 
-#: ../src/subtitle_format.cpp:124
-msgid "FPS"
+#: ../src/dialog_style_editor.cpp:319
+msgid "Encoding:"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:94
+#: ../src/dialog_style_editor.cpp:329
+msgid "Preview of current style"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:332
+msgid "Text to be used for the preview"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:333
+msgid "Color of preview background"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:414
+msgid "There is already a style with this name. Please choose another name."
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:414
+msgid "Style name conflict"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:426
+msgid ""
+"Do you want to change all instances of this style in the script to this new "
+"name?"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:427
+msgid "Update script?"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:454 ../src/subs_edit_box.cpp:593
+msgid "style change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:118
+msgid "&Comment"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:119
+msgid "Comment this line out. Commented lines don't show up on screen."
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:126
+msgid "Style for this line"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:128 ../src/subs_edit_box.cpp:129
+msgid "Edit"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:139
+msgid ""
+"Actor name for this speech. This is only for reference, and is mainly "
+"useless."
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:144
+msgid ""
+"Effect for this line. This can be used to store extra information for "
+"karaoke scripts, or for the effects supported by the renderer."
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:150
+msgid "Number of characters in the longest line of this subtitle."
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:157
+msgid "Layer number"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:161
+msgid "Start time"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:162
+msgid "End time"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:164
+msgid "Line duration"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:167
+msgid "Left Margin (0 = default from style)"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:167
+msgid "left margin change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:168
+msgid "Right Margin (0 = default from style)"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:168
+msgid "right margin change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:169
+msgid "Vertical Margin (0 = default from style)"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:169
+msgid "vertical margin change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:188
+msgid "T&ime"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:188
+msgid "Time by h:mm:ss.cs"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:189
+msgid "F&rame"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:189
+msgid "Time by frame number"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:192
+msgid "Show Original"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:193
+msgid ""
+"Show the contents of the subtitle line when it was first selected above the "
+"edit box. This is sometimes useful when editing subtitles or translating "
+"subtitles into another language."
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:441
+msgid "modify text"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:519
+msgid "modify times"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:599
+msgid "actor change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:604
+msgid "layer change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:609
+msgid "effect change"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:614
+msgid "comment change"
+msgstr ""
+
+#: ../src/menu.cpp:96
+msgid "Empty"
+msgstr ""
+
+#: ../src/menu.cpp:233
+msgid "&Recent"
+msgstr ""
+
+#: ../src/menu.cpp:464
+msgid "No Automation macros loaded"
+msgstr ""
+
+#: ../src/ffmpegsource_common.cpp:91
 msgid "Indexing"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:95
+#: ../src/ffmpegsource_common.cpp:92
 msgid "Reading timecodes and frame/sample data"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:141
+#: ../src/ffmpegsource_common.cpp:155
 #, c-format
 msgid "Track %02d: %s"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:146
+#: ../src/ffmpegsource_common.cpp:160
 msgid "Multiple video tracks detected, please choose the one you wish to load:"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:146
+#: ../src/ffmpegsource_common.cpp:160
 msgid "Multiple audio tracks detected, please choose the one you wish to load:"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:147
+#: ../src/ffmpegsource_common.cpp:161
 msgid "Choose video track"
 msgstr ""
 
-#: ../src/ffmpegsource_common.cpp:147
+#: ../src/ffmpegsource_common.cpp:161
 msgid "Choose audio track"
-msgstr ""
-
-#: ../src/resolution_resampler.cpp:287
-msgid "resolution resampling"
 msgstr ""
 
 #: ../src/project.cpp:187
@@ -5479,202 +5422,32 @@ msgid ""
 "The following providers were tried:\n"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:127
-msgid "Style Editor"
+#: ../src/video_box.cpp:57
+msgid "Seek video"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:178
-msgid "Font"
+#: ../src/video_box.cpp:62
+msgid "Current frame time and number"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:180
-msgid "Margins"
+#: ../src/video_box.cpp:65
+msgid "Time of this frame relative to start and end of current subs"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:181 ../src/dialog_style_editor.cpp:277
-msgid "Outline"
+#: ../src/mkv_wrap.cpp:213
+msgid "Choose which track to read:"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:182
-msgid "Miscellaneous"
+#: ../src/mkv_wrap.cpp:213
+msgid "Multiple subtitle tracks found"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:183
-msgid "Preview"
+#: ../src/mkv_wrap.cpp:251
+msgid "Parsing Matroska"
 msgstr ""
 
-#: ../src/dialog_style_editor.cpp:189
-msgid "&Bold"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:190
-msgid "&Italic"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:191
-msgid "&Underline"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:192
-msgid "&Strikeout"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:204
-msgid "Alignment"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:207
-msgid "&Opaque box"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:215
-msgid "Style name"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:216
-msgid "Font face"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:217
-msgid "Font size"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:218
-msgid "Choose primary color"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:219
-msgid "Choose secondary color"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:220
-msgid "Choose outline color"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:221
-msgid "Choose shadow color"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:222
-msgid "Distance from left edge, in pixels"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:223
-msgid "Distance from right edge, in pixels"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:224
-msgid "Distance from top/bottom edge, in pixels"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:225
-msgid ""
-"When selected, display an opaque box behind the subtitles instead of an "
-"outline around the text"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:226
-msgid "Outline width, in pixels"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:227
-msgid "Shadow distance, in pixels"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:228
-msgid "Scale X, in percentage"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:229
-msgid "Scale Y, in percentage"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:230
-msgid "Angle to rotate in Z axis, in degrees"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:231
-msgid ""
-"Encoding, only useful in unicode if the font doesn't have the proper unicode "
-"mapping"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:232
-msgid "Character spacing, in pixels"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:233
-msgid "Alignment in screen, in numpad style"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:277
-msgid "Primary"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:277
-msgid "Secondary"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:277
-msgid "Shadow"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:306
-msgid "Outline:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:307
-msgid "Shadow:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:312
-msgid "Scale X%:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:313
-msgid "Scale Y%:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:314
-msgid "Rotation:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:315
-msgid "Spacing:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:318
-msgid "Encoding:"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:328
-msgid "Preview of current style"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:331
-msgid "Text to be used for the preview"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:332
-msgid "Color of preview background"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:413
-msgid "There is already a style with this name. Please choose another name."
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:413
-msgid "Style name conflict"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:425
-msgid ""
-"Do you want to change all instances of this style in the script to this new "
-"name?"
-msgstr ""
-
-#: ../src/dialog_style_editor.cpp:426
-msgid "Update script?"
+#: ../src/mkv_wrap.cpp:251
+msgid "Reading subtitles from Matroska file."
 msgstr ""
 
 #: ../src/dialog_export_ebu3264.cpp:84
@@ -5803,155 +5576,454 @@ msgstr ""
 msgid "Display standard"
 msgstr ""
 
-#: ../src/subs_controller.cpp:158
-#, c-format
-msgid "File backup saved as \"%s\"."
-msgstr ""
-
-#: ../src/subs_controller.cpp:260
-#, c-format
-msgid "Do you want to save changes to %s?"
-msgstr ""
-
-#: ../src/subs_controller.cpp:260
-msgid "Unsaved changes"
-msgstr ""
-
-#: ../src/subs_controller.cpp:395
-msgid "Untitled"
-msgstr ""
-
-#: ../src/subs_controller.cpp:397
-msgid "untitled"
-msgstr ""
-
-#: ../src/dialog_video_properties.cpp:44
-msgid "Resolution mismatch"
-msgstr ""
-
-#: ../src/dialog_video_properties.cpp:46
+#: ../src/main.cpp:276
 #, c-format
 msgid ""
-"The resolution of the loaded video and the resolution specified for the "
-"subtitles don't match.\n"
+"Oops, Aegisub has crashed!\n"
 "\n"
-"Video resolution:\t%d x %d\n"
-"Script resolution:\t%d x %d\n"
+"An attempt has been made to save a copy of your file to:\n"
 "\n"
-"Change subtitles resolution to match video?"
+"%s\n"
+"\n"
+"Aegisub will now close."
 msgstr ""
 
-#: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
-msgid "Set to video resolution"
+#: ../src/main.cpp:303
+msgid ""
+"Do you want Aegisub to check for updates whenever it starts? You can still "
+"do it manually via the Help menu."
 msgstr ""
 
-#: ../src/dialog_video_properties.cpp:55
-msgid "Resample script (stretch to new aspect ratio)"
+#: ../src/main.cpp:303
+msgid "Check for updates?"
 msgstr ""
 
-#: ../src/dialog_video_properties.cpp:56
-msgid "Resample script (add borders)"
+#: ../src/main.cpp:420 ../src/main.cpp:423
+msgid "Program error"
 msgstr ""
 
-#: ../src/dialog_video_properties.cpp:57
-msgid "Resample script (remove borders)"
+#: ../src/main.cpp:437
+#, c-format
+msgid ""
+"An unexpected error has occurred. Please save your work and restart "
+"Aegisub.\n"
+"\n"
+"Error Message: %s"
 msgstr ""
 
-#: ../src/dialog_video_properties.cpp:64
-msgid "Resample script"
+#: ../src/subtitle_format_ebu3264.cpp:396
+#, c-format
+msgid "Line over maximum length: %s"
 msgstr ""
 
-#: ../src/dialog_video_properties.cpp:163
-msgid "change script resolution"
+#: ../src/dialog_shift_times.cpp:92
+msgid "unsaved"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:68
-msgid "Attachment List"
+#: ../src/dialog_shift_times.cpp:96
+#, c-format
+msgid "%s frames"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:76
-msgid "Attach &Font"
+#: ../src/dialog_shift_times.cpp:98
+msgid "backward"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:77
-msgid "Attach &Graphics"
+#: ../src/dialog_shift_times.cpp:98
+msgid "forward"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:78
-msgid "E&xtract"
+#: ../src/dialog_shift_times.cpp:102
+msgid "s+e"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:110
-msgid "Attachment name"
+#: ../src/dialog_shift_times.cpp:103
+msgid "s"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:111
-msgid "Size"
+#: ../src/dialog_shift_times.cpp:104
+msgid "e"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:112
-msgid "Group"
+#: ../src/dialog_shift_times.cpp:111
+msgid "all"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:138 ../src/dialog_attachments.cpp:147
-msgid "Choose file to be attached"
+#: ../src/dialog_shift_times.cpp:114
+#, c-format
+msgid "from %d onward"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:142
-msgid "attach font file"
+#: ../src/dialog_shift_times.cpp:117
+msgid "sel "
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:152
-msgid "attach graphics file"
+#: ../src/dialog_shift_times.cpp:144
+msgid "&Time: "
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:164
-msgid "Select the path to save the files to:"
+#: ../src/dialog_shift_times.cpp:145
+msgid "Shift by time"
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:167
-msgid "Select the path to save the file to:"
+#: ../src/dialog_shift_times.cpp:148
+msgid "&Frames: "
 msgstr ""
 
-#: ../src/dialog_attachments.cpp:189
-msgid "remove attachment"
+#: ../src/dialog_shift_times.cpp:149
+msgid "Shift by frames"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:77
+#: ../src/dialog_shift_times.cpp:153
+msgid "Enter time in h:mm:ss.cs notation"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:156
+msgid "Enter number of frames to shift by"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:158
+msgid "For&ward"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:159
+msgid ""
+"Shifts subs forward, making them appear later. Use if they are appearing too "
+"soon."
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:161
+msgid "&Backward"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:162
+msgid ""
+"Shifts subs backward, making them appear earlier. Use if they are appearing "
+"too late."
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:164
+msgid "&All rows"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:164
+msgid "Selection &onward"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:165
+msgid "Affect"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:167
+msgid "Start a&nd End times"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:167
+msgid "&Start times only"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:167
+msgid "&End times only"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:168
+msgid "Times"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:172
+msgid "&Clear"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:203
+msgid "Shift by"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:212
+msgid "Load from history"
+msgstr ""
+
+#: ../src/dialog_shift_times.cpp:410
+msgid "shifting"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:105
+msgid "Dummy video options"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:117
+msgid "Checkerboard &pattern"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:120
+msgid "Video resolution:"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:122
+msgid "Color:"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:123
+msgid "Frame rate (fps):"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:124
+msgid "Duration (frames):"
+msgstr ""
+
+#: ../src/dialog_dummy_video.cpp:170
+#, c-format
+msgid "Resulting duration: %s"
+msgstr ""
+
+#: ../src/audio_display.cpp:707
+#, c-format
+msgid "%d%%, %d pixel/second"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:57
+msgid "Source: "
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:58
+msgid "Dest: "
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:470
+msgid "Kanji timing"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:476
+msgid "Styles"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:478
+msgid "Shortcut Keys"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:479
+msgid "Commands"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:487
+msgid "Attempt to &interpolate kanji."
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:494
+msgid ""
+"When the destination textbox has focus, use the following keys:\n"
+"\n"
+"Right Arrow: Increase dest. selection length\n"
+"Left Arrow: Decrease dest. selection length\n"
+"Up Arrow: Increase source selection length\n"
+"Down Arrow: Decrease source selection length\n"
+"Enter: Link, accept line when done\n"
+"Backspace: Unlink last"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:497
+msgid "S&tart!"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:498
+msgid "&Link"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:499
+msgid "&Unlink"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:500
+msgid "Skip &Source Line"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:501
+msgid "Skip &Dest Line"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:502
+msgid "&Go Back a Line"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:503
+msgid "&Accept Line"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:566
+msgid "kanji timing"
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:574
+msgid "Select source and destination styles first."
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:576
+msgid "The source and destination styles must be different."
+msgstr ""
+
+#: ../src/dialog_kara_timing_copy.cpp:626
+msgid "Group all of the source text."
+msgstr ""
+
+#: ../src/dialog_selection.cpp:106
+msgid "Select"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:117
+msgid "Match"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:121
+msgid "&Matches"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:122
+msgid "&Doesn't Match"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:123
+msgid "Match c&ase"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Exact match"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Contains"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Regular Expression match"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:133
+msgid "Mode"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:137
+msgid "&Style"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:137
+msgid "Act&or"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:137
+msgid "E&ffect"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:142
+msgid "Match dialogues/comments"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:143
+msgid "D&ialogues"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:144
+msgid "Comme&nts"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:149
+msgid "Set se&lection"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:149
+msgid "&Add to selection"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:149
+msgid "S&ubtract from selection"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:149
+msgid "Intersect &with selection"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:211
+#, c-format
+msgid "Selection was set to one line"
+msgid_plural "Selection was set to %u lines"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/dialog_selection.cpp:212
+msgid "Selection was set to no lines"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:218
+#, c-format
+msgid "One line was added to selection"
+msgid_plural "%u lines were added to selection"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/dialog_selection.cpp:219
+msgid "No lines were added to selection"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:230
+#, c-format
+msgid "One line was removed from selection"
+msgid_plural "%u lines were removed from selection"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/dialog_selection.cpp:231
+msgid "No lines were removed from selection"
+msgstr ""
+
+#: ../src/dialog_selection.cpp:236
+msgid "Selection"
+msgstr ""
+
+#: ../src/preferences_base.cpp:63
+msgid "Please choose the folder:"
+msgstr ""
+
+#: ../src/preferences_base.cpp:209
+msgid "Browse..."
+msgstr ""
+
+#: ../src/preferences_base.cpp:244
+msgid "Choose..."
+msgstr ""
+
+#: ../src/preferences_base.cpp:252
+msgid "Font Size"
+msgstr ""
+
+#: ../src/dialog_translation.cpp:79
 msgid "Original"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:100
+#: ../src/dialog_translation.cpp:102
 msgid "Translation"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:115
+#: ../src/dialog_translation.cpp:117
 msgid "Insert original"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:118
+#: ../src/dialog_translation.cpp:120
 msgid "Delete line"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:121
+#: ../src/dialog_translation.cpp:123
 msgid "Enable &preview"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:178 ../src/dialog_translation.cpp:278
+#: ../src/dialog_translation.cpp:180 ../src/dialog_translation.cpp:280
 msgid "No more lines to translate."
 msgstr ""
 
-#: ../src/dialog_translation.cpp:186 ../src/dialog_translation.cpp:236
+#: ../src/dialog_translation.cpp:188 ../src/dialog_translation.cpp:238
 #, c-format
 msgid "Current line: %d/%d"
 msgstr ""
 
-#: ../src/dialog_translation.cpp:273
+#: ../src/dialog_translation.cpp:275
 msgid "translation assistant"
-msgstr ""
-
-#: ../src/visual_tool.cpp:122
-msgid "visual typesetting"
 msgstr ""
 
 #: ../src/dialog_resample.cpp:119
@@ -6002,55 +6074,16 @@ msgstr ""
 msgid "Destination Resolution"
 msgstr ""
 
-#: ../src/dialog_version_check.cpp:94
-msgid "Version Checker"
+#: ../src/subtitles_provider_libass.cpp:107
+msgid "Updating font index"
 msgstr ""
 
-#: ../src/dialog_version_check.cpp:119
-msgid "&Auto Check for Updates"
+#: ../src/subtitles_provider_libass.cpp:108
+msgid "This may take several minutes"
 msgstr ""
 
-#: ../src/dialog_version_check.cpp:124
-msgid "Remind me again in a &week"
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:288
-msgid "Could not connect to updates server."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:310
-msgid "Could not download from updates server."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:312
-#, c-format
-msgid "HTTP request failed, got HTTP response %d."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:343
-msgid "An update to Aegisub was found."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:345
-msgid "Several possible updates to Aegisub were found."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:347
-msgid "There are no updates to Aegisub."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:375
-#, c-format
-msgid ""
-"There was an error checking for updates to Aegisub:\n"
-"%s\n"
-"\n"
-"If other applications can access the Internet fine, this is probably a "
-"temporary server problem on our end."
-msgstr ""
-
-#: ../src/dialog_version_check.cpp:379
-msgid "An unknown error occurred while checking for updates to Aegisub."
+#: ../src/hotkey.cpp:259
+msgid "Invalid command name for hotkey"
 msgstr ""
 
 #: default_menu.json:0
@@ -6174,11 +6207,36 @@ msgstr ""
 
 
 #: default_menu.json:0
-msgid "&Export As..."
+msgid "Window"
 msgstr ""
 
 
-#: default_hotkey.json:602:
+#: default_menu.json:0
+msgid "Open..."
+msgstr ""
+
+
+#: default_menu.json:0
+msgid "Open Recent"
+msgstr ""
+
+
+#: default_menu.json:0
+msgid "Save"
+msgstr ""
+
+
+#: default_menu.json:0
+msgid "Save As..."
+msgstr ""
+
+
+#: default_menu.json:0
+msgid "Export As..."
+msgstr ""
+
+
+#: default_hotkey.json:244:
 msgid "Subtitle Edit Box"
 msgstr ""
 
@@ -6198,13 +6256,38 @@ msgid "Adds \\be1 tags to all selected lines"
 msgstr ""
 
 
-#: ../automation/autoload/karaoke-auto-leadin.lua:32
-msgid "Automatic karaoke lead-in"
+#: ../automation/autoload/strip-tags.lua:17
+msgid "Strip tags"
 msgstr ""
 
 
-#: ../automation/autoload/karaoke-auto-leadin.lua:33
-msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
+#: ../automation/autoload/strip-tags.lua:18
+msgid "Remove all override tags from selected lines"
+msgstr ""
+
+
+#: ../automation/autoload/strip-tags.lua:28
+msgid "strip tags"
+msgstr ""
+
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:6
+msgid "Make text fullwidth"
+msgstr ""
+
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:7
+msgid "Shows how to use the unicode include to iterate over characters and a lookup table to convert those characters to something else."
+msgstr ""
+
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:77
+msgid "Make fullwidth"
+msgstr ""
+
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:80
+msgid "Convert Latin letters to SJIS fullwidth letters"
 msgstr ""
 
 
@@ -6228,48 +6311,43 @@ msgid "Macro and export filter to apply karaoke effects using the template langu
 msgstr ""
 
 
-#: ../automation/autoload/kara-templater.lua:858
+#: ../automation/autoload/kara-templater.lua:860
 msgid "Apply karaoke template"
 msgstr ""
 
 
-#: ../automation/autoload/kara-templater.lua:858
+#: ../automation/autoload/kara-templater.lua:860
 msgid "Applies karaoke effects from templates"
 msgstr ""
 
 
-#: ../automation/autoload/kara-templater.lua:859
+#: ../automation/autoload/kara-templater.lua:861
 msgid "Karaoke template"
 msgstr ""
 
 
-#: ../automation/autoload/kara-templater.lua:859
+#: ../automation/autoload/kara-templater.lua:861
 msgid "Apply karaoke effect templates to the subtitles.\n\nSee the help file for information on how to use this."
 msgstr ""
 
 
-#: ../automation/autoload/strip-tags.lua:17
-msgid "Strip tags"
+#: ../automation/autoload/karaoke-auto-leadin.lua:32
+msgid "Automatic karaoke lead-in"
 msgstr ""
 
 
-#: ../automation/autoload/strip-tags.lua:18
-msgid "Remove all override tags from selected lines"
+#: ../automation/autoload/karaoke-auto-leadin.lua:33
+msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
 msgstr ""
 
 
-#: ../automation/autoload/strip-tags.lua:28
-msgid "strip tags"
+#: ../automation/autoload/select-overlaps.moon:17
+msgid "Select overlaps"
 msgstr ""
 
 
-#: ../automation/autoload/macro-2-mkfullwitdh.lua:77
-msgid "Make fullwidth"
-msgstr ""
-
-
-#: ../automation/autoload/macro-2-mkfullwitdh.lua:80
-msgid "Convert Latin letters to SJIS fullwidth letters"
+#: ../automation/autoload/select-overlaps.moon:18
+msgid "Select lines which begin while another non-comment line is active"
 msgstr ""
 
 
@@ -6285,6 +6363,11 @@ msgstr ""
 
 #: aegisub.desktop:6
 msgid "Create and edit subtitles for film and videos."
+msgstr ""
+
+
+#: aegisub.desktop:12
+msgid "subtitles;subtitle;captions;captioning;video;audio;"
 msgstr ""
 
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,308 +1,961 @@
-# translation of ca.po to Catalan
-# Eduard Ereza Martínez <ereza@catsub.net>, 2008.
 msgid ""
 msgstr ""
 "Project-Id-Version: ca\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-07-01 10:53-0700\n"
-"PO-Revision-Date: 2016-07-14 02:00+0100\n"
-"Last-Translator: Eduard Ereza Martínez <eduard@eduardereza.com>\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2020-02-17 17:47+0100\n"
+"PO-Revision-Date: 2020-02-17 17:49+0100\n"
+"Last-Translator: Eduard Ereza Martínez <eduard@ereza.cat>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 3.10.1\n"
 
-#: ../src/dialog_shift_times.cpp:92
-msgid "unsaved"
-msgstr "no desat"
+#: ../src/visual_tool_drag.cpp:57
+msgid "Toggle between \\move and \\pos"
+msgstr "Commuta entre \\move i \\pos"
 
-#: ../src/dialog_shift_times.cpp:96
-#, c-format
-msgid "%s frames"
-msgstr "%s fotogrames"
+#: ../src/visual_tool_drag.cpp:330 ../src/visual_tool_cross.cpp:62
+msgid "positioning"
+msgstr "el posicionament"
 
-#: ../src/dialog_shift_times.cpp:98
-msgid "backward"
-msgstr "endarrere"
+#: ../src/preferences.cpp:62 ../src/preferences.cpp:64
+#: ../src/preferences.cpp:330 ../src/preferences.cpp:351
+msgid "General"
+msgstr "General"
 
-#: ../src/dialog_shift_times.cpp:98
-msgid "forward"
-msgstr "endavant"
+#: ../src/preferences.cpp:65
+msgid "Check for updates on startup"
+msgstr "Comprova si hi ha actualitzacions en iniciar"
 
-#: ../src/dialog_shift_times.cpp:102
-msgid "s+e"
-msgstr "i+f"
+#: ../src/preferences.cpp:66
+msgid "Show main toolbar"
+msgstr "Mostra la barra d'eines principal"
 
-#: ../src/dialog_shift_times.cpp:103
-msgid "s"
-msgstr "i"
+#: ../src/preferences.cpp:67
+msgid "Save UI state in subtitles files"
+msgstr "Desa l'estat de la IU als fitxers de subtítols"
 
-#: ../src/dialog_shift_times.cpp:104
-msgid "e"
-msgstr "f"
+#: ../src/preferences.cpp:70
+msgid "Toolbar Icon Size"
+msgstr "Mida de les icones de la barra d'eines"
 
-#: ../src/dialog_shift_times.cpp:111
-msgid "all"
-msgstr "tot"
+#: ../src/preferences.cpp:71 ../src/preferences.cpp:196
+msgid "Never"
+msgstr "Mai"
 
-#: ../src/dialog_shift_times.cpp:113
-#, c-format
-msgid "from %d onward"
-msgstr "des de %d en endavant"
+#: ../src/preferences.cpp:71
+msgid "Always"
+msgstr "Sempre"
 
-#: ../src/dialog_shift_times.cpp:115
-msgid "sel "
-msgstr "sel "
+#: ../src/preferences.cpp:71 ../src/preferences.cpp:196
+msgid "Ask"
+msgstr "Demana"
 
-#: ../src/dialog_shift_times.cpp:133 ../src/command/time.cpp:153
-msgid "Shift Times"
-msgstr "Desplaça els temps"
+#: ../src/preferences.cpp:73
+msgid "Automatically load linked files"
+msgstr "Carrega automàticament els fitxers enllaçats"
 
-#: ../src/dialog_shift_times.cpp:142
-msgid "&Time: "
-msgstr "&Temps: "
+#: ../src/preferences.cpp:74
+msgid "Undo Levels"
+msgstr "Nivells per a desfer"
 
-#: ../src/dialog_shift_times.cpp:143
-msgid "Shift by time"
-msgstr "Desplaça per temps"
+#: ../src/preferences.cpp:76
+msgid "Recently Used Lists"
+msgstr "Llistes d'utilitzats recentment"
 
-#: ../src/dialog_shift_times.cpp:146
-msgid "&Frames: "
-msgstr "&Fotogrames: "
+#: ../src/preferences.cpp:77 ../src/dialog_autosave.cpp:70
+msgid "Files"
+msgstr "Fitxers"
 
-#: ../src/dialog_shift_times.cpp:147
-msgid "Shift by frames"
-msgstr "Desplaça per fotogrames"
+#: ../src/preferences.cpp:78
+msgid "Find/Replace"
+msgstr "Cerca/substitueix"
 
-#: ../src/dialog_shift_times.cpp:151
-msgid "Enter time in h:mm:ss.cs notation"
-msgstr "Introduïu el temps en notació h:mm:ss.cs"
+#: ../src/preferences.cpp:84
+msgid "Default styles"
+msgstr "Estils per defecte"
 
-#: ../src/dialog_shift_times.cpp:154
-msgid "Enter number of frames to shift by"
-msgstr "Introduïu el nombre de fotogrames a desplaçar"
+#: ../src/preferences.cpp:86
+msgid "Default style catalogs"
+msgstr "Catàlegs d'estils per defecte"
 
-#: ../src/dialog_shift_times.cpp:156
-msgid "For&ward"
-msgstr "&Endavant"
-
-#: ../src/dialog_shift_times.cpp:157
+#: ../src/preferences.cpp:90
 msgid ""
-"Shifts subs forward, making them appear later. Use if they are appearing too "
-"soon."
+"The chosen style catalogs will be loaded when you start a new file or import "
+"files in the various formats.\n"
+"\n"
+"You can set up style catalogs in the Style Manager."
 msgstr ""
-"Desplaça els subtítols cap endavant, fent que apareguin més tard. Utilitzeu "
-"això si apareixen massa aviat."
+"Els catàlegs d'estils seleccionats es carregaran quan inicieu un nou fitxer "
+"o importeu fitxers en diversos formats.\n"
+"\n"
+"Podeu definir catàlegs d'estils al Gestor d'estils."
 
-#: ../src/dialog_shift_times.cpp:159
-msgid "&Backward"
-msgstr "End&arrere"
+#: ../src/preferences.cpp:115
+msgid "New files"
+msgstr "Nous fitxers"
 
-#: ../src/dialog_shift_times.cpp:160
+#: ../src/preferences.cpp:116
+msgid "MicroDVD import"
+msgstr "Importació de MicroDVD"
+
+#: ../src/preferences.cpp:117
+msgid "SRT import"
+msgstr "Importació d'SRT"
+
+#: ../src/preferences.cpp:118
+msgid "TTXT import"
+msgstr "Importació de TTXT"
+
+#: ../src/preferences.cpp:119
+msgid "Plain text import"
+msgstr "Importació de text pla"
+
+#: ../src/preferences.cpp:126 ../src/preferences.cpp:364
+msgid "Audio"
+msgstr "Àudio"
+
+#: ../src/preferences.cpp:128 ../src/preferences.cpp:168
+#: ../src/dialog_timing_processor.cpp:168 ../src/command/app.cpp:206
+#: ../src/dialog_properties.cpp:146
+msgid "Options"
+msgstr "Opcions"
+
+#: ../src/preferences.cpp:129
+msgid "Default mouse wheel to zoom"
+msgstr "Roda del ratolí per defecte per a ampliar"
+
+#: ../src/preferences.cpp:130
+msgid "Lock scroll on cursor"
+msgstr "Bloca el desplaçament si hi ha el cursor"
+
+#: ../src/preferences.cpp:131
+msgid "Snap markers by default"
+msgstr "Enganxa als marcadors per defecte"
+
+#: ../src/preferences.cpp:132
+msgid "Auto-focus on mouse over"
+msgstr "Focus automàtic en posar-hi el ratolí a damunt"
+
+#: ../src/preferences.cpp:133
+msgid "Play audio when stepping in video"
+msgstr "Reprodueix l'àudio en recórrer el vídeo"
+
+#: ../src/preferences.cpp:134
+msgid "Left-click-drag moves end marker"
+msgstr "Mou el marcador de fi en fer clic esquerre i arrossegar"
+
+#: ../src/preferences.cpp:135
+msgid "Default timing length (ms)"
+msgstr "Llargada per defecte del temps (ms)"
+
+#: ../src/preferences.cpp:136
+msgid "Default lead-in length (ms)"
+msgstr "Llargada per defecte del temps d'entrada (ms)"
+
+#: ../src/preferences.cpp:137
+msgid "Default lead-out length (ms)"
+msgstr "Llargada per defecte del temps de sortida (ms)"
+
+#: ../src/preferences.cpp:139
+msgid "Marker drag-start sensitivity (px)"
+msgstr "Sensibilitat de l'inici d'arrossegament als marcadors (px)"
+
+#: ../src/preferences.cpp:140
+msgid "Line boundary thickness (px)"
+msgstr "Gruix de la línia de límit (px)"
+
+#: ../src/preferences.cpp:141
+msgid "Maximum snap distance (px)"
+msgstr "Distància màxima per a enganxar-se (px)"
+
+#: ../src/preferences.cpp:143
+msgid "Don't show"
+msgstr "No les mostris"
+
+#: ../src/preferences.cpp:143
+msgid "Show previous"
+msgstr "Mostra l'anterior"
+
+#: ../src/preferences.cpp:143
+msgid "Show previous and next"
+msgstr "Mostra l'anterior i la següent"
+
+#: ../src/preferences.cpp:143
+msgid "Show all"
+msgstr "Mostra-ho tot"
+
+#: ../src/preferences.cpp:145
+msgid "Show inactive lines"
+msgstr "Mostra les línies inactives"
+
+#: ../src/preferences.cpp:147
+msgid "Include commented inactive lines"
+msgstr "Inclou les les línies inactives comentades"
+
+#: ../src/preferences.cpp:149
+msgid "Display Visual Options"
+msgstr "Opcions visuals"
+
+#: ../src/preferences.cpp:150
+msgid "Keyframes in dialogue mode"
+msgstr "Fotogrames clau en mode de diàleg"
+
+#: ../src/preferences.cpp:151
+msgid "Keyframes in karaoke mode"
+msgstr "Fotogrames clau en mode de karaoke"
+
+#: ../src/preferences.cpp:152
+msgid "Cursor time"
+msgstr "Temps del cursor"
+
+#: ../src/preferences.cpp:153
+msgid "Video position"
+msgstr "Posició del vídeo"
+
+#: ../src/preferences.cpp:154 ../src/preferences.cpp:250
+msgid "Seconds boundaries"
+msgstr "Límits dels segons"
+
+#: ../src/preferences.cpp:156
+msgid "Waveform Style"
+msgstr "Estil en forma d'ona"
+
+#: ../src/preferences.cpp:158
+msgid "Audio labels"
+msgstr "Etiquetes de l'àudio"
+
+#: ../src/preferences.cpp:166 ../src/preferences.cpp:427
+#: ../src/dialog_video_details.cpp:66
+msgid "Video"
+msgstr "Vídeo"
+
+#: ../src/preferences.cpp:169
+msgid "Show keyframes in slider"
+msgstr "Mostra els fotogrames clau a la barra de desplaçament"
+
+#: ../src/preferences.cpp:171
+msgid "Only show visual tools when mouse is over video"
+msgstr "Mostra les eines visuals només quan el ratolí sigui sobre el vídeo"
+
+#: ../src/preferences.cpp:173
+msgid "Seek video to line start on selection change"
+msgstr "Mou el vídeo al temps d'inici de la línia en canviar la selecció"
+
+#: ../src/preferences.cpp:175
+msgid "Automatically open audio when opening video"
+msgstr "Obre l'àudio automàticament en obrir el vídeo"
+
+#: ../src/preferences.cpp:180
+msgid "Default Zoom"
+msgstr "Ampliació per defecte"
+
+#: ../src/preferences.cpp:182
+msgid "Fast jump step in frames"
+msgstr "Pas del salt ràpid en fotogrames"
+
+#: ../src/preferences.cpp:186
+msgid "Screenshot save path"
+msgstr "Camí on es desaran les captures de pantalla"
+
+#: ../src/preferences.cpp:188
+msgid "Script Resolution"
+msgstr "Resolució de l'script"
+
+#: ../src/preferences.cpp:189
+msgid "Use resolution of first video opened"
+msgstr "Utilitza la resolució del primer vídeo obert"
+
+#: ../src/preferences.cpp:192
+msgid "Default width"
+msgstr "Amplada per defecte"
+
+#: ../src/preferences.cpp:194
+msgid "Default height"
+msgstr "Alçada per defecte"
+
+#: ../src/preferences.cpp:196
+msgid "Always set"
+msgstr "Defineix sempre"
+
+#: ../src/preferences.cpp:196
+msgid "Always resample"
+msgstr "Reajusta sempre"
+
+#: ../src/preferences.cpp:198
+msgid "Match video resolution on open"
+msgstr "Encaixa la resolució del vídeo en obrir"
+
+#: ../src/preferences.cpp:205
+msgid "Interface"
+msgstr "Interfície"
+
+#: ../src/preferences.cpp:207
+msgid "Edit Box"
+msgstr "Capsa d'edició"
+
+#: ../src/preferences.cpp:208
+msgid "Enable call tips"
+msgstr "Activa els consells de crides"
+
+#: ../src/preferences.cpp:209
+msgid "Overwrite in time boxes"
+msgstr "Sobreescriu a les capses de temps"
+
+#: ../src/preferences.cpp:211
+msgid "Enable syntax highlighting"
+msgstr "Activa el ressaltat de la sintaxi"
+
+#: ../src/preferences.cpp:212
+msgid "Dictionaries path"
+msgstr "Camí dels diccionaris"
+
+#: ../src/preferences.cpp:215
+msgid "Character Counter"
+msgstr "Comptador de caràcters"
+
+#: ../src/preferences.cpp:216
+msgid "Maximum characters per line"
+msgstr "Màxim de caràcters per línia"
+
+#: ../src/preferences.cpp:217
+msgid "Characters Per Second Warning Threshold"
+msgstr "Llindar d'advertència de caràcters per segon"
+
+#: ../src/preferences.cpp:218
+msgid "Characters Per Second Error Threshold"
+msgstr "Llindar d'error de caràcters per segon"
+
+#: ../src/preferences.cpp:219
+msgid "Ignore whitespace"
+msgstr "Ignora els espais en blanc"
+
+#: ../src/preferences.cpp:220
+msgid "Ignore punctuation"
+msgstr "Ignora la puntuació"
+
+#: ../src/preferences.cpp:222
+msgid "Grid"
+msgstr "Graella"
+
+#: ../src/preferences.cpp:223
+msgid "Focus grid on click"
+msgstr "Posa el focus a la graella en fer-hi clic"
+
+#: ../src/preferences.cpp:224
+msgid "Highlight visible subtitles"
+msgstr "Ressalta els subtítols visibles"
+
+#: ../src/preferences.cpp:225
+msgid "Hide overrides symbol"
+msgstr "Símbol per a amagar les etiquetes d'estil"
+
+#: ../src/preferences.cpp:228 ../src/command/tool.cpp:201
+#: ../src/dialog_translation.cpp:66
+msgid "Translation Assistant"
+msgstr "Auxiliar de traducció"
+
+#: ../src/preferences.cpp:229
+msgid "Skip over whitespace"
+msgstr "Omet els espais en blanc"
+
+#: ../src/preferences.cpp:236 ../src/dialog_style_editor.cpp:180
+msgid "Colors"
+msgstr "Colors"
+
+#: ../src/preferences.cpp:244
+msgid "Audio Display"
+msgstr "Visualització d'àudio"
+
+#: ../src/preferences.cpp:245
+msgid "Play cursor"
+msgstr "Cursor de reproducció"
+
+#: ../src/preferences.cpp:246
+msgid "Line boundary start"
+msgstr "Línia del límit d'inici"
+
+#: ../src/preferences.cpp:247
+msgid "Line boundary end"
+msgstr "Línia del límit de final"
+
+#: ../src/preferences.cpp:248
+msgid "Line boundary inactive line"
+msgstr "Línia del límit de línia inactiva"
+
+#: ../src/preferences.cpp:249
+msgid "Syllable boundaries"
+msgstr "Límits de síl·laba"
+
+#: ../src/preferences.cpp:252
+msgid "Syntax Highlighting"
+msgstr "Ressaltat de sintaxi"
+
+#: ../src/preferences.cpp:253
+msgid "Background"
+msgstr "Fons"
+
+#: ../src/preferences.cpp:254
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/preferences.cpp:255
+msgid "Comments"
+msgstr "Comentaris"
+
+#: ../src/preferences.cpp:256
+msgid "Drawings"
+msgstr "Dibuixos"
+
+#: ../src/preferences.cpp:257
+msgid "Brackets"
+msgstr "Claudàtors"
+
+#: ../src/preferences.cpp:258
+msgid "Slashes and Parentheses"
+msgstr "Barres i parèntesis"
+
+#: ../src/preferences.cpp:259
+msgid "Tags"
+msgstr "Etiquetes"
+
+#: ../src/preferences.cpp:260
+msgid "Parameters"
+msgstr "Paràmetres"
+
+#: ../src/preferences.cpp:261 ../src/dialog_fonts_collector.cpp:303
+#: ../src/dialog_fonts_collector.cpp:308 ../src/dialog_fonts_collector.cpp:313
+#: ../src/dialog_kara_timing_copy.cpp:574
+#: ../src/dialog_kara_timing_copy.cpp:576
+#: ../src/dialog_kara_timing_copy.cpp:626
+msgid "Error"
+msgstr "Error"
+
+#: ../src/preferences.cpp:262
+msgid "Error Background"
+msgstr "Fons d'error"
+
+#: ../src/preferences.cpp:263
+msgid "Line Break"
+msgstr "Salt de línia"
+
+#: ../src/preferences.cpp:264
+msgid "Karaoke templates"
+msgstr "Plantilles de karaoke"
+
+#: ../src/preferences.cpp:265
+msgid "Karaoke variables"
+msgstr "Variables de karaoke"
+
+#: ../src/preferences.cpp:271
+msgid "Audio Color Schemes"
+msgstr "Esquemes de color d'àudio"
+
+#: ../src/preferences.cpp:273 ../src/preferences.cpp:380
+msgid "Spectrum"
+msgstr "Espectre"
+
+#: ../src/preferences.cpp:274
+msgid "Waveform"
+msgstr "Forma d'ona"
+
+#: ../src/preferences.cpp:276
+msgid "Subtitle Grid"
+msgstr "Graella dels subtítols"
+
+#: ../src/preferences.cpp:277
+msgid "Standard foreground"
+msgstr "Frontal estàndard"
+
+#: ../src/preferences.cpp:278
+msgid "Standard background"
+msgstr "Fons estàndard"
+
+#: ../src/preferences.cpp:279
+msgid "Selection foreground"
+msgstr "Frontal seleccionat"
+
+#: ../src/preferences.cpp:280
+msgid "Selection background"
+msgstr "Fons seleccionat"
+
+#: ../src/preferences.cpp:281
+msgid "Collision foreground"
+msgstr "Frontal de col·lisió"
+
+#: ../src/preferences.cpp:282
+msgid "In frame background"
+msgstr "Fons dins del fotograma"
+
+#: ../src/preferences.cpp:283
+msgid "Comment background"
+msgstr "Fons dels comentaris"
+
+#: ../src/preferences.cpp:284
+msgid "Selected comment background"
+msgstr "Fons seleccionat dels comentaris"
+
+#: ../src/preferences.cpp:285
+msgid "Header background"
+msgstr "Fons de la capçalera"
+
+#: ../src/preferences.cpp:286
+msgid "Left Column"
+msgstr "Columna esquerra"
+
+#: ../src/preferences.cpp:287
+msgid "Active Line Border"
+msgstr "Vora de la línia activa"
+
+#: ../src/preferences.cpp:288
+msgid "Lines"
+msgstr "Línies"
+
+#: ../src/preferences.cpp:289
+msgid "CPS Error"
+msgstr "Error de CPS"
+
+#: ../src/preferences.cpp:291
+msgid "Visual Typesetting Tools"
+msgstr "Eines per a la definició d'estils visual"
+
+#: ../src/preferences.cpp:292
+msgid "Primary Lines"
+msgstr "Línies, primari"
+
+#: ../src/preferences.cpp:293
+msgid "Secondary Lines"
+msgstr "Línies, secundari"
+
+#: ../src/preferences.cpp:294
+msgid "Primary Highlight"
+msgstr "Ressaltat, primari"
+
+#: ../src/preferences.cpp:295
+msgid "Secondary Highlight"
+msgstr "Ressaltat, secundari"
+
+#: ../src/preferences.cpp:298
+msgid "Visual Typesetting Tools Alpha"
+msgstr "Eines per a la definició d'estils visual alfa"
+
+#: ../src/preferences.cpp:299
+msgid "Shaded Area"
+msgstr "Àrea ombrejada"
+
+#: ../src/preferences.cpp:308
+msgid "Backup"
+msgstr "Còpia de seguretat"
+
+#: ../src/preferences.cpp:310
+msgid "Automatic Save"
+msgstr "Desament automàtic"
+
+#: ../src/preferences.cpp:311 ../src/preferences.cpp:319
+msgid "Enable"
+msgstr "Activa"
+
+#: ../src/preferences.cpp:314
+msgid "Interval in seconds"
+msgstr "Interval en segons"
+
+#: ../src/preferences.cpp:315 ../src/preferences.cpp:321
+#: ../src/preferences.cpp:378
+msgid "Path"
+msgstr "Camí"
+
+#: ../src/preferences.cpp:316
+msgid "Autosave after every change"
+msgstr "Desa automàticament després de cada canvi"
+
+#: ../src/preferences.cpp:318
+msgid "Automatic Backup"
+msgstr "Còpia de seguretat automàtica"
+
+#: ../src/preferences.cpp:328 ../src/command/automation.cpp:75
+#: ../src/command/automation.cpp:87
+msgid "Automation"
+msgstr "Automatització"
+
+#: ../src/preferences.cpp:332
+msgid "Base path"
+msgstr "Camí base"
+
+#: ../src/preferences.cpp:333
+msgid "Include path"
+msgstr "Camí d'inclusió"
+
+#: ../src/preferences.cpp:334
+msgid "Auto-load path"
+msgstr "Camí de càrrega automàtica"
+
+#: ../src/preferences.cpp:336
+msgid "0: Fatal"
+msgstr "0: Fatal"
+
+#: ../src/preferences.cpp:336
+msgid "1: Error"
+msgstr "1: Error"
+
+#: ../src/preferences.cpp:336
+msgid "2: Warning"
+msgstr "2: Advertència"
+
+#: ../src/preferences.cpp:336
+msgid "3: Hint"
+msgstr "3: Informació"
+
+#: ../src/preferences.cpp:336
+msgid "4: Debug"
+msgstr "4: Depuració"
+
+#: ../src/preferences.cpp:336
+msgid "5: Trace"
+msgstr "5: Traça"
+
+#: ../src/preferences.cpp:338
+msgid "Trace level"
+msgstr "Nivell de traça"
+
+#: ../src/preferences.cpp:340
+msgid "No scripts"
+msgstr "Cap script"
+
+#: ../src/preferences.cpp:340
+msgid "Subtitle-local scripts"
+msgstr "Scripts del subtítol local"
+
+#: ../src/preferences.cpp:340
+msgid "Global autoload scripts"
+msgstr "Scripts globals de càrrega automàtica"
+
+#: ../src/preferences.cpp:340
+msgid "All scripts"
+msgstr "Tots els scripts"
+
+#: ../src/preferences.cpp:342
+msgid "Autoreload on Export"
+msgstr "Recarrega automàticament en exportar"
+
+#: ../src/preferences.cpp:349
+msgid "Advanced"
+msgstr "Avançades"
+
+#: ../src/preferences.cpp:353
 msgid ""
-"Shifts subs backward, making them appear earlier. Use if they are appearing "
-"too late."
+"Changing these settings might result in bugs and/or crashes.  Do not touch "
+"these unless you know what you're doing."
 msgstr ""
-"Desplaça els subtítols cap endarrere, fent que apareguin més aviat. "
-"Utilitzeu això si apareixen massa tard."
+"Si canvieu aquesta configuració podeu provocar comportaments inesperats o "
+"errades. No la modifiqueu si no sabeu què feu."
 
-#: ../src/dialog_shift_times.cpp:162
-msgid "&All rows"
-msgstr "T&otes les línies"
+#: ../src/preferences.cpp:366 ../src/preferences.cpp:429
+msgid "Expert"
+msgstr "Per a experts"
 
-#: ../src/dialog_shift_times.cpp:162 ../src/dialog_search_replace.cpp:88
-msgid "Selected &rows"
-msgstr "Les línies &seleccionades"
+#: ../src/preferences.cpp:369
+msgid "Audio provider"
+msgstr "Proveïdor d'àudio"
 
-#: ../src/dialog_shift_times.cpp:162
-msgid "Selection &onward"
-msgstr "De &la selecció cap endavant"
+#: ../src/preferences.cpp:372
+msgid "Audio player"
+msgstr "Reproductor d'àudio"
 
-#: ../src/dialog_shift_times.cpp:163
-msgid "Affect"
-msgstr "Afecta"
+#: ../src/preferences.cpp:374
+msgid "Cache"
+msgstr "Memòria cau"
 
-#: ../src/dialog_shift_times.cpp:165
-msgid "Start a&nd End times"
-msgstr "Te&mps d'inici i de final"
+#: ../src/preferences.cpp:375
+msgid "None (NOT RECOMMENDED)"
+msgstr "Cap (NO RECOMANAT)"
 
-#: ../src/dialog_shift_times.cpp:165
-msgid "&Start times only"
-msgstr "Només els temps d'&inici"
+#: ../src/preferences.cpp:375
+msgid "RAM"
+msgstr "RAM"
 
-#: ../src/dialog_shift_times.cpp:165
-msgid "&End times only"
-msgstr "Només els tem&ps de final"
+#: ../src/preferences.cpp:375
+msgid "Hard Disk"
+msgstr "Disc dur"
 
-#: ../src/dialog_shift_times.cpp:166
-msgid "Times"
-msgstr "Temps"
+#: ../src/preferences.cpp:377
+msgid "Cache type"
+msgstr "Tipus de memòria cau"
 
-#: ../src/dialog_shift_times.cpp:170
-msgid "&Clear"
-msgstr "&Neteja"
+#: ../src/preferences.cpp:382
+msgid "Regular quality"
+msgstr "Qualitat regular"
 
-#: ../src/dialog_shift_times.cpp:201
-msgid "Shift by"
-msgstr "Desplaça per"
+#: ../src/preferences.cpp:382
+msgid "Better quality"
+msgstr "Qualitat mitjana"
 
-#: ../src/dialog_shift_times.cpp:210
-msgid "Load from history"
-msgstr "Carrega de l'historial"
+#: ../src/preferences.cpp:382
+msgid "High quality"
+msgstr "Qualitat alta"
 
-#: ../src/dialog_shift_times.cpp:405
-msgid "shifting"
-msgstr "desplaçant"
+#: ../src/preferences.cpp:382
+msgid "Insane quality"
+msgstr "Qualitat exagerada"
+
+#: ../src/preferences.cpp:384
+msgid "Quality"
+msgstr "Qualitat"
+
+#: ../src/preferences.cpp:386
+msgid "Cache memory max (MB)"
+msgstr "Màxim de memòria cau (MB)"
+
+#: ../src/preferences.cpp:392
+msgid "Avisynth down-mixer"
+msgstr "Mesclador a la baixa de l'Avisynth"
+
+#: ../src/preferences.cpp:393
+msgid "Force sample rate"
+msgstr "Força la taxa de mostreig"
+
+#: ../src/preferences.cpp:399
+msgid "Ignore"
+msgstr "Ignora"
+
+#: ../src/preferences.cpp:399 ../src/command/edit.cpp:1222
+#: ../src/command/edit.cpp:1223
+msgid "Clear"
+msgstr "Esborra"
+
+#: ../src/preferences.cpp:399
+msgid "Stop"
+msgstr "Atura"
+
+#: ../src/preferences.cpp:399
+msgid "Abort"
+msgstr "Avorta"
+
+#: ../src/preferences.cpp:401
+msgid "Audio indexing error handling mode"
+msgstr "Mode de gestió d'errors en la indexació d'àudio"
+
+#: ../src/preferences.cpp:403
+msgid "Always index all audio tracks"
+msgstr "Indexa sempre totes les pistes d'àudio"
+
+#: ../src/preferences.cpp:408
+msgid "Portaudio device"
+msgstr "Dispositiu Portaudio"
+
+#: ../src/preferences.cpp:413
+msgid "OSS Device"
+msgstr "Dispositiu OSS"
+
+#: ../src/preferences.cpp:418
+msgid "Buffer latency"
+msgstr "Latència de la memòria intermèdia"
+
+#: ../src/preferences.cpp:419
+msgid "Buffer length"
+msgstr "Llargada de la memòria intermèdia"
+
+#: ../src/preferences.cpp:432
+msgid "Video provider"
+msgstr "Proveïdor del vídeo"
+
+#: ../src/preferences.cpp:435
+msgid "Subtitles provider"
+msgstr "Proveïdor de subtítols"
+
+#: ../src/preferences.cpp:439
+msgid "Allow pre-2.56a Avisynth"
+msgstr "Permet l'Avisynth anterior a 2.56a"
+
+#: ../src/preferences.cpp:441
+msgid "Avisynth memory limit"
+msgstr "Límit de memòria de l'Avisynth"
+
+#: ../src/preferences.cpp:449
+msgid "Debug log verbosity"
+msgstr "Loquacitat del registre de depuració"
+
+#: ../src/preferences.cpp:451
+msgid "Decoding threads"
+msgstr "Fils de descodificació"
+
+#: ../src/preferences.cpp:452
+msgid "Enable unsafe seeking"
+msgstr "Activa el desplaçament insegur"
+
+#: ../src/preferences.cpp:581
+msgid "Hotkeys"
+msgstr "Dreceres del teclat"
+
+#: ../src/preferences.cpp:585 ../src/dialog_style_manager.cpp:203
+msgid "&New"
+msgstr "&Nou"
+
+#: ../src/preferences.cpp:586 ../src/dialog_style_manager.cpp:204
+msgid "&Edit"
+msgstr "&Edita"
+
+#: ../src/preferences.cpp:587 ../src/dialog_style_manager.cpp:206
+#: ../src/dialog_attachments.cpp:79
+msgid "&Delete"
+msgstr "&Suprimeix"
+
+#: ../src/preferences.cpp:680
+msgid ""
+"Are you sure that you want to restore the defaults? All your settings will "
+"be overridden."
+msgstr ""
+"Esteu segur que voleu restaurar els valors per defecte? Tota la configuració "
+"se sobreescriurà."
+
+#: ../src/preferences.cpp:680
+msgid "Restore defaults?"
+msgstr "Voleu restaurar els valors per defecte?"
+
+#: ../src/preferences.cpp:698
+msgid "Preferences"
+msgstr "Preferències"
+
+#: ../src/preferences.cpp:726
+msgid "&Restore Defaults"
+msgstr "&Restableix els valors per defecte"
 
 #: ../src/export_fixstyle.cpp:46
 msgid "Fix Styles"
-msgstr "Arregla els estils"
+msgstr "Corregeix els estils"
 
 #: ../src/export_fixstyle.cpp:46
 msgid ""
 "Fixes styles by replacing any style that isn't available on file with "
 "Default."
 msgstr ""
-"Arregla els estils substituint qualsevol estil que no estigui disponible al "
-"fitxer per Default."
+"Corregeix els estils substituint qualsevol estil que no estigui disponible "
+"al fitxer per Default."
 
-#: ../src/audio_karaoke.cpp:72
-msgid "Discard all uncommitted splits"
-msgstr "Descarta totes les divisions no aplicades"
+#: ../src/dialog_text_import.cpp:47
+msgid "Text import options"
+msgstr "Opcions d'importació de text"
 
-#: ../src/audio_karaoke.cpp:76
-msgid "Commit splits"
-msgstr "Aplica les divisions"
+#: ../src/dialog_text_import.cpp:54
+msgid "Actor separator:"
+msgstr "Separador d'actor:"
 
-#: ../src/audio_karaoke.cpp:239
-msgid "Karaoke tag"
-msgstr "Etiqueta de karaoke"
+#: ../src/dialog_text_import.cpp:56
+msgid "Comment starter:"
+msgstr "Inici dels comentaris:"
 
-#: ../src/audio_karaoke.cpp:242
-msgid "Change karaoke tag to \\k"
-msgstr "Canvia l'etiqueta del karaoke a \\k"
+#: ../src/dialog_text_import.cpp:61
+msgid "Include blank lines"
+msgstr "Inclou les línies en blanc"
 
-#: ../src/audio_karaoke.cpp:243
-msgid "Change karaoke tag to \\kf"
-msgstr "Canvia l'etiqueta del karaoke a \\kf"
-
-#: ../src/audio_karaoke.cpp:244
-msgid "Change karaoke tag to \\ko"
-msgstr "Canvia l'etiqueta del karaoke a \\ko"
-
-#: ../src/audio_karaoke.cpp:418
-msgid "karaoke split"
-msgstr "la divisió de karaoke"
-
-#: ../src/timeedit_ctrl.cpp:208 ../src/dialog_style_manager.cpp:204
-#: ../src/subs_edit_ctrl.cpp:366
-msgid "&Copy"
-msgstr "&Copia"
-
-#: ../src/timeedit_ctrl.cpp:209 ../src/subs_edit_ctrl.cpp:367
-msgid "&Paste"
-msgstr "Engan&xa"
-
-#: ../src/auto4_base.cpp:460
+#: ../src/subtitle_format.cpp:102
 #, c-format
-msgid ""
-"Failed to load Automation script '%s':\n"
-"%s"
-msgstr ""
-"No s'ha pogut carregar l'script d'automatització '%s':\n"
-"%s"
+msgid "From video (%g)"
+msgstr "Del vídeo (%g)"
 
-#: ../src/auto4_base.cpp:467
-#, c-format
-msgid "The file was not recognised as an Automation script: %s"
-msgstr "El fitxer no s'ha reconegut com a script d'automatització: %s"
+#: ../src/subtitle_format.cpp:104
+msgid "From video (VFR)"
+msgstr "Del vídeo (VFR)"
 
-#: ../src/auto4_base.cpp:496 ../src/command/timecode.cpp:74
-#: ../src/command/timecode.cpp:94 ../src/command/video.cpp:568
-#: ../src/command/audio.cpp:84 ../src/command/keyframe.cpp:74
-msgid "All Files"
-msgstr "Tots els fitxers"
+#: ../src/subtitle_format.cpp:110
+msgid "15.000 FPS"
+msgstr "15.000 FPS"
 
-#: ../src/auto4_base.cpp:502 ../src/command/timecode.cpp:74
-#: ../src/command/timecode.cpp:94 ../src/command/keyframe.cpp:74
-#: ../src/subtitle_format.cpp:312
+#: ../src/subtitle_format.cpp:111
+msgid "23.976 FPS (Decimated NTSC)"
+msgstr "23.976 FPS (NTSC decimat)"
+
+#: ../src/subtitle_format.cpp:112
+msgid "24.000 FPS (FILM)"
+msgstr "24.000 FPS (FILM)"
+
+#: ../src/subtitle_format.cpp:113
+msgid "25.000 FPS (PAL)"
+msgstr "25.000 FPS (PAL)"
+
+#: ../src/subtitle_format.cpp:114
+msgid "29.970 FPS (NTSC)"
+msgstr "29.970 FPS (NTSC)"
+
+#: ../src/subtitle_format.cpp:116
+msgid "29.970 FPS (NTSC with SMPTE dropframe)"
+msgstr "29.970 FPS (NTSC amb caiguda de fotogrames SMPTE)"
+
+#: ../src/subtitle_format.cpp:117
+msgid "30.000 FPS"
+msgstr "30.000 FPS"
+
+#: ../src/subtitle_format.cpp:118
+msgid "50.000 FPS (PAL x2)"
+msgstr "50.000 FPS (PAL x2)"
+
+#: ../src/subtitle_format.cpp:119
+msgid "59.940 FPS (NTSC x2)"
+msgstr "59.940 FPS (NTSC x2)"
+
+#: ../src/subtitle_format.cpp:120
+msgid "60.000 FPS"
+msgstr "60.000 FPS"
+
+#: ../src/subtitle_format.cpp:121
+msgid "119.880 FPS (NTSC x4)"
+msgstr "119.880 FPS (NTSC x4)"
+
+#: ../src/subtitle_format.cpp:122
+msgid "120.000 FPS"
+msgstr "120.000 FPS"
+
+#: ../src/subtitle_format.cpp:126
+msgid "Please choose the appropriate FPS for the subtitles:"
+msgstr "Trieu els FPS apropiats per als subtítols:"
+
+#: ../src/subtitle_format.cpp:126
+msgid "FPS"
+msgstr "FPS"
+
+#: ../src/subtitle_format.cpp:315 ../src/auto4_base.cpp:499
+#: ../src/command/keyframe.cpp:75 ../src/command/timecode.cpp:74
+#: ../src/command/timecode.cpp:94
 msgid "All Supported Formats"
-msgstr "Tots els formats suportats"
+msgstr "Tots els formats admesos"
 
-#: ../src/auto4_base.cpp:508
-msgid "File was not recognized as a script"
-msgstr "El fitxer no s'ha reconegut com a script"
+#: ../src/dialog_export.cpp:102
+msgid "Export"
+msgstr "Exporta"
 
-#: ../src/search_replace_engine.cpp:247 ../src/search_replace_engine.cpp:331
-msgid "replace"
-msgstr "la substitució"
+#: ../src/dialog_export.cpp:122
+msgid "Move &Up"
+msgstr "Mou am&unt"
 
-#: ../src/search_replace_engine.cpp:332
-#, c-format
-msgid "One match was replaced."
-msgid_plural "%d matches were replaced."
-msgstr[0] "S'ha substituït una coincidència."
-msgstr[1] "S'han substituït %d coincidències."
+#: ../src/dialog_export.cpp:123
+msgid "Move &Down"
+msgstr "Mou a&vall"
 
-#: ../src/search_replace_engine.cpp:335
-msgid "No matches found."
-msgstr "No s'han trobat coincidències."
+#: ../src/dialog_export.cpp:124 ../src/command/subtitle.cpp:396
+#: ../src/subs_edit_ctrl.cpp:391 ../src/dialog_selected_choices.cpp:26
+msgid "Select &All"
+msgstr "Seleccion&a-ho tot"
 
-#: ../src/visual_tool_drag.cpp:56
-msgid "Toggle between \\move and \\pos"
-msgstr "Canvia entre \\move i \\pos"
+#: ../src/dialog_export.cpp:125 ../src/dialog_selected_choices.cpp:33
+msgid "Select &None"
+msgstr "&No seleccionis res"
 
-#: ../src/visual_tool_drag.cpp:326 ../src/visual_tool_cross.cpp:62
-msgid "positioning"
-msgstr "el posicionament"
+#: ../src/dialog_export.cpp:141
+msgid "Text encoding:"
+msgstr "Codificació del text:"
 
-#: ../src/font_file_lister_fontconfig.cpp:80
-msgid "Updating font cache\n"
-msgstr "S'està actualitzant la memòria cau de tipus de lletra\n"
+#: ../src/dialog_export.cpp:149
+msgid "Filters"
+msgstr "Filtres"
 
-#: ../src/subtitle_format_ebu3264.cpp:408
-#, c-format
-msgid "Line over maximum length: %s"
-msgstr "Línia per sobre de la llargada màxima: %s"
+#: ../src/dialog_export.cpp:156
+msgid "Export..."
+msgstr "Exporta..."
 
-#: ../src/dialog_video_details.cpp:44
-msgid "Video Details"
-msgstr "Detalls del vídeo"
-
-#: ../src/dialog_video_details.cpp:58
-msgid "File name:"
-msgstr "Nom del fitxer:"
-
-#: ../src/dialog_video_details.cpp:59
-msgid "FPS:"
-msgstr "FPS:"
-
-#: ../src/dialog_video_details.cpp:60
-msgid "Resolution:"
-msgstr "Resolució:"
-
-#: ../src/dialog_video_details.cpp:61
-msgid "Length:"
-msgstr "Durada:"
-
-#: ../src/dialog_video_details.cpp:61
-#, c-format
-msgid "1 frame"
-msgid_plural "%d frames (%s)"
-msgstr[0] "1 fotograma"
-msgstr[1] "%d fotogrames (%s)"
-
-#: ../src/dialog_video_details.cpp:63
-msgid "Decoder:"
-msgstr "Descodificador: "
-
-#: ../src/dialog_video_details.cpp:65 ../src/preferences.cpp:165
-#: ../src/preferences.cpp:417
-msgid "Video"
-msgstr "Vídeo"
+#: ../src/dialog_export.cpp:188
+msgid "Export subtitles file"
+msgstr "Exporta el fitxer de subtítols"
 
 #: ../src/dialog_timing_processor.cpp:139 ../src/command/tool.cpp:189
 msgid "Timing Post-Processor"
@@ -330,13 +983,7 @@ msgstr "Ca&p"
 
 #: ../src/dialog_timing_processor.cpp:165
 msgid "Deselect all styles"
-msgstr "Deselecciona tots els estils"
-
-#: ../src/dialog_timing_processor.cpp:168 ../src/command/app.cpp:207
-#: ../src/dialog_properties.cpp:138 ../src/preferences.cpp:127
-#: ../src/preferences.cpp:167
-msgid "Options"
-msgstr "Opcions"
+msgstr "Desselecciona tots els estils"
 
 #: ../src/dialog_timing_processor.cpp:169
 msgid "Affect &selection only"
@@ -352,7 +999,7 @@ msgstr "Afegeix temps d'&entrada:"
 
 #: ../src/dialog_timing_processor.cpp:178
 msgid "Enable adding of lead-ins to lines"
-msgstr "Activa l'afegit de temps d'entrada a les línies"
+msgstr "Activa l'addició de temps d'entrada a les línies"
 
 #: ../src/dialog_timing_processor.cpp:179
 msgid "Lead in to be added, in milliseconds"
@@ -364,7 +1011,7 @@ msgstr "Afegeix temps de &sortida:"
 
 #: ../src/dialog_timing_processor.cpp:183
 msgid "Enable adding of lead-outs to lines"
-msgstr "Activa l'afegit de temps de sortida a les línies"
+msgstr "Activa l'addició de temps de sortida a les línies"
 
 #: ../src/dialog_timing_processor.cpp:184
 msgid "Lead out to be added, in milliseconds"
@@ -400,14 +1047,14 @@ msgstr ""
 
 #: ../src/dialog_timing_processor.cpp:197
 msgid "Max overlap:"
-msgstr "Sobreposició màxima:"
+msgstr "Superposició màxima:"
 
 #: ../src/dialog_timing_processor.cpp:198
 msgid ""
 "Maximum overlap between the end and start time for two subtitles to be made "
 "continuous, in milliseconds"
 msgstr ""
-"Sobreposició màxima entre el temps de final i inici de dos subtítols perquè "
+"Superposició màxima entre el temps de final i inici de dos subtítols perquè "
 "es facin continus, en mil·lisegons"
 
 #: ../src/dialog_timing_processor.cpp:201
@@ -447,51 +1094,52 @@ msgstr ""
 
 #: ../src/dialog_timing_processor.cpp:229
 msgid "Starts before thres.:"
-msgstr "Valor si comença abans:"
+msgstr "Llindar si comença abans:"
 
 #: ../src/dialog_timing_processor.cpp:230
 msgid ""
 "Threshold for 'before start' distance, that is, how many milliseconds a "
 "subtitle must start before a keyframe to snap to it"
 msgstr ""
-"Valor per a la distància 'si comença abans', és a dir, quants segons abans "
-"d'un fotograma clau ha de començar un subtítol per enganxar-s'hi"
+"Llindar per a la distància 'si comença abans', és a dir, quants mil·lisegons "
+"abans d'un fotograma clau ha de començar un subtítol per a enganxar-s'hi"
 
 #: ../src/dialog_timing_processor.cpp:232
 msgid "Starts after thres.:"
-msgstr "Valor si comença després:"
+msgstr "Llindar si comença després:"
 
 #: ../src/dialog_timing_processor.cpp:233
 msgid ""
 "Threshold for 'after start' distance, that is, how many milliseconds a "
 "subtitle must start after a keyframe to snap to it"
 msgstr ""
-"Valor per a la distància 'si acaba després', és a dir, quants segons després "
-"d'un fotograma clau ha de començar un subtítol per enganxar-s'hi"
+"Llindar per a la distància 'si comença després', és a dir, quants "
+"mil·lisegons després d'un fotograma clau ha de començar un subtítol per a "
+"enganxar-s'hi"
 
 #: ../src/dialog_timing_processor.cpp:237
 msgid "Ends before thres.:"
-msgstr "Valor si acaba abans:"
+msgstr "Llindar si acaba abans:"
 
 #: ../src/dialog_timing_processor.cpp:238
 msgid ""
 "Threshold for 'before end' distance, that is, how many milliseconds a "
 "subtitle must end before a keyframe to snap to it"
 msgstr ""
-"Valor per a la distància 'si acaba abans', és a dir, quants segons abans "
-"d'un fotograma clau ha d'acabar un subtítol per enganxar-s'hi"
+"Llindar per a la distància 'si acaba abans', és a dir, quants mil·lisegons "
+"abans d'un fotograma clau ha d'acabar un subtítol per a enganxar-s'hi"
 
 #: ../src/dialog_timing_processor.cpp:240
 msgid "Ends after thres.:"
-msgstr "Valor si acaba després:"
+msgstr "Llindar si acaba després:"
 
 #: ../src/dialog_timing_processor.cpp:241
 msgid ""
 "Threshold for 'after end' distance, that is, how many milliseconds a "
 "subtitle must end after a keyframe to snap to it"
 msgstr ""
-"Valor per a la distància 'si acaba després', és a dir, quants segons després "
-"d'un fotograma clau ha d'acabar un subtítol per enganxar-s'hi"
+"Llindar per a la distància 'si acaba després', és a dir, quants mil·lisegons "
+"després d'un fotograma clau ha d'acabar un subtítol per a enganxar-s'hi"
 
 #: ../src/dialog_timing_processor.cpp:349
 #, c-format
@@ -506,248 +1154,520 @@ msgstr "Script invàlid"
 msgid "timing processor"
 msgstr "el processador de temps"
 
-#: ../src/mkv_wrap.cpp:213
-msgid "Choose which track to read:"
-msgstr "Escolliu quina pista voleu llegir:"
+#: ../src/auto4_base.cpp:457
+#, c-format
+msgid ""
+"Failed to load Automation script '%s':\n"
+"%s"
+msgstr ""
+"No s'ha pogut carregar l'script d'automatització '%s':\n"
+"%s"
 
-#: ../src/mkv_wrap.cpp:213
-msgid "Multiple subtitle tracks found"
-msgstr "S'han trobat múltiples pistes de subtítols"
+#: ../src/auto4_base.cpp:464
+#, c-format
+msgid "The file was not recognised as an Automation script: %s"
+msgstr "No s'ha reconegut el fitxer com a script d'automatització: %s"
 
-#: ../src/mkv_wrap.cpp:251
-msgid "Parsing Matroska"
-msgstr "S'està analitzant el fitxer Matroska"
+#: ../src/auto4_base.cpp:493 ../src/command/keyframe.cpp:77
+#: ../src/command/video.cpp:568 ../src/command/timecode.cpp:74
+#: ../src/command/timecode.cpp:94 ../src/command/audio.cpp:85
+msgid "All Files"
+msgstr "Tots els fitxers"
 
-#: ../src/mkv_wrap.cpp:251
-msgid "Reading subtitles from Matroska file."
-msgstr "S'estan llegint els subtítols del fitxer Matroska."
+#: ../src/auto4_base.cpp:505
+msgid "File was not recognized as a script"
+msgstr "El fitxer no s'ha reconegut com a script"
 
-#: ../src/dialog_styling_assistant.cpp:55 ../src/command/tool.cpp:123
-msgid "Styling Assistant"
-msgstr "Auxiliar d'estils"
+#: ../src/dialog_automation.cpp:106
+msgid "Automation Manager"
+msgstr "Gestor de l'automatització"
 
-#: ../src/dialog_styling_assistant.cpp:65
-#: ../src/dialog_styling_assistant.cpp:66
-msgid "Current line"
-msgstr "Línia actual"
+#: ../src/dialog_automation.cpp:117
+msgid "&Add"
+msgstr "&Afegeix"
 
-#: ../src/dialog_styling_assistant.cpp:72
-msgid "Styles available"
-msgstr "Estils disponibles"
+#: ../src/dialog_automation.cpp:118
+msgid "&Remove"
+msgstr "Sup&rimeix"
 
-#: ../src/dialog_styling_assistant.cpp:80
-msgid "Set style"
-msgstr "Defineix l'estil"
+#: ../src/dialog_automation.cpp:119
+msgid "Re&load"
+msgstr "Recarre&ga"
 
-#: ../src/dialog_styling_assistant.cpp:87 ../src/dialog_translation.cpp:108
-msgid "Keys"
-msgstr "Tecles"
+#: ../src/dialog_automation.cpp:120
+msgid "Show &Info"
+msgstr "Mostra la &informació"
 
-#: ../src/dialog_styling_assistant.cpp:90 ../src/command/tool.cpp:142
-#: ../src/command/tool.cpp:226 ../src/dialog_translation.cpp:111
-msgid "Accept changes"
-msgstr "Accepta els canvis"
+#: ../src/dialog_automation.cpp:121
+msgid "Re&scan Autoload Dir"
+msgstr "Ree&scaneja el directori de càrrega automàtica"
 
-#: ../src/dialog_styling_assistant.cpp:91 ../src/command/tool.cpp:153
-#: ../src/command/tool.cpp:237 ../src/dialog_translation.cpp:112
-msgid "Preview changes"
-msgstr "Previsualitza els canvis"
+#: ../src/dialog_automation.cpp:122 ../src/dialog_attachments.cpp:89
+#: ../src/dialog_version_check.cpp:125 ../src/dialog_kara_timing_copy.cpp:504
+msgid "&Close"
+msgstr "Tan&ca"
 
-#: ../src/dialog_styling_assistant.cpp:92 ../src/dialog_translation.cpp:113
-msgid "Previous line"
-msgstr "Línia anterior"
+#: ../src/dialog_automation.cpp:134
+msgid "Name"
+msgstr "Nom"
 
-#: ../src/dialog_styling_assistant.cpp:93 ../src/dialog_translation.cpp:114
-msgid "Next line"
-msgstr "Línia següent"
+#: ../src/dialog_automation.cpp:135
+msgid "Filename"
+msgstr "Nom del fitxer"
 
-#: ../src/dialog_styling_assistant.cpp:94 ../src/dialog_translation.cpp:116
-msgid "Play video"
-msgstr "Reprodueix el vídeo"
+#: ../src/dialog_automation.cpp:136
+msgid "Description"
+msgstr "Descripció"
 
-#: ../src/dialog_styling_assistant.cpp:95 ../src/dialog_translation.cpp:117
-msgid "Play audio"
-msgstr "Reprodueix l'àudio"
+#: ../src/dialog_automation.cpp:222
+msgid "Add Automation script"
+msgstr "Afegeix un script d'automatització"
 
-#: ../src/dialog_styling_assistant.cpp:96
-msgid "Click on list"
-msgstr "Clic a la llista"
+#: ../src/dialog_automation.cpp:277
+#, c-format
+msgid ""
+"Total scripts loaded: %d\n"
+"Global scripts loaded: %d\n"
+"Local scripts loaded: %d\n"
+msgstr ""
+"Total d'scripts carregats: %d\n"
+"Scripts globals carregats: %d\n"
+"Scripts locals carregats: %d\n"
 
-#: ../src/dialog_styling_assistant.cpp:97
-msgid "Select style"
-msgstr "Selecciona l'estil"
+#: ../src/dialog_automation.cpp:282
+msgid "Scripting engines installed:"
+msgstr "Motors d'scripts instal·lats:"
 
-#: ../src/dialog_styling_assistant.cpp:101
-msgid "&Seek video to line start time"
-msgstr "&Mou el vídeo al temps d'inici de la línia"
+#: ../src/dialog_automation.cpp:295
+msgid "Correctly loaded"
+msgstr "S'ha carregat correctament"
 
-#: ../src/dialog_styling_assistant.cpp:110 ../src/dialog_translation.cpp:129
-msgid "Actions"
-msgstr "Accions"
+#: ../src/dialog_automation.cpp:295
+msgid "Failed to load"
+msgstr "No s'ha pogut carregar"
 
-#: ../src/dialog_styling_assistant.cpp:113 ../src/dialog_translation.cpp:131
-msgid "Play &Audio"
-msgstr "Reprodueix l'à&udio"
+#: ../src/dialog_automation.cpp:289
+#, c-format
+msgid ""
+"\n"
+"Script info:\n"
+"Name: %s\n"
+"Description: %s\n"
+"Author: %s\n"
+"Version: %s\n"
+"Full path: %s\n"
+"State: %s\n"
+"\n"
+"Features provided by script:"
+msgstr ""
+"\n"
+"Informació de l'script:\n"
+"Nom: %s\n"
+"Descripció: %s\n"
+"Autor: %s\n"
+"Versió: %s\n"
+"Camí complet: %s\n"
+"Estat: %s\n"
+"\n"
+"Característiques proporcionades per l'script:"
 
-#: ../src/dialog_styling_assistant.cpp:117 ../src/dialog_translation.cpp:136
-msgid "Play &Video"
-msgstr "Reprodueix el &vídeo"
+#: ../src/dialog_automation.cpp:298
+#, c-format
+msgid "    Macro: %s (%s)"
+msgstr "    Macro: %s (%s)"
 
-#: ../src/dialog_styling_assistant.cpp:175
-msgid "styling assistant"
-msgstr "l'auxiliar d'estils"
+#: ../src/dialog_automation.cpp:301
+#, c-format
+msgid "    Export filter: %s"
+msgstr "    Filtre d'exportació: %s"
 
-#: ../src/audio_timing_karaoke.cpp:241
-msgid "karaoke timing"
-msgstr "el temps de karaoke"
+#: ../src/dialog_automation.cpp:305
+msgid "Automation Script Info"
+msgstr "Informació de l'script d'automatització"
 
-#: ../src/dialog_jumpto.cpp:66 ../src/command/video.cpp:523
-msgid "Jump to"
-msgstr "Salta a"
+#: ../src/dialog_search_replace.cpp:46
+msgid "Replace"
+msgstr "Substitueix"
 
-#: ../src/dialog_jumpto.cpp:72
-msgid "Frame: "
-msgstr "Fotograma:"
+#: ../src/dialog_search_replace.cpp:46 ../src/command/subtitle.cpp:94
+msgid "Find"
+msgstr "Cerca"
 
-#: ../src/dialog_jumpto.cpp:73
-msgid "Time: "
-msgstr "Temps:"
+#: ../src/dialog_search_replace.cpp:67
+msgid "Find what:"
+msgstr "Cerca això:"
 
-#: ../src/dialog_style_manager.cpp:188
+#: ../src/dialog_search_replace.cpp:73 ../src/dialog_spellchecker.cpp:127
+msgid "Replace with:"
+msgstr "Substitueix-ho per:"
+
+#: ../src/dialog_search_replace.cpp:78
+msgid "&Match case"
+msgstr "Distingeix entre &majúscules i minúscules"
+
+#: ../src/dialog_search_replace.cpp:79
+msgid "&Use regular expressions"
+msgstr "&Utilitza expressions regulars"
+
+#: ../src/dialog_search_replace.cpp:80 ../src/dialog_spellchecker.cpp:182
+msgid "&Skip Comments"
+msgstr "&Omet els comentaris"
+
+#: ../src/dialog_search_replace.cpp:81
+msgid "S&kip Override Tags"
+msgstr "O&met les etiquetes d'estil"
+
+#: ../src/dialog_search_replace.cpp:87 ../src/dialog_selection.cpp:137
+msgid "&Text"
+msgstr "&Text"
+
+#: ../src/dialog_search_replace.cpp:87
+msgid "St&yle"
+msgstr "Est&il"
+
+#: ../src/dialog_search_replace.cpp:87
+msgid "A&ctor"
+msgstr "A&ctor"
+
+#: ../src/dialog_search_replace.cpp:87 ../src/command/grid.cpp:133
+#: ../src/command/grid.cpp:145
+msgid "&Effect"
+msgstr "&Efecte"
+
+#: ../src/dialog_search_replace.cpp:88
+msgid "A&ll rows"
+msgstr "&Totes les línies"
+
+#: ../src/dialog_search_replace.cpp:88 ../src/dialog_shift_times.cpp:164
+msgid "Selected &rows"
+msgstr "Les línies &seleccionades"
+
+#: ../src/dialog_search_replace.cpp:90 ../src/dialog_selection.cpp:138
+msgid "In Field"
+msgstr "Al camp"
+
+#: ../src/dialog_search_replace.cpp:91
+msgid "Limit to"
+msgstr "Limita a"
+
+#: ../src/dialog_search_replace.cpp:93
+msgid "&Find next"
+msgstr "C&erca el següent"
+
+#: ../src/dialog_search_replace.cpp:94
+msgid "Replace &next"
+msgstr "&Substitueix el següent"
+
+#: ../src/dialog_search_replace.cpp:95 ../src/dialog_spellchecker.cpp:190
+msgid "Replace &all"
+msgstr "Substitueix-ho &tot"
+
+#: ../src/search_replace_engine.cpp:189 ../src/search_replace_engine.cpp:273
+msgid "replace"
+msgstr "la substitució"
+
+#: ../src/search_replace_engine.cpp:274
+#, c-format
+msgid "One match was replaced."
+msgid_plural "%d matches were replaced."
+msgstr[0] "S'ha substituït una coincidència."
+msgstr[1] "S'han substituït %d coincidències."
+
+#: ../src/search_replace_engine.cpp:277
+msgid "No matches found."
+msgstr "No s'ha trobat cap coincidència."
+
+#: ../src/dialog_detached_video.cpp:66 ../src/dialog_detached_video.cpp:134
+#, c-format
+msgid "Video: %s"
+msgstr "Vídeo: %s"
+
+#: ../src/dialog_fonts_collector.cpp:109
+msgid "Symlinking fonts to folder...\n"
+msgstr "S'estan enllaçant simbòlicament els tipus de lletra a la carpeta...\n"
+
+#: ../src/dialog_fonts_collector.cpp:113
+msgid "Copying fonts to folder...\n"
+msgstr "S'estan copiant els tipus de lletra a la carpeta...\n"
+
+#: ../src/dialog_fonts_collector.cpp:116
+msgid "Copying fonts to archive...\n"
+msgstr "S'estan copiant els tipus de lletra a l'arxiu...\n"
+
+#: ../src/dialog_fonts_collector.cpp:128
+#, c-format
+msgid "* Failed to create directory '%s': %s.\n"
+msgstr "* No s'ha pogut crear el directori '%s': %s.\n"
+
+#: ../src/dialog_fonts_collector.cpp:139
+#, c-format
+msgid "* Failed to open %s.\n"
+msgstr "* No s'ha pogut obrir %s.\n"
+
+#: ../src/dialog_fonts_collector.cpp:194
+#, c-format
+msgid "* Copied %s.\n"
+msgstr "* S'ha copiat %s.\n"
+
+#: ../src/dialog_fonts_collector.cpp:196
+#, c-format
+msgid "* %s already exists on destination.\n"
+msgstr "* %s ja existeix a la destinació.\n"
+
+#: ../src/dialog_fonts_collector.cpp:198
+#, c-format
+msgid "* Symlinked %s.\n"
+msgstr "* S'ha enllaçat simbòlicament %s.\n"
+
+#: ../src/dialog_fonts_collector.cpp:200
+#, c-format
+msgid "* Failed to copy %s.\n"
+msgstr "* No s'ha pogut copiar %s.\n"
+
+#: ../src/dialog_fonts_collector.cpp:206
+msgid "Done. All fonts copied."
+msgstr "Fet. S'han copiat tots els tipus de lletra."
+
+#: ../src/dialog_fonts_collector.cpp:208
+msgid "Done. Some fonts could not be copied."
+msgstr "Fet. No s'han pogut copiar alguns tipus de lletra."
+
+#: ../src/dialog_fonts_collector.cpp:211
+msgid ""
+"\n"
+"Over 32 MB of fonts were copied. Some of the fonts may not be loaded by the "
+"player if they are all attached to a Matroska file."
+msgstr ""
+"\n"
+"S'han copiat més de 32 MB de tipus de lletra. És possible que el reproductor "
+"no carregui alguns dels tipus de lletra si els adjunteu tots en un fitxer "
+"Matroska."
+
+#: ../src/dialog_fonts_collector.cpp:220 ../src/command/tool.cpp:84
+msgid "Fonts Collector"
+msgstr "Recol·lector de tipus de lletra"
+
+#: ../src/dialog_fonts_collector.cpp:227
+msgid "Check fonts for availability"
+msgstr "Comprova la disponibilitat dels tipus de lletra"
+
+#: ../src/dialog_fonts_collector.cpp:228
+msgid "Copy fonts to folder"
+msgstr "Copia els tipus de lletra a una carpeta"
+
+#: ../src/dialog_fonts_collector.cpp:229
+msgid "Copy fonts to subtitle file's folder"
+msgstr "Copia els tipus de lletra a la carpeta del fitxer de subtítols"
+
+#: ../src/dialog_fonts_collector.cpp:230
+msgid "Copy fonts to zipped archive"
+msgstr "Copia els tipus de lletra a un arxiu zip"
+
+#: ../src/dialog_fonts_collector.cpp:232
+msgid "Symlink fonts to folder"
+msgstr "Enllaça simbòlicament els tipus de lletra a la carpeta"
+
+#: ../src/dialog_fonts_collector.cpp:237 ../src/dialog_selection.cpp:150
+msgid "Action"
+msgstr "Acció"
+
+#: ../src/dialog_fonts_collector.cpp:243
+msgid "Destination"
+msgstr "Destinació"
+
+#: ../src/dialog_fonts_collector.cpp:247
+msgid "&Browse..."
+msgstr "Na&vega..."
+
+#: ../src/dialog_fonts_collector.cpp:256
+msgid "Log"
+msgstr "Registre"
+
+#: ../src/dialog_fonts_collector.cpp:269
+msgid "&Start!"
+msgstr "C&omença!"
+
+#: ../src/dialog_fonts_collector.cpp:303
+msgid "Invalid destination."
+msgstr "Destinació invàlida."
+
+#: ../src/dialog_fonts_collector.cpp:308
+msgid "Could not create destination folder."
+msgstr "No s'ha pogut crear la carpeta de destinació."
+
+#: ../src/dialog_fonts_collector.cpp:313
+msgid "Invalid path for .zip file."
+msgstr "Camí invàlid per al fitxer .zip."
+
+#: ../src/dialog_fonts_collector.cpp:337
+msgid "Select archive file name"
+msgstr "Trieu el nom de fitxer de l'arxiu"
+
+#: ../src/dialog_fonts_collector.cpp:344
+msgid "Select folder to save fonts on"
+msgstr "Seleccioneu la carpeta on voleu desar els tipus de lletra"
+
+#: ../src/dialog_fonts_collector.cpp:363
+msgid "N/A"
+msgstr "N/A"
+
+#: ../src/dialog_fonts_collector.cpp:371
+msgid ""
+"Choose the folder where the fonts will be collected to. It will be created "
+"if it doesn't exist."
+msgstr ""
+"Trieu la carpeta en què es recol·lectaran els tipus de lletra. Es crearà si "
+"no existeix."
+
+#: ../src/dialog_fonts_collector.cpp:378
+msgid ""
+"Enter the name of the destination zip file to collect the fonts to. If a "
+"folder is entered, a default name will be used."
+msgstr ""
+"Introduïu el nom del fitxer zip de destinació on s'han de recol·lectar els "
+"tipus de lletra. Si introduïu una carpeta, s'utilitzarà un nom per defecte."
+
+#: ../src/charset_detect.cpp:55
+msgid ""
+"Aegisub could not narrow down the character set to a single one.\n"
+"Please pick one below:"
+msgstr ""
+"L'Aegisub no ha pogut decidir un únic joc de caràcters.\n"
+"Trieu-ne un a continuació:"
+
+#: ../src/charset_detect.cpp:56
+msgid "Choose character set"
+msgstr "Trieu la codificació"
+
+#: ../src/dialog_style_manager.cpp:189
 msgid "Move style up"
 msgstr "Mou l'estil cap amunt"
 
-#: ../src/dialog_style_manager.cpp:189
+#: ../src/dialog_style_manager.cpp:190
 msgid "Move style down"
 msgstr "Mou l'estil cap avall"
 
-#: ../src/dialog_style_manager.cpp:190
+#: ../src/dialog_style_manager.cpp:191
 msgid "Move style to top"
 msgstr "Mou l'estil a dalt de tot"
 
-#: ../src/dialog_style_manager.cpp:191
+#: ../src/dialog_style_manager.cpp:192
 msgid "Move style to bottom"
 msgstr "Mou l'estil a baix de tot"
 
-#: ../src/dialog_style_manager.cpp:192
+#: ../src/dialog_style_manager.cpp:193
 msgid "Sort styles alphabetically"
 msgstr "Ordena els estils alfabèticament"
 
-#: ../src/dialog_style_manager.cpp:202 ../src/preferences.cpp:578
-msgid "&New"
-msgstr "&Nou"
+#: ../src/dialog_style_manager.cpp:205 ../src/timeedit_ctrl.cpp:208
+#: ../src/subs_edit_ctrl.cpp:388
+msgid "&Copy"
+msgstr "&Copia"
 
-#: ../src/dialog_style_manager.cpp:203 ../src/preferences.cpp:579
-msgid "&Edit"
-msgstr "&Edita"
-
-#: ../src/dialog_style_manager.cpp:205 ../src/preferences.cpp:580
-#: ../src/dialog_attachments.cpp:79
-msgid "&Delete"
-msgstr "&Suprimeix"
-
-#: ../src/dialog_style_manager.cpp:218
+#: ../src/dialog_style_manager.cpp:219
 #, c-format
 msgid "%s - Copy"
 msgstr "%s - Còpia"
 
-#: ../src/dialog_style_manager.cpp:220
+#: ../src/dialog_style_manager.cpp:221
 #, c-format
 msgid "%s - Copy (%d)"
 msgstr "%s - Còpia (%d)"
 
-#: ../src/dialog_style_manager.cpp:243
+#: ../src/dialog_style_manager.cpp:244
 msgid "Could not parse style"
 msgstr "No s'ha pogut analitzar l'estil"
 
-#: ../src/dialog_style_manager.cpp:248
+#: ../src/dialog_style_manager.cpp:249
 #, c-format
 msgid "Are you sure you want to delete this style?"
 msgid_plural "Are you sure you want to delete these %d styles?"
 msgstr[0] "Esteu segur que voleu suprimir aquest estil?"
 msgstr[1] "Esteu segur que voleu suprimir aquests %d estils?"
 
-#: ../src/dialog_style_manager.cpp:259 ../src/command/tool.cpp:165
+#: ../src/dialog_style_manager.cpp:260 ../src/command/tool.cpp:165
 msgid "Styles Manager"
 msgstr "Gestor d'estils"
 
-#: ../src/dialog_style_manager.cpp:273
+#: ../src/dialog_style_manager.cpp:274
 msgid "Catalog of available storages"
 msgstr "Catàleg de magatzems disponibles"
 
-#: ../src/dialog_style_manager.cpp:275
+#: ../src/dialog_style_manager.cpp:276
 msgid "New"
 msgstr "Nou"
 
-#: ../src/dialog_style_manager.cpp:276
+#: ../src/dialog_style_manager.cpp:277
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: ../src/dialog_style_manager.cpp:282
+#: ../src/dialog_style_manager.cpp:283
 msgid "Copy to &current script ->"
 msgstr "C&opia a l'script actual ->"
 
-#: ../src/dialog_style_manager.cpp:289
+#: ../src/dialog_style_manager.cpp:290
 msgid "Storage"
 msgstr "Magatzem"
 
-#: ../src/dialog_style_manager.cpp:295
-msgid "&Import from script..."
-msgstr "&Importa des d'un script..."
-
 #: ../src/dialog_style_manager.cpp:296
+msgid "&Import from script..."
+msgstr "&Importa d'un script..."
+
+#: ../src/dialog_style_manager.cpp:297
 msgid "<- Copy to &storage"
 msgstr "<- Copia al magat&zem"
 
-#: ../src/dialog_style_manager.cpp:307
+#: ../src/dialog_style_manager.cpp:308
 msgid "Current script"
 msgstr "Script actual"
 
-#: ../src/dialog_style_manager.cpp:314 ../src/dialog_progress.cpp:179
+#: ../src/dialog_style_manager.cpp:315 ../src/command/subtitle.cpp:256
+#: ../src/command/subtitle.cpp:257 ../src/command/subtitle.cpp:258
+#: ../src/dialog_progress.cpp:179
 msgid "Close"
 msgstr "Tanca"
 
-#: ../src/dialog_style_manager.cpp:454
+#: ../src/dialog_style_manager.cpp:455
 msgid "New storage name:"
 msgstr "Nom del magatzem nou:"
 
-#: ../src/dialog_style_manager.cpp:454
+#: ../src/dialog_style_manager.cpp:455
 msgid "New catalog entry"
 msgstr "Nova entrada al catàleg"
 
-#: ../src/dialog_style_manager.cpp:469
+#: ../src/dialog_style_manager.cpp:470
 msgid "A catalog with that name already exists."
 msgstr "Ja existeix un catàleg amb aquest nom."
 
-#: ../src/dialog_style_manager.cpp:469
+#: ../src/dialog_style_manager.cpp:470
 msgid "Catalog name conflict"
 msgstr "Conflicte de nom de catàleg"
 
-#: ../src/dialog_style_manager.cpp:476
+#: ../src/dialog_style_manager.cpp:477
 #, c-format
 msgid ""
 "The specified catalog name contains one or more illegal characters. They "
 "have been replaced with underscores instead.\n"
 "The catalog has been renamed to \"%s\"."
 msgstr ""
-"El nom de catàleg especificat conté un o més caràcters il·legals. S'han "
-"reemplaçat per guions baixos.\n"
-"El catàleg s'ha reanomenat a \"%s\"."
+"El nom de catàleg especificat conté un o més caràcters invàlids. S'han "
+"substituït per guions baixos.\n"
+"S'ha canviat el nom del catàleg a \"%s\"."
 
-#: ../src/dialog_style_manager.cpp:477
+#: ../src/dialog_style_manager.cpp:478
 msgid "Invalid characters"
 msgstr "Caràcters invàlids"
 
-#: ../src/dialog_style_manager.cpp:490
+#: ../src/dialog_style_manager.cpp:491
 #, c-format
 msgid "Are you sure you want to delete the storage \"%s\" from the catalog?"
 msgstr "Esteu segur que voleu suprimir el magatzem \"%s\" del catàleg?"
 
-#: ../src/dialog_style_manager.cpp:491
+#: ../src/dialog_style_manager.cpp:492
 msgid "Confirm delete"
 msgstr "Confirmeu la supressió"
 
-#: ../src/dialog_style_manager.cpp:509
+#: ../src/dialog_style_manager.cpp:510
 #, c-format
 msgid ""
 "There is already a style with the name \"%s\" in the current storage. "
@@ -756,12 +1676,12 @@ msgstr ""
 "Ja hi ha un estil amb el nom \"%s\" al magatzem actual. El voleu "
 "sobreescriure?"
 
-#: ../src/dialog_style_manager.cpp:509 ../src/dialog_style_manager.cpp:536
-#: ../src/dialog_style_manager.cpp:714
+#: ../src/dialog_style_manager.cpp:510 ../src/dialog_style_manager.cpp:537
+#: ../src/dialog_style_manager.cpp:715
 msgid "Style name collision"
 msgstr "Col·lisió de nom d'estil"
 
-#: ../src/dialog_style_manager.cpp:536 ../src/dialog_style_manager.cpp:713
+#: ../src/dialog_style_manager.cpp:537 ../src/dialog_style_manager.cpp:714
 #, c-format
 msgid ""
 "There is already a style with the name \"%s\" in the current script. "
@@ -770,99 +1690,962 @@ msgstr ""
 "Ja hi ha un estil amb el nom \"%s\" a l'script actual. El voleu "
 "sobreescriure?"
 
-#: ../src/dialog_style_manager.cpp:547
+#: ../src/dialog_style_manager.cpp:548
 msgid "style copy"
 msgstr "la còpia de l'estil"
 
-#: ../src/dialog_style_manager.cpp:576
+#: ../src/dialog_style_manager.cpp:577
 msgid "style paste"
-msgstr "l'enganxat de l'estil"
+msgstr "l'enganxament de l'estil"
 
-#: ../src/dialog_style_manager.cpp:620
+#: ../src/dialog_style_manager.cpp:621
 msgid "Confirm delete from storage"
 msgstr "Confirmeu la supressió del magatzem"
 
-#: ../src/dialog_style_manager.cpp:659
+#: ../src/dialog_style_manager.cpp:660
 msgid "Confirm delete from current"
 msgstr "Confirmeu la supressió de l'actual"
 
-#: ../src/dialog_style_manager.cpp:663
+#: ../src/dialog_style_manager.cpp:664
 msgid "style delete"
 msgstr "la supressió de l'estil"
 
-#: ../src/dialog_style_manager.cpp:668 ../src/command/subtitle.cpp:240
-#: ../src/command/subtitle.cpp:270
+#: ../src/dialog_style_manager.cpp:669 ../src/command/subtitle.cpp:275
+#: ../src/command/subtitle.cpp:305
 msgid "Open subtitles file"
 msgstr "Obre el fitxer de subtítols"
 
-#: ../src/dialog_style_manager.cpp:698
+#: ../src/dialog_style_manager.cpp:699
 msgid "The selected file has no available styles."
 msgstr "El fitxer seleccionat no té cap estil disponible."
 
-#: ../src/dialog_style_manager.cpp:698
+#: ../src/dialog_style_manager.cpp:699
 msgid "Error Importing Styles"
 msgstr "S'ha produït un error en importar estils"
 
-#: ../src/dialog_style_manager.cpp:704
+#: ../src/dialog_style_manager.cpp:705
 msgid "Choose styles to import:"
-msgstr "Escolliu els estils per importar:"
+msgstr "Trieu els estils a importar:"
 
-#: ../src/dialog_style_manager.cpp:704
+#: ../src/dialog_style_manager.cpp:705
 msgid "Import Styles"
 msgstr "Importa estils"
 
-#: ../src/dialog_style_manager.cpp:730
+#: ../src/dialog_style_manager.cpp:731
 msgid "style import"
 msgstr "la importació d'estils"
 
-#: ../src/dialog_style_manager.cpp:839
+#: ../src/dialog_style_manager.cpp:840
 msgid "Are you sure? This cannot be undone!"
 msgstr "N'esteu segur? No ho podreu desfer!"
 
-#: ../src/dialog_style_manager.cpp:839
+#: ../src/dialog_style_manager.cpp:840
 msgid "Sort styles"
 msgstr "Ordena els estils"
 
-#: ../src/dialog_style_manager.cpp:880
+#: ../src/dialog_style_manager.cpp:881
 msgid "style move"
 msgstr "el moviment de l'estil"
 
-#: ../src/command/timecode.cpp:52 ../src/command/timecode.cpp:53
-msgid "Close Timecodes File"
-msgstr "Tanca el fitxer de codis de temps"
+#: ../src/audio_karaoke.cpp:72
+msgid "Discard all uncommitted splits"
+msgstr "Descarta totes les divisions no aplicades"
 
-#: ../src/command/timecode.cpp:54
-msgid "Close the currently open timecodes file"
-msgstr "Tanca el fitxer de codis de temps obert actualment"
+#: ../src/audio_karaoke.cpp:76
+msgid "Commit splits"
+msgstr "Aplica les divisions"
 
-#: ../src/command/timecode.cpp:69
-msgid "Open Timecodes File..."
-msgstr "Obre el fitxer de codis de temps..."
+#: ../src/audio_karaoke.cpp:239
+msgid "Karaoke tag"
+msgstr "Etiqueta de karaoke"
 
-#: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
-msgid "Open Timecodes File"
-msgstr "Obre el fitxer de codis de temps"
+#: ../src/audio_karaoke.cpp:242
+msgid "Change karaoke tag to \\k"
+msgstr "Canvia l'etiqueta de karaoke a \\k"
 
-#: ../src/command/timecode.cpp:71
-msgid "Open a VFR timecodes v1 or v2 file"
-msgstr "Obre el fitxer de codis de temps VFR v1 o v2"
+#: ../src/audio_karaoke.cpp:243
+msgid "Change karaoke tag to \\kf"
+msgstr "Canvia l'etiqueta de karaoke a \\kf"
 
-#: ../src/command/timecode.cpp:84
-msgid "Save Timecodes File..."
-msgstr "Desa el fitxer de codis de temps..."
+#: ../src/audio_karaoke.cpp:244
+msgid "Change karaoke tag to \\ko"
+msgstr "Canvia l'etiqueta de karaoke a \\ko"
 
-#: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
-msgid "Save Timecodes File"
-msgstr "Desa el fitxer de codis de temps"
+#: ../src/audio_karaoke.cpp:421
+msgid "karaoke split"
+msgstr "la divisió de karaoke"
 
-#: ../src/command/timecode.cpp:86
-msgid "Save a VFR timecodes v2 file"
-msgstr "Desa el fitxer de codis de temps VFR v2"
+#: ../src/dialog_video_properties.cpp:44
+msgid "Resolution mismatch"
+msgstr "Resolució no coincident"
+
+#: ../src/dialog_video_properties.cpp:46
+#, c-format
+msgid ""
+"The resolution of the loaded video and the resolution specified for the "
+"subtitles don't match.\n"
+"\n"
+"Video resolution:\t%d x %d\n"
+"Script resolution:\t%d x %d\n"
+"\n"
+"Change subtitles resolution to match video?"
+msgstr ""
+"La resolució del vídeo carregat i la resolució especificada als subtítols no "
+"coincideixen.\n"
+"\n"
+"Resolució del vídeo:\t%d x %d\n"
+"Resolució de l'script:\t%d x %d\n"
+"\n"
+"Voleu canviar la resolució dels subtítols perquè coincideixi amb la del "
+"vídeo?"
+
+#: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
+msgid "Set to video resolution"
+msgstr "Defineix a la resolució del vídeo"
+
+#: ../src/dialog_video_properties.cpp:55
+msgid "Resample script (stretch to new aspect ratio)"
+msgstr "Reajusta l'script (estira a la nova relació d'aspecte)"
+
+#: ../src/dialog_video_properties.cpp:56
+msgid "Resample script (add borders)"
+msgstr "Reajusta l'script (afegeix vores)"
+
+#: ../src/dialog_video_properties.cpp:57
+msgid "Resample script (remove borders)"
+msgstr "Reajusta l'script (elimina vores)"
+
+#: ../src/dialog_video_properties.cpp:64
+msgid "Resample script"
+msgstr "Reajusta l'script"
+
+#: ../src/dialog_video_properties.cpp:163
+msgid "change script resolution"
+msgstr "el canvi de resolució de l'script"
+
+#: ../src/dialog_attachments.cpp:68
+msgid "Attachment List"
+msgstr "Llista d'adjuncions"
+
+#: ../src/dialog_attachments.cpp:76
+msgid "Attach &Font"
+msgstr "Adjunta tipus de &lletra"
+
+#: ../src/dialog_attachments.cpp:77
+msgid "Attach &Graphics"
+msgstr "Adjunta &gràfics"
+
+#: ../src/dialog_attachments.cpp:78
+msgid "E&xtract"
+msgstr "E&xtreu"
+
+#: ../src/dialog_attachments.cpp:110
+msgid "Attachment name"
+msgstr "Nom de l'adjunció"
+
+#: ../src/dialog_attachments.cpp:111
+msgid "Size"
+msgstr "Mida"
+
+#: ../src/dialog_attachments.cpp:112
+msgid "Group"
+msgstr "Grup"
+
+#: ../src/dialog_attachments.cpp:138 ../src/dialog_attachments.cpp:147
+msgid "Choose file to be attached"
+msgstr "Trieu el fitxer que voleu adjuntar"
+
+#: ../src/dialog_attachments.cpp:142
+msgid "attach font file"
+msgstr "l'adjunció del fitxer de tipus de lletra"
+
+#: ../src/dialog_attachments.cpp:152
+msgid "attach graphics file"
+msgstr "l'adjunció del fitxer de gràfics"
+
+#: ../src/dialog_attachments.cpp:164
+msgid "Select the path to save the files to:"
+msgstr "Seleccioneu el camí on es desaran els fitxers:"
+
+#: ../src/dialog_attachments.cpp:167
+msgid "Select the path to save the file to:"
+msgstr "Seleccioneu el camí on es desarà el fitxer:"
+
+#: ../src/dialog_attachments.cpp:189
+msgid "remove attachment"
+msgstr "l'eliminació de l'adjunció"
+
+#: ../src/audio_timing_dialogue.cpp:512 ../src/audio_timing_dialogue.cpp:518
+#: ../src/command/time.cpp:177
+msgid "timing"
+msgstr "els temps"
+
+#: ../src/subs_controller.cpp:246
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Voleu desar els canvis a %s?"
+
+#: ../src/subs_controller.cpp:246
+msgid "Unsaved changes"
+msgstr "Canvis no desats"
+
+#: ../src/subs_controller.cpp:279
+#, c-format
+msgid "File backup saved as \"%s\"."
+msgstr "S'ha desat una còpia de seguretat del fitxer com a \"%s\"."
+
+#: ../src/subs_controller.cpp:404
+msgid "Untitled"
+msgstr "Sense títol"
+
+#: ../src/subs_controller.cpp:406
+msgid "untitled"
+msgstr "sense títol"
+
+#: ../src/dialog_jumpto.cpp:67 ../src/command/video.cpp:523
+msgid "Jump to"
+msgstr "Salta a"
+
+#: ../src/dialog_jumpto.cpp:73
+msgid "Frame: "
+msgstr "Fotograma: "
+
+#: ../src/dialog_jumpto.cpp:74
+msgid "Time: "
+msgstr "Temps: "
+
+#: ../src/dialog_version_check.cpp:93
+msgid "Version Checker"
+msgstr "Comprovador de versió"
+
+#: ../src/dialog_version_check.cpp:118
+msgid "&Auto Check for Updates"
+msgstr "Comprova &automàticament si hi ha actualitzacions"
+
+#: ../src/dialog_version_check.cpp:123
+msgid "Remind me again in a &week"
+msgstr "Recorda-m'ho d'aquí a una &setmana"
+
+#: ../src/dialog_version_check.cpp:287
+msgid "Could not connect to updates server."
+msgstr "No s'ha pogut connectar al servidor d'actualitzacions."
+
+#: ../src/dialog_version_check.cpp:309
+msgid "Could not download from updates server."
+msgstr "No s'ha pogut baixar del servidor d'actualitzacions."
+
+#: ../src/dialog_version_check.cpp:311
+#, c-format
+msgid "HTTP request failed, got HTTP response %d."
+msgstr "La petició HTTP ha fallat, s'ha obtingut la resposta HTTP %d."
+
+#: ../src/dialog_version_check.cpp:342
+msgid "An update to Aegisub was found."
+msgstr "S'ha trobat una actualització de l'Aegisub."
+
+#: ../src/dialog_version_check.cpp:344
+msgid "Several possible updates to Aegisub were found."
+msgstr "S'han trobat diverses possibles actualitzacions de l'Aegisub."
+
+#: ../src/dialog_version_check.cpp:346
+msgid "There are no updates to Aegisub."
+msgstr "No hi ha cap actualització de l'Aegisub."
+
+#: ../src/dialog_version_check.cpp:374
+#, c-format
+msgid ""
+"There was an error checking for updates to Aegisub:\n"
+"%s\n"
+"\n"
+"If other applications can access the Internet fine, this is probably a "
+"temporary server problem on our end."
+msgstr ""
+"S'ha produït un error en comprovar les actualitzacions de l'Aegisub:\n"
+"%s\n"
+"\n"
+"Si hi ha altres aplicacions que poden accedir correctament a Internet, "
+"probablement sigui causat per un problema temporal als nostres servidors."
+
+#: ../src/dialog_version_check.cpp:378
+msgid "An unknown error occurred while checking for updates to Aegisub."
+msgstr ""
+"S'ha produït un error desconegut en comprovar les actualitzacions de "
+"l'Aegisub."
+
+#: ../src/grid_column.cpp:105
+msgid "#"
+msgstr "N"
+
+#: ../src/grid_column.cpp:106
+msgid "Line Number"
+msgstr "Número de línia"
+
+#: ../src/grid_column.cpp:129
+msgid "L"
+msgstr "C"
+
+#: ../src/grid_column.cpp:130 ../src/dialog_paste_over.cpp:64
+#: ../src/command/grid.cpp:182 ../src/command/grid.cpp:194
+msgid "Layer"
+msgstr "Capa"
+
+#: ../src/grid_column.cpp:151
+msgid "Start"
+msgstr "Inici"
+
+#: ../src/grid_column.cpp:152 ../src/dialog_paste_over.cpp:65
+#: ../src/command/grid.cpp:206 ../src/command/grid.cpp:218
+msgid "Start Time"
+msgstr "Temps d'inici"
+
+#: ../src/grid_column.cpp:169
+msgid "End"
+msgstr "Fi"
+
+#: ../src/grid_column.cpp:170 ../src/dialog_paste_over.cpp:66
+#: ../src/command/grid.cpp:158 ../src/command/grid.cpp:170
+msgid "End Time"
+msgstr "Temps de final"
+
+#: ../src/grid_column.cpp:200 ../src/grid_column.cpp:201
+#: ../src/dialog_paste_over.cpp:67
+msgid "Style"
+msgstr "Estil"
+
+#: ../src/grid_column.cpp:214 ../src/grid_column.cpp:215
+#: ../src/dialog_paste_over.cpp:72 ../src/command/grid.cpp:134
+#: ../src/command/grid.cpp:146 ../src/subs_edit_box.cpp:144
+msgid "Effect"
+msgstr "Efecte"
+
+#: ../src/grid_column.cpp:228 ../src/grid_column.cpp:229
+#: ../src/dialog_paste_over.cpp:68 ../src/subs_edit_box.cpp:139
+msgid "Actor"
+msgstr "Actor"
+
+#: ../src/grid_column.cpp:263 ../src/dialog_style_editor.cpp:289
+msgid "Left"
+msgstr "Esq."
+
+#: ../src/grid_column.cpp:264
+msgid "Left Margin"
+msgstr "Marge esquerre"
+
+#: ../src/grid_column.cpp:269 ../src/dialog_style_editor.cpp:289
+msgid "Right"
+msgstr "Dret"
+
+#: ../src/grid_column.cpp:270
+msgid "Right Margin"
+msgstr "Marge dret"
+
+#: ../src/grid_column.cpp:275 ../src/dialog_style_editor.cpp:289
+msgid "Vert"
+msgstr "Vert."
+
+#: ../src/grid_column.cpp:276
+msgid "Vertical Margin"
+msgstr "Marge vertical"
+
+#: ../src/grid_column.cpp:294
+msgid "CPS"
+msgstr "CPS"
+
+#: ../src/grid_column.cpp:295
+msgid "Characters Per Second"
+msgstr "Caràcters per segon"
+
+#: ../src/grid_column.cpp:362 ../src/grid_column.cpp:363
+#: ../src/dialog_paste_over.cpp:73 ../src/dialog_kara_timing_copy.cpp:475
+msgid "Text"
+msgstr "Text"
+
+#: ../src/dialog_paste_over.cpp:55
+msgid "Select Fields to Paste Over"
+msgstr "Seleccioneu els camps per enganxar-hi a sobre"
+
+#: ../src/dialog_paste_over.cpp:58
+msgid "Fields"
+msgstr "Camps"
+
+#: ../src/dialog_paste_over.cpp:59
+msgid "Please select the fields that you want to paste over:"
+msgstr "Seleccioneu els camps sobre els quals voleu enganxar:"
+
+#: ../src/dialog_paste_over.cpp:63
+msgid "Comment"
+msgstr "Comenta"
+
+#: ../src/dialog_paste_over.cpp:69
+msgid "Margin Left"
+msgstr "Marge esquerre"
+
+#: ../src/dialog_paste_over.cpp:70
+msgid "Margin Right"
+msgstr "Marge dret"
+
+#: ../src/dialog_paste_over.cpp:71
+msgid "Margin Vertical"
+msgstr "Marge vertical"
+
+#: ../src/dialog_paste_over.cpp:92
+msgid "&Times"
+msgstr "&Temps"
+
+#: ../src/dialog_paste_over.cpp:94
+msgid "T&ext"
+msgstr "T&ext"
+
+#: ../src/command/vis_tool.cpp:56 ../src/command/vis_tool.cpp:57
+msgid "Standard"
+msgstr "Estàndard"
+
+#: ../src/command/vis_tool.cpp:58
+msgid "Standard mode, double click sets position"
+msgstr "Mode estàndard, el doble clic defineix la posició"
+
+#: ../src/command/vis_tool.cpp:64 ../src/command/vis_tool.cpp:65
+#: ../src/visual_tool_vector_clip.cpp:58
+msgid "Drag"
+msgstr "Arrossega"
+
+#: ../src/command/vis_tool.cpp:66
+msgid "Drag subtitles"
+msgstr "Arrossega els subtítols"
+
+#: ../src/command/vis_tool.cpp:72 ../src/command/vis_tool.cpp:73
+msgid "Rotate Z"
+msgstr "Gira en Z"
+
+#: ../src/command/vis_tool.cpp:74
+msgid "Rotate subtitles on their Z axis"
+msgstr "Gira els subtítols en l'eix Z"
+
+#: ../src/command/vis_tool.cpp:80 ../src/command/vis_tool.cpp:81
+msgid "Rotate XY"
+msgstr "Gira en XY"
+
+#: ../src/command/vis_tool.cpp:82
+msgid "Rotate subtitles on their X and Y axes"
+msgstr "Gira els subtítols en els eixos X i Y"
+
+#: ../src/command/vis_tool.cpp:88 ../src/command/vis_tool.cpp:89
+msgid "Scale"
+msgstr "Escala"
+
+#: ../src/command/vis_tool.cpp:90
+msgid "Scale subtitles on X and Y axes"
+msgstr "Escala els subtítols en els eixos X i Y"
+
+#: ../src/command/vis_tool.cpp:96 ../src/command/vis_tool.cpp:97
+msgid "Clip"
+msgstr "Retalla"
+
+#: ../src/command/vis_tool.cpp:98
+msgid "Clip subtitles to a rectangle"
+msgstr "Retalla els subtítols a un rectangle"
+
+#: ../src/command/vis_tool.cpp:104 ../src/command/vis_tool.cpp:105
+msgid "Vector Clip"
+msgstr "Retallat vectorial"
+
+#: ../src/command/vis_tool.cpp:106
+msgid "Clip subtitles to a vectorial area"
+msgstr "Retalla els subtítols a una àrea vectorial"
+
+#: ../src/command/keyframe.cpp:50 ../src/command/keyframe.cpp:51
+msgid "Close Keyframes"
+msgstr "Tanca els fotogrames clau"
+
+#: ../src/command/keyframe.cpp:52
+msgid ""
+"Discard the currently loaded keyframes and use those from the video, if any"
+msgstr ""
+"Descarta els fotogrames clau carregats actualment i utilitza els del vídeo, "
+"si n'hi ha"
+
+#: ../src/command/keyframe.cpp:67
+msgid "Open Keyframes..."
+msgstr "Obre els fotogrames clau..."
+
+#: ../src/command/keyframe.cpp:68
+msgid "Open Keyframes"
+msgstr "Obre els fotogrames clau"
+
+#: ../src/command/keyframe.cpp:69
+msgid "Open a keyframe list file"
+msgstr "Obre el fitxer amb una llista de fotogrames clau"
+
+#: ../src/command/keyframe.cpp:73
+msgid "Open keyframes file"
+msgstr "Obre el fitxer de fotogrames clau"
+
+#: ../src/command/keyframe.cpp:88
+msgid "Save Keyframes..."
+msgstr "Desa els fotogrames clau..."
+
+#: ../src/command/keyframe.cpp:89
+msgid "Save Keyframes"
+msgstr "Desa els fotogrames clau"
+
+#: ../src/command/keyframe.cpp:90
+msgid "Save the current list of keyframes to a file"
+msgstr "Desa la llista actual de fotogrames clau a un fitxer"
+
+#: ../src/command/keyframe.cpp:98
+msgid "Save keyframes file"
+msgstr "Desa el fitxer de fotogrames clau"
+
+#: ../src/command/automation.cpp:48
+msgid "&Reload Automation scripts"
+msgstr "&Recarrega els scripts d'automatització"
+
+#: ../src/command/automation.cpp:49
+msgid "Reload Automation scripts"
+msgstr "Recarrega els scripts d'automatització"
+
+#: ../src/command/automation.cpp:50
+msgid "Reload all Automation scripts and rescan the autoload folder"
+msgstr ""
+"Recarrega tots els scripts d'automatització i reescaneja la carpeta de "
+"càrrega automàtica"
+
+#: ../src/command/automation.cpp:55
+msgid "Reloaded all Automation scripts"
+msgstr "S'han recarregat tots els scripts d'automatització"
+
+#: ../src/command/automation.cpp:61
+msgid "R&eload autoload Automation scripts"
+msgstr "R&ecarrega tots els scripts d'automatització de càrrega automàtica"
+
+#: ../src/command/automation.cpp:62
+msgid "Reload autoload Automation scripts"
+msgstr "Recarrega tots els scripts d'automatització de càrrega automàtica"
+
+#: ../src/command/automation.cpp:63
+msgid "Rescan the Automation autoload folder"
+msgstr "Reescaneja la carpeta de càrrega automàtica de l'automatització"
+
+#: ../src/command/automation.cpp:67
+msgid "Reloaded autoload Automation scripts"
+msgstr "S'han recarregat els scripts d'automatització de càrrega automàtica"
+
+#: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
+msgid "&Automation..."
+msgstr "&Automatització..."
+
+#: ../src/command/automation.cpp:76
+msgid "Open automation manager"
+msgstr "Obre el gestor de l'automatització"
+
+#: ../src/command/automation.cpp:88
+msgid ""
+"Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
+"autoload folder and reload all automation scripts"
+msgstr ""
+"Obre el gestor de l'automatització. Ctrl: Reescaneja la carpeta de càrrega "
+"automàtica. Ctrl+Maj: Reescaneja la carpeta de càrrega automàtica i "
+"recarrega tots els scripts d'automatització"
+
+#: ../src/command/app.cpp:57
+msgid "&About"
+msgstr "&Quant a"
+
+#: ../src/command/app.cpp:58
+msgid "About"
+msgstr "Quant a"
+
+#: ../src/command/app.cpp:59 ../src/dialog_about.cpp:44
+msgid "About Aegisub"
+msgstr "Quant a l'Aegisub"
+
+#: ../src/command/app.cpp:68
+msgid "&Audio+Subs View"
+msgstr "Visu&alització de l'àudio i els subtítols"
+
+#: ../src/command/app.cpp:69
+msgid "Audio+Subs View"
+msgstr "Visualitzció de l'àudio i els subtítols"
+
+#: ../src/command/app.cpp:70
+msgid "Display audio and the subtitles grid only"
+msgstr "Mostra només l'àudio i la graella dels subtítols"
+
+#: ../src/command/app.cpp:88
+msgid "&Full view"
+msgstr "V&isualització completa"
+
+#: ../src/command/app.cpp:89
+msgid "Full view"
+msgstr "Visualització completa"
+
+#: ../src/command/app.cpp:90
+msgid "Display audio, video and then subtitles grid"
+msgstr "Mostra l'àudio, el vídeo i la graella dels subtítols"
+
+#: ../src/command/app.cpp:108
+msgid "S&ubs Only View"
+msgstr "Visualització només dels s&ubtítols"
+
+#: ../src/command/app.cpp:109
+msgid "Subs Only View"
+msgstr "Visualització només dels subtítols"
+
+#: ../src/command/app.cpp:110
+msgid "Display the subtitles grid only"
+msgstr "Mostra només la graella dels subtítols"
+
+#: ../src/command/app.cpp:124
+msgid "&Video+Subs View"
+msgstr "Visualització del &vídeo i els subtítols"
+
+#: ../src/command/app.cpp:125
+msgid "Video+Subs View"
+msgstr "Visualització dels vídeo i els subtítols"
+
+#: ../src/command/app.cpp:126
+msgid "Display video and the subtitles grid only"
+msgstr "Mostra només el vídeo i la graella dels subtítols"
+
+#: ../src/command/app.cpp:144
+msgid "E&xit"
+msgstr "Sur&t"
+
+#: ../src/command/app.cpp:145
+msgid "Exit"
+msgstr "Surt"
+
+#: ../src/command/app.cpp:146
+msgid "Exit the application"
+msgstr "Surt de l'aplicació"
+
+#: ../src/command/app.cpp:156
+msgid "&Language..."
+msgstr "&Llengua..."
+
+#: ../src/command/app.cpp:157
+msgid "Language"
+msgstr "Llengua"
+
+#: ../src/command/app.cpp:158
+msgid "Select Aegisub interface language"
+msgstr "Seleccioneu la llengua de la interfície de l'Aegisub"
+
+#: ../src/command/app.cpp:181
+msgid "&Log window"
+msgstr "Finestra de&l registre"
+
+#: ../src/command/app.cpp:182 ../src/dialog_log.cpp:100
+msgid "Log window"
+msgstr "Finestra del registre"
+
+#: ../src/command/app.cpp:183
+msgid "View the event log"
+msgstr "Mostra el registre d'esdeveniments"
+
+#: ../src/command/app.cpp:193
+msgid "New &Window"
+msgstr "&Finestra nova"
+
+#: ../src/command/app.cpp:194
+msgid "New Window"
+msgstr "Finestra nova"
+
+#: ../src/command/app.cpp:195
+msgid "Open a new application window"
+msgstr "Obre una nova finestra de l'aplicació"
+
+#: ../src/command/app.cpp:205
+msgid "&Options..."
+msgstr "&Opcions..."
+
+#: ../src/command/app.cpp:207
+msgid "Configure Aegisub"
+msgstr "Configura l'Aegisub"
+
+#: ../src/command/app.cpp:221 ../src/command/app.cpp:222
+msgid "Toggle global hotkey overrides"
+msgstr "Commuta els canvis a les dreceres de teclat globals"
+
+#: ../src/command/app.cpp:223
+msgid "Toggle global hotkey overrides (Medusa Mode)"
+msgstr "Commuta els canvis a les dreceres de teclat globals (mode Medusa)"
+
+#: ../src/command/app.cpp:238
+msgid "Toggle the main toolbar"
+msgstr "Commuta la barra d'eines principal"
+
+#: ../src/command/app.cpp:243
+msgid "Hide Toolbar"
+msgstr "Amaga la barra d'eines"
+
+#: ../src/command/app.cpp:244
+msgid "Show Toolbar"
+msgstr "Mostra la barra d'eines"
+
+#: ../src/command/app.cpp:259
+msgid "&Check for Updates..."
+msgstr "&Comprova si hi ha actualitzacions..."
+
+#: ../src/command/app.cpp:260
+msgid "Check for Updates"
+msgstr "Comprova si hi ha actualitzacions"
+
+#: ../src/command/app.cpp:261
+msgid "Check to see if there is a new version of Aegisub available"
+msgstr "Comprova si hi ha una nova versió de l'Aegisub disponible"
+
+#: ../src/command/app.cpp:271 ../src/command/app.cpp:272
+msgid "Minimize"
+msgstr "Minimitza"
+
+#: ../src/command/app.cpp:273
+msgid "Minimize the active window"
+msgstr "Minimitza la finestra activa"
+
+#: ../src/command/app.cpp:282 ../src/command/app.cpp:283
+msgid "Zoom"
+msgstr "Ampliació"
+
+#: ../src/command/app.cpp:284
+msgid "Maximize the active window"
+msgstr "Maximitza la finestra activa"
+
+#: ../src/command/app.cpp:293 ../src/command/app.cpp:294
+msgid "Bring All to Front"
+msgstr "Porta-ho tot al davant"
+
+#: ../src/command/app.cpp:295
+msgid "Bring forward all open documents to the front"
+msgstr "Porta tots els documents oberts al davant"
+
+#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:45
+#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:47
+#: ../src/command/recent.cpp:48 ../src/command/recent.cpp:52
+#: ../src/command/recent.cpp:53 ../src/command/recent.cpp:63
+#: ../src/command/recent.cpp:64 ../src/command/recent.cpp:74
+#: ../src/command/recent.cpp:75 ../src/command/recent.cpp:90
+#: ../src/command/recent.cpp:91 ../src/command/recent.cpp:101
+#: ../src/command/recent.cpp:102
+msgid "Recent"
+msgstr "Recents"
+
+#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:54
+msgid "Open recent audio"
+msgstr "Obre un àudio recent"
+
+#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:65
+msgid "Open recent keyframes"
+msgstr "Obre fotogrames clau recents"
+
+#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:76
+msgid "Open recent subtitles"
+msgstr "Obre subtítols recents"
+
+#: ../src/command/recent.cpp:47 ../src/command/recent.cpp:92
+msgid "Open recent timecodes"
+msgstr "Obre codis de temps recents"
+
+#: ../src/command/recent.cpp:48
+msgid "Open recent video"
+msgstr "Obre un vídeo recent"
+
+#: ../src/command/recent.cpp:103
+msgid "Open recent videos"
+msgstr "Obre vídeos recents"
 
 #: ../src/command/command.cpp:31
 #, c-format
 msgid "'%s' is not a valid command name"
 msgstr "'%s' no és un nom d'ordre vàlid"
+
+#: ../src/command/tool.cpp:58
+msgid "ASSDraw3..."
+msgstr "ASSDraw3..."
+
+#: ../src/command/tool.cpp:59
+msgid "ASSDraw3"
+msgstr "ASSDraw3"
+
+#: ../src/command/tool.cpp:60
+msgid "Launch the ASSDraw3 tool for vector drawing"
+msgstr "Llança l'eina ASSDraw3 per a dibuixos vectorials"
+
+#: ../src/command/tool.cpp:70
+msgid "&Export Subtitles..."
+msgstr "&Exporta els subtítols..."
+
+#: ../src/command/tool.cpp:71
+msgid "Export Subtitles"
+msgstr "Exporta els subtítols"
+
+#: ../src/command/tool.cpp:72
+msgid ""
+"Save a copy of subtitles in a different format or with processing applied to "
+"it"
+msgstr ""
+"Desa una còpia dels subtítols en un format diferent o aplicant-hi "
+"processament"
+
+#: ../src/command/tool.cpp:83
+msgid "&Fonts Collector..."
+msgstr "Recol·lector de tipus de &lletra..."
+
+#: ../src/command/tool.cpp:85
+msgid "Open fonts collector"
+msgstr "Obre el recol·lector de tipus de lletra"
+
+#: ../src/command/tool.cpp:95
+msgid "S&elect Lines..."
+msgstr "S&elecciona línies..."
+
+#: ../src/command/tool.cpp:96
+msgid "Select Lines"
+msgstr "Selecciona línies"
+
+#: ../src/command/tool.cpp:97
+msgid "Select lines based on defined criteria"
+msgstr "Selecciona línies basant-se en criteris definits"
+
+#: ../src/command/tool.cpp:107
+msgid "&Resample Resolution..."
+msgstr "&Reajusta la resolució..."
+
+#: ../src/command/tool.cpp:108 ../src/dialog_resample.cpp:90
+msgid "Resample Resolution"
+msgstr "Reajusta la resolució"
+
+#: ../src/command/tool.cpp:109
+msgid ""
+"Resample subtitles to maintain their current appearance at a different "
+"script resolution"
+msgstr ""
+"Reajusta els subtítols perquè mantinguin la seva aparença actual amb una "
+"resolució d'script diferent"
+
+#: ../src/command/tool.cpp:122
+msgid "St&yling Assistant..."
+msgstr "Au&xiliar d'estils..."
+
+#: ../src/command/tool.cpp:123 ../src/dialog_styling_assistant.cpp:55
+msgid "Styling Assistant"
+msgstr "Auxiliar d'estils"
+
+#: ../src/command/tool.cpp:124
+msgid "Open styling assistant"
+msgstr "Obre l'auxiliar d'estils"
+
+#: ../src/command/tool.cpp:141 ../src/command/tool.cpp:225
+msgid "&Accept changes"
+msgstr "&Accepta els canvis"
+
+#: ../src/command/tool.cpp:142 ../src/command/tool.cpp:226
+#: ../src/dialog_styling_assistant.cpp:90 ../src/dialog_translation.cpp:113
+msgid "Accept changes"
+msgstr "Accepta els canvis"
+
+#: ../src/command/tool.cpp:143 ../src/command/tool.cpp:227
+msgid "Commit changes and move to the next line"
+msgstr "Aplica els canvis i es mou a la següent línia"
+
+#: ../src/command/tool.cpp:152 ../src/command/tool.cpp:236
+msgid "&Preview changes"
+msgstr "&Previsualitza els canvis"
+
+#: ../src/command/tool.cpp:153 ../src/command/tool.cpp:237
+#: ../src/dialog_styling_assistant.cpp:91 ../src/dialog_translation.cpp:114
+msgid "Preview changes"
+msgstr "Previsualitza els canvis"
+
+#: ../src/command/tool.cpp:154 ../src/command/tool.cpp:238
+msgid "Commit changes and stay on the current line"
+msgstr "Aplica els canvis i roman a la línia actual"
+
+#: ../src/command/tool.cpp:164
+msgid "&Styles Manager..."
+msgstr "Ge&stor d'estils..."
+
+#: ../src/command/tool.cpp:166
+msgid "Open the styles manager"
+msgstr "Obre el gestor d'estils"
+
+#: ../src/command/tool.cpp:176
+msgid "&Kanji Timer..."
+msgstr "Creador de temps per a &kanjis..."
+
+#: ../src/command/tool.cpp:177
+msgid "Kanji Timer"
+msgstr "Creador de temps per a kanjis"
+
+#: ../src/command/tool.cpp:178
+msgid "Open the Kanji timer copier"
+msgstr "Obre el copiador de temps per a kanjis"
+
+#: ../src/command/tool.cpp:188
+msgid "&Timing Post-Processor..."
+msgstr "Postprocessador de &temps..."
+
+#: ../src/command/tool.cpp:190
+msgid ""
+"Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
+"to scene changes, etc."
+msgstr ""
+"Postprocessa els temps dels subtítols per a afegir-hi temps d'entrada i de "
+"sortida, enganxar els temps als canvis d'escena, etc."
+
+#: ../src/command/tool.cpp:200
+msgid "&Translation Assistant..."
+msgstr "Auxiliar de &traducció..."
+
+#: ../src/command/tool.cpp:202
+msgid "Open translation assistant"
+msgstr "Obre l'auxiliar de traducció"
+
+#: ../src/command/tool.cpp:210
+msgid "There is nothing to translate in the file."
+msgstr "No hi ha res a traduir en aquest fitxer."
+
+#: ../src/command/tool.cpp:247
+msgid "&Next Line"
+msgstr "Línia &següent"
+
+#: ../src/command/tool.cpp:248 ../src/command/time.cpp:356
+#: ../src/command/time.cpp:357 ../src/command/grid.cpp:51
+#: ../src/command/grid.cpp:52 ../src/command/grid.cpp:63
+#: ../src/command/grid.cpp:64
+msgid "Next Line"
+msgstr "Línia següent"
+
+#: ../src/command/tool.cpp:249
+msgid "Move to the next line without committing changes"
+msgstr "Es mou a la línia següent sense aplicar els canvis"
+
+#: ../src/command/tool.cpp:258
+msgid "&Previous Line"
+msgstr "Línia &anterior"
+
+#: ../src/command/tool.cpp:259 ../src/command/time.cpp:368
+#: ../src/command/time.cpp:369 ../src/command/grid.cpp:90
+#: ../src/command/grid.cpp:91
+msgid "Previous Line"
+msgstr "Línia anterior"
+
+#: ../src/command/tool.cpp:260
+msgid "Move to the previous line without committing changes"
+msgstr "Es mou a la línia anterior sense aplicar els canvis"
+
+#: ../src/command/tool.cpp:269
+msgid "&Insert Original"
+msgstr "&Insereix l'original"
+
+#: ../src/command/tool.cpp:270 ../src/command/edit.cpp:1254
+#: ../src/command/edit.cpp:1255
+msgid "Insert Original"
+msgstr "Insereix l'original"
+
+#: ../src/command/tool.cpp:271
+msgid "Insert the untranslated text"
+msgstr "Insereix el text sense traduir"
 
 #: ../src/command/video.cpp:84
 msgid "&Cinematic (2.35)"
@@ -874,7 +2657,7 @@ msgstr "Pantalla cinemàtica (2.35)"
 
 #: ../src/command/video.cpp:86
 msgid "Force video to 2.35 aspect ratio"
-msgstr "Força el vídeo a la relació d'aspecte 2,35"
+msgstr "Força el vídeo a la relació d'aspecte 2.35"
 
 #: ../src/command/video.cpp:102
 msgid "C&ustom..."
@@ -914,11 +2697,11 @@ msgstr "Relació d'aspecte invàlida"
 
 #: ../src/command/video.cpp:145
 msgid "&Default"
-msgstr "Pre&definida"
+msgstr "Per &defecte"
 
-#: ../src/command/video.cpp:146 ../src/ass_style.cpp:194
+#: ../src/command/video.cpp:146 ../src/ass_style.cpp:196
 msgid "Default"
-msgstr "Predefinit"
+msgstr "Per defecte"
 
 #: ../src/command/video.cpp:147
 msgid "Use video's original aspect ratio"
@@ -1013,13 +2796,13 @@ msgstr "Mostra els detalls del vídeo"
 
 #: ../src/command/video.cpp:274 ../src/command/video.cpp:275
 msgid "Toggle video slider focus"
-msgstr "Posa/treu el focus a la barra de desplaçament del vídeo"
+msgstr "Commuta el focus a la barra de desplaçament del vídeo"
 
 #: ../src/command/video.cpp:276
 msgid ""
 "Toggle focus between the video slider and the previous thing to have focus"
 msgstr ""
-"Canvia el focus entre la barra de desplaçament del vídeo i l'anterior "
+"Commuta el focus entre la barra de desplaçament del vídeo i l'anterior "
 "element que tenia el focus"
 
 #: ../src/command/video.cpp:297 ../src/command/video.cpp:298
@@ -1092,7 +2875,7 @@ msgstr "Fotograma clau anterior"
 
 #: ../src/command/video.cpp:428
 msgid "Seek to the previous keyframe"
-msgstr "Desplaça a l'anterior fotograma clau"
+msgstr "Desplaça al fotograma clau anterior"
 
 #: ../src/command/video.cpp:448 ../src/command/video.cpp:449
 #: ../src/command/video.cpp:450
@@ -1166,7 +2949,7 @@ msgstr "Obre el vídeo"
 msgid "Open a video file"
 msgstr "Obre el fitxer de vídeo"
 
-#: ../src/command/video.cpp:567 ../src/command/audio.cpp:83
+#: ../src/command/video.cpp:567 ../src/command/audio.cpp:84
 msgid "Video Formats"
 msgstr "Formats de vídeo"
 
@@ -1188,12 +2971,12 @@ msgstr "Obre una peça de vídeo fictici amb un color sòlid"
 
 #: ../src/command/video.cpp:592 ../src/command/video.cpp:593
 msgid "Toggle autoscroll of video"
-msgstr "Activa/desactiva el moviment automàtic del vídeo"
+msgstr "Commuta el desplaçament automàtic del vídeo"
 
 #: ../src/command/video.cpp:594
 msgid "Toggle automatically seeking video to the start time of selected lines"
 msgstr ""
-"Activa/desactiva el salt automàtic del vídeo al temps d'inici de les línies "
+"Commuta el desplaçament automàtic del vídeo al temps d'inici de les línies "
 "seleccionades"
 
 #: ../src/command/video.cpp:609 ../src/command/video.cpp:610
@@ -1208,8 +2991,8 @@ msgstr "Reprodueix el vídeo començant en aquesta posició"
 msgid "Play line"
 msgstr "Reprodueix la línia"
 
-#: ../src/command/video.cpp:623 ../src/command/audio.cpp:260
-#: ../src/command/audio.cpp:261
+#: ../src/command/video.cpp:623 ../src/command/audio.cpp:206
+#: ../src/command/audio.cpp:207
 msgid "Play current line"
 msgstr "Reprodueix la línia actual"
 
@@ -1226,7 +3009,7 @@ msgid ""
 "Show a mask over the video, indicating areas that might get cropped off by "
 "overscan on televisions"
 msgstr ""
-"Mostra una màscara sobre el vídeo, indicant les àres que poden ser "
+"Mostra una màscara sobre el vídeo, indicant les àrees que poden ser "
 "retallades per sobreescaneig als televisors"
 
 #: ../src/command/video.cpp:650
@@ -1289,1062 +3072,193 @@ msgstr "Redueix"
 msgid "Zoom video out"
 msgstr "Redueix el vídeo"
 
-#: ../src/command/edit.cpp:131 ../src/command/edit.cpp:831
-msgid "paste"
-msgstr "l'enganxat"
+#: ../src/command/time.cpp:101
+msgid "adjoin"
+msgstr "l'ajuntament"
 
-#: ../src/command/edit.cpp:369
-msgid "set color"
-msgstr "la definició del color"
+#: ../src/command/time.cpp:106
+msgid "Change &End"
+msgstr "Canvia &el final"
 
-#: ../src/command/edit.cpp:383
-msgid "Primary Color..."
-msgstr "Color primari..."
+#: ../src/command/time.cpp:107
+msgid "Change End"
+msgstr "Canvia el final"
 
-#: ../src/command/edit.cpp:384
-msgid "Primary Color"
-msgstr "Color primari"
-
-#: ../src/command/edit.cpp:385
-msgid "Set the primary fill color (\\c) at the cursor position"
-msgstr "Defineix el color d'emplenat primari (\\c) a la posició del cursor"
-
-#: ../src/command/edit.cpp:395
-msgid "Secondary Color..."
-msgstr "Color secundari..."
-
-#: ../src/command/edit.cpp:396
-msgid "Secondary Color"
-msgstr "Color secundari"
-
-#: ../src/command/edit.cpp:397
-msgid "Set the secondary (karaoke) fill color (\\2c) at the cursor position"
+#: ../src/command/time.cpp:108
+msgid "Change end times of lines to the next line's start time"
 msgstr ""
-"Defineix el color d'emplenat secundari (de karaoke, \\2c) a la posició del "
-"cursor"
+"Canvia els temps de final de les línies al temps d'inici de la següent línia"
 
-#: ../src/command/edit.cpp:407
-msgid "Outline Color..."
-msgstr "Color del contorn..."
+#: ../src/command/time.cpp:117
+msgid "Change &Start"
+msgstr "Canvia l'&inici"
 
-#: ../src/command/edit.cpp:408
-msgid "Outline Color"
-msgstr "Color del contorn"
+#: ../src/command/time.cpp:118
+msgid "Change Start"
+msgstr "Canvia l'inici"
 
-#: ../src/command/edit.cpp:409
-msgid "Set the outline color (\\3c) at the cursor position"
-msgstr "Defineix el color del contorn (\\3c) a la posició del cursor"
+#: ../src/command/time.cpp:119
+msgid "Change start times of lines to the previous line's end time"
+msgstr ""
+"Canvia els temps d'inici de les línies al temps de final de l'anterior línia"
 
-#: ../src/command/edit.cpp:419
-msgid "Shadow Color..."
-msgstr "Color de l'ombra"
+#: ../src/command/time.cpp:129
+msgid "Shift to &Current Frame"
+msgstr "Desplaça al &fotograma actual"
 
-#: ../src/command/edit.cpp:420
-msgid "Shadow Color"
-msgstr "Color de l'ombra"
+#: ../src/command/time.cpp:130
+msgid "Shift to Current Frame"
+msgstr "Desplaça al fotograma actual"
 
-#: ../src/command/edit.cpp:421
-msgid "Set the shadow color (\\4c) at the cursor position"
-msgstr "Defineix el color de l'ombra (\\4c) a la posició del cursor"
+#: ../src/command/time.cpp:131
+msgid "Shift selection so that the active line starts at current frame"
+msgstr ""
+"Desplaça la selecció perquè la línia activa comenci al fotograma actual"
 
-#: ../src/command/edit.cpp:431 ../src/command/edit.cpp:432
-msgid "Toggle Bold"
-msgstr "Activa/desactiva la negreta"
+#: ../src/command/time.cpp:147
+msgid "shift to frame"
+msgstr "el desplaçament al fotograma"
 
-#: ../src/command/edit.cpp:433
+#: ../src/command/time.cpp:154
+msgid "S&hift Times..."
+msgstr "Des&plaça els temps..."
+
+#: ../src/command/time.cpp:155 ../src/dialog_shift_times.cpp:135
+msgid "Shift Times"
+msgstr "Desplaça els temps"
+
+#: ../src/command/time.cpp:156
+msgid "Shift subtitles by time or frames"
+msgstr "Desplaça els subtítols per temps o per fotogrames"
+
+#: ../src/command/time.cpp:183
+msgid "Snap &End to Video"
+msgstr "&Enganxa el final al vídeo"
+
+#: ../src/command/time.cpp:184
+msgid "Snap End to Video"
+msgstr "Enganxa el final al vídeo"
+
+#: ../src/command/time.cpp:185
+msgid "Set end of selected subtitles to current video frame"
+msgstr "Posa el final dels subtítols al fotograma actual del vídeo"
+
+#: ../src/command/time.cpp:195
+msgid "Snap to S&cene"
+msgstr "Enganxa a l'es&cena"
+
+#: ../src/command/time.cpp:196
+msgid "Snap to Scene"
+msgstr "Enganxa a l'escena"
+
+#: ../src/command/time.cpp:197
 msgid ""
-"Toggle bold (\\b) for the current selection or at the current cursor position"
+"Set start and end of subtitles to the keyframes around current video frame"
 msgstr ""
-"Activa/desactiva la negreta (\\b) a la selecció o a la posició del cursor "
-"actual"
+"Posa l'inici i el final dels subtítols als fotogrames clau al voltant del "
+"fotograma de vídeo actual"
 
-#: ../src/command/edit.cpp:436
-msgid "toggle bold"
-msgstr "el canvi de la negreta"
+#: ../src/command/time.cpp:234
+msgid "snap to scene"
+msgstr "l'enganxament a l'escena"
 
-#: ../src/command/edit.cpp:443 ../src/command/edit.cpp:444
-msgid "Toggle Italics"
-msgstr "Activa/desactiva la cursiva"
+#: ../src/command/time.cpp:240 ../src/command/time.cpp:241
+msgid "Add lead in and out"
+msgstr "Afegeix temps d'entrada i sortida"
 
-#: ../src/command/edit.cpp:445
+#: ../src/command/time.cpp:242
+msgid "Add both lead in and out to the selected lines"
+msgstr "Afegeix tant temps d'entrada com de sortida a les línies seleccionades"
+
+#: ../src/command/time.cpp:254 ../src/command/time.cpp:255
+msgid "Add lead in"
+msgstr "Afegeix temps d'entrada"
+
+#: ../src/command/time.cpp:256
+msgid "Add the lead in time to the selected lines"
+msgstr "Afegeix el temps d'entrada a les línies seleccionades"
+
+#: ../src/command/time.cpp:266 ../src/command/time.cpp:267
+msgid "Add lead out"
+msgstr "Afegeix temps de sortida"
+
+#: ../src/command/time.cpp:268
+msgid "Add the lead out time to the selected lines"
+msgstr "Afegeix el temps de sortida a les línies seleccionades"
+
+#: ../src/command/time.cpp:277 ../src/command/time.cpp:278
+msgid "Increase length"
+msgstr "Augmenta la llargada"
+
+#: ../src/command/time.cpp:279
+msgid "Increase the length of the current timing unit"
+msgstr "Augmenta la llargada de la unitat de temps actual"
+
+#: ../src/command/time.cpp:288 ../src/command/time.cpp:289
+msgid "Increase length and shift"
+msgstr "Augmenta la llargada i desplaça"
+
+#: ../src/command/time.cpp:290
 msgid ""
-"Toggle italics (\\i) for the current selection or at the current cursor "
-"position"
+"Increase the length of the current timing unit and shift the following items"
 msgstr ""
-"Activa/desactiva la cursiva (\\i) a la selecció o a la posició del cursor "
-"actual"
+"Augmenta la llargada de la unitat de temps actual i desplaça els següents "
+"elements"
 
-#: ../src/command/edit.cpp:448
-msgid "toggle italic"
-msgstr "el canvi de la cursiva"
+#: ../src/command/time.cpp:299 ../src/command/time.cpp:300
+msgid "Decrease length"
+msgstr "Disminueix la llargada"
 
-#: ../src/command/edit.cpp:455 ../src/command/edit.cpp:456
-msgid "Toggle Underline"
-msgstr "Activa/desactiva el subratllat"
+#: ../src/command/time.cpp:301
+msgid "Decrease the length of the current timing unit"
+msgstr "Disminueix la llargada de la unitat de temps actual"
 
-#: ../src/command/edit.cpp:457
+#: ../src/command/time.cpp:310 ../src/command/time.cpp:311
+msgid "Decrease length and shift"
+msgstr "Disminueix la llargada i desplaça"
+
+#: ../src/command/time.cpp:312
 msgid ""
-"Toggle underline (\\u) for the current selection or at the current cursor "
-"position"
+"Decrease the length of the current timing unit and shift the following items"
 msgstr ""
-"Activa/desactiva el subratllat (\\u) a la selecció o a la posició del cursor "
-"actual"
-
-#: ../src/command/edit.cpp:460
-msgid "toggle underline"
-msgstr "el canvi del subratllat"
-
-#: ../src/command/edit.cpp:467 ../src/command/edit.cpp:468
-msgid "Toggle Strikeout"
-msgstr "Activa/desactiva el tatxat"
-
-#: ../src/command/edit.cpp:469
-msgid ""
-"Toggle strikeout (\\s) for the current selection or at the current cursor "
-"position"
-msgstr ""
-"Activa/desactiva el tatxat (\\s) a la selecció o a la posició del cursor "
-"actual"
-
-#: ../src/command/edit.cpp:472
-msgid "toggle strikeout"
-msgstr "el canvi del tatxat"
-
-#: ../src/command/edit.cpp:479
-msgid "Font Face..."
-msgstr "Tipus de lletra..."
-
-#: ../src/command/edit.cpp:480 ../src/preferences_base.cpp:251
-msgid "Font Face"
-msgstr "Tipus de lletra"
-
-#: ../src/command/edit.cpp:481
-msgid "Select a font face and size"
-msgstr "Selecciona un tipus de lletra i una mida"
-
-#: ../src/command/edit.cpp:508
-msgid "set font"
-msgstr "la definició del tipus de lletra"
-
-#: ../src/command/edit.cpp:535
-msgid "Find and R&eplace..."
-msgstr "Cerca i &substitueix..."
-
-#: ../src/command/edit.cpp:536
-msgid "Find and Replace"
-msgstr "Cerca i substitueix"
-
-#: ../src/command/edit.cpp:537
-msgid "Find and replace words in subtitles"
-msgstr "Cerca i substitueix paraules als subtítols"
-
-#: ../src/command/edit.cpp:598
-msgid "&Copy Lines"
-msgstr "&Copia les línies"
-
-#: ../src/command/edit.cpp:599
-msgid "Copy Lines"
-msgstr "Copia les línies"
-
-#: ../src/command/edit.cpp:600
-msgid "Copy subtitles to the clipboard"
-msgstr "Copia els subtítols al porta-retalls"
-
-#: ../src/command/edit.cpp:621
-msgid "Cu&t Lines"
-msgstr "Re&talla les línies"
-
-#: ../src/command/edit.cpp:622
-msgid "Cut Lines"
-msgstr "Retalla les línies"
-
-#: ../src/command/edit.cpp:623
-msgid "Cut subtitles"
-msgstr "Retalla els subtítols"
-
-#: ../src/command/edit.cpp:630
-msgid "cut lines"
-msgstr "el retallat de les línies"
-
-#: ../src/command/edit.cpp:638
-msgid "De&lete Lines"
-msgstr "Suprimeix &les línies"
-
-#: ../src/command/edit.cpp:639
-msgid "Delete Lines"
-msgstr "Suprimeix les línies"
-
-#: ../src/command/edit.cpp:640
-msgid "Delete currently selected lines"
-msgstr "Suprimeix les línies seleccionades"
-
-#: ../src/command/edit.cpp:643
-msgid "delete lines"
-msgstr "l'eliminació de les línies"
-
-#: ../src/command/edit.cpp:708 ../src/command/edit.cpp:1093
-msgid "split"
-msgstr "la divisió"
-
-#: ../src/command/edit.cpp:708
-msgid "duplicate lines"
-msgstr "el duplicat de les línies"
-
-#: ../src/command/edit.cpp:715
-msgid "&Duplicate Lines"
-msgstr "&Duplica les línies"
-
-#: ../src/command/edit.cpp:716
-msgid "Duplicate Lines"
-msgstr "Duplica les línies"
-
-#: ../src/command/edit.cpp:717
-msgid "Duplicate the selected lines"
-msgstr "Duplica les línies seleccionades"
-
-#: ../src/command/edit.cpp:726 ../src/command/edit.cpp:727
-msgid "Split lines after current frame"
-msgstr "Divideix les línies després del fotograma actual"
-
-#: ../src/command/edit.cpp:728
-msgid ""
-"Split the current line into a line which ends on the current frame and a "
-"line which starts on the next frame"
-msgstr ""
-"Divideix la línia actual en una línia que acaba al fotograma actual i una "
-"línia que comença al següent fotograma"
-
-#: ../src/command/edit.cpp:738 ../src/command/edit.cpp:739
-msgid "Split lines before current frame"
-msgstr "Divideix les línies abans del fotograma actual"
-
-#: ../src/command/edit.cpp:740
-msgid ""
-"Split the current line into a line which ends on the previous frame and a "
-"line which starts on the current frame"
-msgstr ""
-"Divideix la línia actual en una línia que acaba al fotograma anterior i una "
-"línia que comença al fotograma actual"
-
-#: ../src/command/edit.cpp:775
-msgid "As &Karaoke"
-msgstr "Com a &karaoke"
-
-#: ../src/command/edit.cpp:776
-msgid "As Karaoke"
-msgstr "Com a karaoke"
-
-#: ../src/command/edit.cpp:777
-msgid "Join selected lines in a single one, as karaoke"
-msgstr "Uneix les línies seleccionada en una de sola, com a karaoke"
-
-#: ../src/command/edit.cpp:780
-msgid "join as karaoke"
-msgstr "la unió com a karaoke"
-
-#: ../src/command/edit.cpp:786
-msgid "&Concatenate"
-msgstr "&Concatena"
-
-#: ../src/command/edit.cpp:787
-msgid "Concatenate"
-msgstr "Concatena"
-
-#: ../src/command/edit.cpp:788
-msgid "Join selected lines in a single one, concatenating text together"
-msgstr "Uneix les línies seleccionades en una de sola, concatenant-ne el text"
-
-#: ../src/command/edit.cpp:791 ../src/command/edit.cpp:802
-msgid "join lines"
-msgstr "la unió de les línies"
-
-#: ../src/command/edit.cpp:797
-msgid "Keep &First"
-msgstr "&Mantingues la primera"
-
-#: ../src/command/edit.cpp:798
-msgid "Keep First"
-msgstr "Mantingues la primera"
-
-#: ../src/command/edit.cpp:799
-msgid ""
-"Join selected lines in a single one, keeping text of first and discarding "
-"remaining"
-msgstr ""
-"Uneix les línies seleccionades en una de sola, mantenint el text de la "
-"primera i descartant el de la resta"
-
-#: ../src/command/edit.cpp:840
-msgid "&Paste Lines"
-msgstr "Engan&xa les línies"
-
-#: ../src/command/edit.cpp:841
-msgid "Paste Lines"
-msgstr "Enganxa les línies"
-
-#: ../src/command/edit.cpp:842
-msgid "Paste subtitles"
-msgstr "Enganxa els subtítols"
-
-#: ../src/command/edit.cpp:871
-msgid "Paste Lines &Over..."
-msgstr "Enganxa les línies a s&obre..."
-
-#: ../src/command/edit.cpp:872
-msgid "Paste Lines Over"
-msgstr "Enganxa les línies a sobre"
-
-#: ../src/command/edit.cpp:873
-msgid "Paste subtitles over others"
-msgstr "Enganxa els subtítols damunt dels altres"
-
-#: ../src/command/edit.cpp:956
-msgid "Recom&bine Lines"
-msgstr "Recom&bina les línies"
-
-#: ../src/command/edit.cpp:957
-msgid "Recombine Lines"
-msgstr "Recombina les línies"
-
-#: ../src/command/edit.cpp:958
-msgid "Recombine subtitles which have been split and merged"
-msgstr "Recombina els subtítols que han estat dividits i fusionats"
-
-#: ../src/command/edit.cpp:1028
-msgid "combining"
-msgstr "la combinació"
-
-#: ../src/command/edit.cpp:1034 ../src/command/edit.cpp:1035
-msgid "Split Lines (by karaoke)"
-msgstr "Divideix les línies (per karaoke)"
-
-#: ../src/command/edit.cpp:1036
-msgid "Use karaoke timing to split line into multiple smaller lines"
-msgstr ""
-"Utilitza el temps dels karaokes per dividir la línia en múltiples línies més "
-"petites"
-
-#: ../src/command/edit.cpp:1070
-msgid "splitting"
-msgstr "la divisió"
-
-#: ../src/command/edit.cpp:1098 ../src/command/edit.cpp:1099
-#: ../src/subs_edit_ctrl.cpp:375
-msgid "Split at cursor (estimate times)"
-msgstr "Divideix al cursor (estima els temps)"
-
-#: ../src/command/edit.cpp:1100
-msgid ""
-"Split the current line at the cursor, dividing the original line's duration "
-"between the new ones"
-msgstr ""
-"Divideix la línia actual al cursor, dividint la durada de la línia original "
-"entre les noves"
-
-#: ../src/command/edit.cpp:1114 ../src/command/edit.cpp:1115
-#: ../src/subs_edit_ctrl.cpp:374
-msgid "Split at cursor (preserve times)"
-msgstr "Divideix al cursor (conserva els temps)"
-
-#: ../src/command/edit.cpp:1116
-msgid ""
-"Split the current line at the cursor, setting both lines to the original "
-"line's times"
-msgstr ""
-"Divideix la línia actual al cursor, definint el temps de les dues línies al "
-"temps de la línia original"
-
-#: ../src/command/edit.cpp:1125 ../src/command/edit.cpp:1126
-msgid "Split at cursor (at video frame)"
-msgstr "Divideix al cursor (al fotograma del vídeo)"
-
-#: ../src/command/edit.cpp:1127
-msgid ""
-"Split the current line at the cursor, dividing the line's duration at the "
-"current video frame"
-msgstr ""
-"Divideix la línia actual al cursor, dividint la durada de la línia al "
-"fotograma actual del vídeo"
-
-#: ../src/command/edit.cpp:1143
-msgid "Redo last undone action"
-msgstr "Refés l'última acció desfeta"
-
-#: ../src/command/edit.cpp:1148
-msgid "Nothing to &redo"
-msgstr "No hi ha res a &refer"
-
-#: ../src/command/edit.cpp:1149
-#, c-format
-msgid "&Redo %s"
-msgstr "&Refés %s"
-
-#: ../src/command/edit.cpp:1153
-msgid "Nothing to redo"
-msgstr "No hi ha res a refer"
-
-#: ../src/command/edit.cpp:1154
-#, c-format
-msgid "Redo %s"
-msgstr "Refés %s"
-
-#: ../src/command/edit.cpp:1169
-msgid "Undo last action"
-msgstr "Desfés l'última acció"
-
-#: ../src/command/edit.cpp:1174
-msgid "Nothing to &undo"
-msgstr "No hi ha res a &desfer"
-
-#: ../src/command/edit.cpp:1175
-#, c-format
-msgid "&Undo %s"
-msgstr "&Desfés %s"
-
-#: ../src/command/edit.cpp:1179
-msgid "Nothing to undo"
-msgstr "No hi ha res a desfer"
-
-#: ../src/command/edit.cpp:1180
-#, c-format
-msgid "Undo %s"
-msgstr "Desfés %s"
-
-#: ../src/command/edit.cpp:1194 ../src/command/edit.cpp:1195
-msgid "Revert"
-msgstr "Reverteix"
-
-#: ../src/command/edit.cpp:1196
-msgid "Revert the active line to its initial state (shown in the upper editor)"
-msgstr ""
-"Reverteix la línia activa al seu estat inicial (mostrat a l'editor de dalt)"
-
-#: ../src/command/edit.cpp:1201
-msgid "revert line"
-msgstr "el revertit de la línia"
-
-#: ../src/command/edit.cpp:1207 ../src/command/edit.cpp:1208
-#: ../src/preferences.cpp:389
-msgid "Clear"
-msgstr "Esborra"
-
-#: ../src/command/edit.cpp:1209
-msgid "Clear the current line's text"
-msgstr "Esborra el text de la línia actual"
-
-#: ../src/command/edit.cpp:1214 ../src/command/edit.cpp:1233
-msgid "clear line"
-msgstr "l'esborrat de la línia"
-
-#: ../src/command/edit.cpp:1221 ../src/command/edit.cpp:1222
-msgid "Clear Text"
-msgstr "Esborra el text"
-
-#: ../src/command/edit.cpp:1223
-msgid "Clear the current line's text, leaving override tags"
-msgstr "Esborra el text de la línia actual, deixant-ne les etiquetes d'estil"
-
-#: ../src/command/edit.cpp:1239 ../src/command/edit.cpp:1240
-#: ../src/command/tool.cpp:271
-msgid "Insert Original"
-msgstr "Insereix l'original"
-
-#: ../src/command/edit.cpp:1241
-msgid "Insert the original line text at the cursor"
-msgstr "Insereix la línia de text original al cursor"
-
-#: ../src/command/edit.cpp:1249
-msgid "insert original"
-msgstr "la inserció de l'original"
-
-#: ../src/command/recent.cpp:43 ../src/command/recent.cpp:44
-#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:46
-#: ../src/command/recent.cpp:47 ../src/command/recent.cpp:51
-#: ../src/command/recent.cpp:52 ../src/command/recent.cpp:62
-#: ../src/command/recent.cpp:63 ../src/command/recent.cpp:73
-#: ../src/command/recent.cpp:74 ../src/command/recent.cpp:85
-#: ../src/command/recent.cpp:86 ../src/command/recent.cpp:96
-#: ../src/command/recent.cpp:97
-msgid "Recent"
-msgstr "Recents"
-
-#: ../src/command/recent.cpp:43 ../src/command/recent.cpp:53
-msgid "Open recent audio"
-msgstr "Obre l'àudio recent"
-
-#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:64
-msgid "Open recent keyframes"
-msgstr "Obre els fotogrames clau recents"
-
-#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:75
-msgid "Open recent subtitles"
-msgstr "Obre els subtítols recents"
-
-#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:87
-msgid "Open recent timecodes"
-msgstr "Obre els codis de temps recents"
-
-#: ../src/command/recent.cpp:47
-msgid "Open recent video"
-msgstr "Obre el vídeo recent"
-
-#: ../src/command/recent.cpp:98
-msgid "Open recent videos"
-msgstr "Obre els vídeos recents"
-
-#: ../src/command/subtitle.cpp:78
-msgid "A&ttachments..."
-msgstr "Ad&juncions..."
-
-#: ../src/command/subtitle.cpp:79
-msgid "Attachments"
-msgstr "Adjuncions"
-
-#: ../src/command/subtitle.cpp:80
-msgid "Open the attachment manager dialog"
-msgstr "Obre el diàleg del gestor d'adjuncions"
-
-#: ../src/command/subtitle.cpp:91
-msgid "&Find..."
-msgstr "C&erca..."
-
-#: ../src/command/subtitle.cpp:92 ../src/dialog_search_replace.cpp:46
-msgid "Find"
-msgstr "Cerca"
-
-#: ../src/command/subtitle.cpp:93
-msgid "Search for text in the subtitles"
-msgstr "Cerca text als subtítols"
-
-#: ../src/command/subtitle.cpp:104
-msgid "Find &Next"
-msgstr "Cerca el següe&nt"
-
-#: ../src/command/subtitle.cpp:105
-msgid "Find Next"
-msgstr "Cerca el següent"
-
-#: ../src/command/subtitle.cpp:106
-msgid "Find next match of last search"
-msgstr "Cerca la següent coincidència de l'última cerca"
-
-#: ../src/command/subtitle.cpp:126 ../src/command/subtitle.cpp:160
-#: ../src/command/subtitle.cpp:202 ../src/command/grid.cpp:82
-msgid "line insertion"
-msgstr "la inserció de la línia"
-
-#: ../src/command/subtitle.cpp:133
-msgid "&After Current"
-msgstr "Després de l'&actual"
-
-#: ../src/command/subtitle.cpp:134
-msgid "After Current"
-msgstr "Després de l'actual"
-
-#: ../src/command/subtitle.cpp:135
-msgid "Insert a new line after the current one"
-msgstr "Insereix una línia nova després de l'actual"
-
-#: ../src/command/subtitle.cpp:167 ../src/command/subtitle.cpp:168
-msgid "After Current, at Video Time"
-msgstr "Després de l'actual, al temps del vídeo"
-
-#: ../src/command/subtitle.cpp:169
-msgid "Insert a new line after the current one, starting at video time"
-msgstr ""
-"Insereix una línia nova després de l'actual, començant al temps del vídeo"
-
-#: ../src/command/subtitle.cpp:178
-msgid "&Before Current"
-msgstr "A&bans de l'actual"
-
-#: ../src/command/subtitle.cpp:179
-msgid "Before Current"
-msgstr "Abans de l'actual"
-
-#: ../src/command/subtitle.cpp:180
-msgid "Insert a new line before the current one"
-msgstr "Insereix una línia nova abans de l'actual"
-
-#: ../src/command/subtitle.cpp:209 ../src/command/subtitle.cpp:210
-msgid "Before Current, at Video Time"
-msgstr "Abans de l'actual, al temps del vídeo"
-
-#: ../src/command/subtitle.cpp:211
-msgid "Insert a new line before the current one, starting at video time"
-msgstr ""
-"Insereix una línia nova abans de l'actual, començant al temps del vídeo"
-
-#: ../src/command/subtitle.cpp:221
-msgid "&New Subtitles"
-msgstr "&Nous subtítols"
-
-#: ../src/command/subtitle.cpp:222
-msgid "New Subtitles"
-msgstr "Nous subtítols"
-
-#: ../src/command/subtitle.cpp:223
-msgid "New subtitles"
-msgstr "Nous subtítols"
-
-#: ../src/command/subtitle.cpp:234
-msgid "&Open Subtitles..."
-msgstr "&Obre els subtítols..."
-
-#: ../src/command/subtitle.cpp:235
-msgid "Open Subtitles"
-msgstr "Obre els subtítols"
-
-#: ../src/command/subtitle.cpp:236
-msgid "Open a subtitles file"
-msgstr "Obre el fitxer de subtítols"
-
-#: ../src/command/subtitle.cpp:248
-msgid "Open A&utosaved Subtitles..."
-msgstr "Obre els subtítols desats a&utomàticament..."
-
-#: ../src/command/subtitle.cpp:249
-msgid "Open Autosaved Subtitles"
-msgstr "Obre els subtítols desats automàticament"
-
-#: ../src/command/subtitle.cpp:250
-msgid "Open a previous version of a file which was autosaved by Aegisub"
-msgstr ""
-"Obre una versió anterior d'un fitxer que hagi estat desat automàticament per "
-"l'Aegisub"
-
-#: ../src/command/subtitle.cpp:263
-msgid "Open Subtitles with &Charset..."
-msgstr "Obre els subtítols amb &codificació..."
-
-#: ../src/command/subtitle.cpp:264
-msgid "Open Subtitles with Charset"
-msgstr "Obre els subtítols amb codificació"
-
-#: ../src/command/subtitle.cpp:265
-msgid "Open a subtitles file with a specific file encoding"
-msgstr "Obre el fitxer de subtítols amb una codificació de fitxer concreta"
-
-#: ../src/command/subtitle.cpp:273
-msgid "Choose charset code:"
-msgstr "Escolliu el codi de la codificació:"
-
-#: ../src/command/subtitle.cpp:273
-msgid "Charset"
-msgstr "Codificació"
-
-#: ../src/command/subtitle.cpp:282
-msgid "Open Subtitles from &Video"
-msgstr "Obre els subtítols del &vídeo"
-
-#: ../src/command/subtitle.cpp:283
-msgid "Open Subtitles from Video"
-msgstr "Obre els subtítols del vídeo"
-
-#: ../src/command/subtitle.cpp:284
-msgid "Open the subtitles from the current video file"
-msgstr "Obre els subtítols del fitxer de vídeo actual"
-
-#: ../src/command/subtitle.cpp:300
-msgid "&Properties..."
-msgstr "&Propietats..."
-
-#: ../src/command/subtitle.cpp:301
-msgid "Properties"
-msgstr "Propietats"
-
-#: ../src/command/subtitle.cpp:302
-msgid "Open script properties window"
-msgstr "Obre la finestra de propietats de l'script"
-
-#: ../src/command/subtitle.cpp:313
-msgid "Save subtitles file"
-msgstr "Desa el fitxer de subtítols"
-
-#: ../src/command/subtitle.cpp:333
-msgid "&Save Subtitles"
-msgstr "De&sa els subtítols"
-
-#: ../src/command/subtitle.cpp:334
-msgid "Save Subtitles"
-msgstr "Desa els subtítols"
-
-#: ../src/command/subtitle.cpp:335
-msgid "Save the current subtitles"
-msgstr "Desa els subtítols actuals"
-
-#: ../src/command/subtitle.cpp:350
-msgid "Save Subtitles &as..."
-msgstr "&Anomena i desa els subtítols..."
-
-#: ../src/command/subtitle.cpp:351
-msgid "Save Subtitles as"
-msgstr "Anomena i desa els subtítols"
-
-#: ../src/command/subtitle.cpp:352
-msgid "Save subtitles with another name"
-msgstr "Desa els subtítols amb un altre nom"
-
-#: ../src/command/subtitle.cpp:361 ../src/dialog_selected_choices.cpp:26
-#: ../src/subs_edit_ctrl.cpp:369 ../src/dialog_export.cpp:125
-msgid "Select &All"
-msgstr "Seleccion&a-ho tot"
-
-#: ../src/command/subtitle.cpp:362
-msgid "Select All"
-msgstr "Selecciona-ho tot"
-
-#: ../src/command/subtitle.cpp:363
-msgid "Select all dialogue lines"
-msgstr "Selecciona totes les línies de diàleg"
-
-#: ../src/command/subtitle.cpp:375 ../src/command/subtitle.cpp:376
-msgid "Select Visible"
-msgstr "Selecciona les visibles"
-
-#: ../src/command/subtitle.cpp:377
-msgid "Select all dialogue lines that are visible on the current video frame"
-msgstr ""
-"Selecciona totes les línies de diàleg que són visibles en el fotograma "
-"actual del vídeo"
-
-#: ../src/command/subtitle.cpp:407
-msgid "Spell &Checker..."
-msgstr "&Corrector ortogràfic..."
-
-#: ../src/command/subtitle.cpp:408 ../src/dialog_spellchecker.cpp:103
-msgid "Spell Checker"
-msgstr "Corrector ortogràfic"
-
-#: ../src/command/subtitle.cpp:409
-msgid "Open spell checker"
-msgstr "Obre el corrector ortogràfic"
-
-#: ../src/command/tool.cpp:58
-msgid "ASSDraw3..."
-msgstr "AssDraw3..."
-
-#: ../src/command/tool.cpp:59
-msgid "ASSDraw3"
-msgstr "ASSDraw3"
-
-#: ../src/command/tool.cpp:60
-msgid "Launch the ASSDraw3 tool for vector drawing"
-msgstr "Llança l'eina ASSDraw3 per a dibuixos vectorials"
-
-#: ../src/command/tool.cpp:70
-msgid "&Export Subtitles..."
-msgstr "&Exporta els subtítols..."
-
-#: ../src/command/tool.cpp:71
-msgid "Export Subtitles"
-msgstr "Exporta els subtítols"
-
-#: ../src/command/tool.cpp:72
-msgid ""
-"Save a copy of subtitles in a different format or with processing applied to "
-"it"
-msgstr ""
-"Desa una còpia dels subtítols en un format diferent o aplicant-hi "
-"processament"
-
-#: ../src/command/tool.cpp:83
-msgid "&Fonts Collector..."
-msgstr "Recol·lector de tipus de &lletra..."
-
-#: ../src/command/tool.cpp:84 ../src/dialog_fonts_collector.cpp:218
-msgid "Fonts Collector"
-msgstr "Recol·lector de tipus de lletra"
-
-#: ../src/command/tool.cpp:85
-msgid "Open fonts collector"
-msgstr "Obre el recol·lector de tipus de lletra"
-
-#: ../src/command/tool.cpp:95
-msgid "S&elect Lines..."
-msgstr "S&elecciona línies..."
-
-#: ../src/command/tool.cpp:96
-msgid "Select Lines"
-msgstr "Selecciona línies"
-
-#: ../src/command/tool.cpp:97
-msgid "Select lines based on defined criteria"
-msgstr "Selecciona línies basant-se en criteris definits"
-
-#: ../src/command/tool.cpp:107
-msgid "&Resample Resolution..."
-msgstr "&Reajusta la resolució..."
-
-#: ../src/command/tool.cpp:108 ../src/dialog_resample.cpp:90
-msgid "Resample Resolution"
-msgstr "Reajusta la resolució"
-
-#: ../src/command/tool.cpp:109
-msgid ""
-"Resample subtitles to maintain their current appearance at a different "
-"script resolution"
-msgstr ""
-"Reajusta els subtítols perquè mantinguin la seva aparença actual amb una "
-"resolució d'script diferent"
-
-#: ../src/command/tool.cpp:122
-msgid "St&yling Assistant..."
-msgstr "Au&xiliar d'estils..."
-
-#: ../src/command/tool.cpp:124
-msgid "Open styling assistant"
-msgstr "Obre l'auxiliar d'estils"
-
-#: ../src/command/tool.cpp:141 ../src/command/tool.cpp:225
-msgid "&Accept changes"
-msgstr "&Accepta els canvis"
-
-#: ../src/command/tool.cpp:143 ../src/command/tool.cpp:227
-msgid "Commit changes and move to the next line"
-msgstr "Aplica els canvis i es mou a la següent línia"
-
-#: ../src/command/tool.cpp:152 ../src/command/tool.cpp:236
-msgid "&Preview changes"
-msgstr "&Previsualitza els canvis"
-
-#: ../src/command/tool.cpp:154 ../src/command/tool.cpp:238
-msgid "Commit changes and stay on the current line"
-msgstr "Aplica els canvis i es queda a la línia actual"
-
-#: ../src/command/tool.cpp:164
-msgid "&Styles Manager..."
-msgstr "Ge&stor d'estils..."
-
-#: ../src/command/tool.cpp:166
-msgid "Open the styles manager"
-msgstr "Obre el gestor d'estils"
-
-#: ../src/command/tool.cpp:176
-msgid "&Kanji Timer..."
-msgstr "Creador de temps per a &kanjis..."
-
-#: ../src/command/tool.cpp:177
-msgid "Kanji Timer"
-msgstr "Creador de temps per a kanjis"
-
-#: ../src/command/tool.cpp:178
-msgid "Open the Kanji timer copier"
-msgstr "Obre el copiador de temps per a kanjis"
-
-#: ../src/command/tool.cpp:188
-msgid "&Timing Post-Processor..."
-msgstr "Postprocessador de &temps..."
-
-#: ../src/command/tool.cpp:190
-msgid ""
-"Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
-"to scene changes, etc."
-msgstr ""
-"Postprocessa els temps dels subtítols per afegir-hi temps d'entrada i de "
-"sortida, enganxar els temps als canvis d'escena, etc."
-
-#: ../src/command/tool.cpp:200
-msgid "&Translation Assistant..."
-msgstr "Auxiliar de &traducció..."
-
-#: ../src/command/tool.cpp:201 ../src/dialog_translation.cpp:64
-msgid "Translation Assistant"
-msgstr "Auxiliar de traducció"
-
-#: ../src/command/tool.cpp:202
-msgid "Open translation assistant"
-msgstr "Obre l'auxiliar de traducció"
-
-#: ../src/command/tool.cpp:210
-msgid "There is nothing to translate in the file."
-msgstr "No hi ha res a traduir en aquest fitxer."
-
-#: ../src/command/tool.cpp:247
-msgid "&Next Line"
-msgstr "Línia &següent"
-
-#: ../src/command/tool.cpp:248 ../src/command/grid.cpp:51
-#: ../src/command/grid.cpp:52 ../src/command/grid.cpp:63
-#: ../src/command/grid.cpp:64 ../src/command/time.cpp:354
-#: ../src/command/time.cpp:355
-msgid "Next Line"
-msgstr "Línia següent"
-
-#: ../src/command/tool.cpp:249
-msgid "Move to the next line without committing changes"
-msgstr "Es mou a la línia següent sense aplicar els canvis"
-
-#: ../src/command/tool.cpp:258
-msgid "&Previous Line"
-msgstr "Línia &anterior"
-
-#: ../src/command/tool.cpp:259 ../src/command/grid.cpp:90
-#: ../src/command/grid.cpp:91 ../src/command/time.cpp:366
-#: ../src/command/time.cpp:367
-msgid "Previous Line"
-msgstr "Línia anterior"
-
-#: ../src/command/tool.cpp:260
-msgid "Move to the previous line without committing changes"
-msgstr "Es mou a la línia anterior sense aplicar els canvis"
-
-#: ../src/command/tool.cpp:270
-msgid "&Insert Original"
-msgstr "&Insereix l'original"
-
-#: ../src/command/tool.cpp:272
-msgid "Insert the untranslated text"
-msgstr "Insereix el text sense traduir"
-
-#: ../src/command/app.cpp:58
-msgid "&About"
-msgstr "&Quant a"
-
-#: ../src/command/app.cpp:59
-msgid "About"
-msgstr "Quant a"
-
-#: ../src/command/app.cpp:60 ../src/dialog_about.cpp:44
-msgid "About Aegisub"
-msgstr "Quant a l'Aegisub"
-
-#: ../src/command/app.cpp:69
-msgid "&Audio+Subs View"
-msgstr "Vist&a de l'àudio i els subtítols"
-
-#: ../src/command/app.cpp:70
-msgid "Audio+Subs View"
-msgstr "Vista de l'àudio i els subtítols"
-
-#: ../src/command/app.cpp:71
-msgid "Display audio and the subtitles grid only"
-msgstr "Mostra només l'àudio i la graella dels subtítols"
-
-#: ../src/command/app.cpp:89
-msgid "&Full view"
-msgstr "V&ista completa"
-
-#: ../src/command/app.cpp:90
-msgid "Full view"
-msgstr "Vista completa"
-
-#: ../src/command/app.cpp:91
-msgid "Display audio, video and then subtitles grid"
-msgstr "Mostra l'àudio, el vídeo i la graella dels subtítols"
-
-#: ../src/command/app.cpp:109
-msgid "S&ubs Only View"
-msgstr "Vista només dels s&ubtítols"
-
-#: ../src/command/app.cpp:110
-msgid "Subs Only View"
-msgstr "Vista només dels subtítols"
-
-#: ../src/command/app.cpp:111
-msgid "Display the subtitles grid only"
-msgstr "Mostra només la graella dels subtítols"
-
-#: ../src/command/app.cpp:125
-msgid "&Video+Subs View"
-msgstr "Vista del &vídeo i els subtítols"
-
-#: ../src/command/app.cpp:126
-msgid "Video+Subs View"
-msgstr "Vista dels vídeo i els subtítols"
-
-#: ../src/command/app.cpp:127
-msgid "Display video and the subtitles grid only"
-msgstr "Mostra només el vídeo i la graella dels subtítols"
-
-#: ../src/command/app.cpp:145
-msgid "E&xit"
-msgstr "Sur&t"
-
-#: ../src/command/app.cpp:146
-msgid "Exit"
-msgstr "Surt"
-
-#: ../src/command/app.cpp:147
-msgid "Exit the application"
-msgstr "Surt de l'aplicació"
-
-#: ../src/command/app.cpp:157
-msgid "&Language..."
-msgstr "&Idioma..."
-
-#: ../src/command/app.cpp:158
-msgid "Language"
-msgstr "Idioma"
-
-#: ../src/command/app.cpp:159
-msgid "Select Aegisub interface language"
-msgstr "Seleccioneu l'idioma de la interfície de l'Aegisub"
-
-#: ../src/command/app.cpp:182
-msgid "&Log window"
-msgstr "Finestra de&l registre"
-
-#: ../src/command/app.cpp:183 ../src/dialog_log.cpp:99
-msgid "Log window"
-msgstr "Finestra del registre"
-
-#: ../src/command/app.cpp:184
-msgid "View the event log"
-msgstr "Mostra el registre d'esdeveniments"
-
-#: ../src/command/app.cpp:194
-msgid "New &Window"
-msgstr "&Finestra nova"
-
-#: ../src/command/app.cpp:195
-msgid "New Window"
-msgstr "Finestra nova"
-
-#: ../src/command/app.cpp:196
-msgid "Open a new application window"
-msgstr "Obre una nova finestra de l'aplicació"
-
-#: ../src/command/app.cpp:206
-msgid "&Options..."
-msgstr "&Opcions..."
-
-#: ../src/command/app.cpp:208
-msgid "Configure Aegisub"
-msgstr "Configura l'Aegisub"
-
-#: ../src/command/app.cpp:222 ../src/command/app.cpp:223
-msgid "Toggle global hotkey overrides"
-msgstr "Activa/desactiva els canvis a les dreceres de teclat globals"
-
-#: ../src/command/app.cpp:224
-msgid "Toggle global hotkey overrides (Medusa Mode)"
-msgstr ""
-"Activa/desactiva els canvis a les dreceres de teclat globals (mode Medusa)"
-
-#: ../src/command/app.cpp:239
-msgid "Toggle the main toolbar"
-msgstr "Mostra/amaga la barra d'eines principal"
-
-#: ../src/command/app.cpp:244
-msgid "Hide Toolbar"
-msgstr "Amaga la barra d'eines"
-
-#: ../src/command/app.cpp:245
-msgid "Show Toolbar"
-msgstr "Mostra la barra d'eines"
-
-#: ../src/command/app.cpp:260
-msgid "&Check for Updates..."
-msgstr "&Comprova si hi ha actualitzacions..."
-
-#: ../src/command/app.cpp:261
-msgid "Check for Updates"
-msgstr "Comprova si hi ha actualitzacions"
-
-#: ../src/command/app.cpp:262
-msgid "Check to see if there is a new version of Aegisub available"
-msgstr "Comprova si hi ha una nova versió de l'Aegisub disponible"
+"Disminueix la llargada de la unitat de temps actual i desplaça els següents "
+"elements"
+
+#: ../src/command/time.cpp:321 ../src/command/time.cpp:322
+msgid "Shift start time forward"
+msgstr "Desplaça el temps d'inici cap endavant"
+
+#: ../src/command/time.cpp:323
+msgid "Shift the start time of the current timing unit forward"
+msgstr "Desplaça el temps d'inici de la unitat de temps actual cap endavant"
+
+#: ../src/command/time.cpp:332 ../src/command/time.cpp:333
+msgid "Shift start time backward"
+msgstr "Desplaça el temps d'inici cap endarrere"
+
+#: ../src/command/time.cpp:334
+msgid "Shift the start time of the current timing unit backward"
+msgstr "Desplaça el temps d'inici de la unitat de temps actual cap endarrere"
+
+#: ../src/command/time.cpp:344
+msgid "Snap &Start to Video"
+msgstr "E&nganxa l'inici al vídeo"
+
+#: ../src/command/time.cpp:345
+msgid "Snap Start to Video"
+msgstr "Enganxa l'inici al vídeo"
+
+#: ../src/command/time.cpp:346
+msgid "Set start of selected subtitles to current video frame"
+msgstr "Posa l'inici dels subtítols seleccionats al fotograma actual del vídeo"
+
+#: ../src/command/time.cpp:358
+msgid "Next line or syllable"
+msgstr "Línia o síl·laba següent"
+
+#: ../src/command/time.cpp:370
+msgid "Previous line or syllable"
+msgstr "Línia o síl·laba anterior"
 
 #: ../src/command/grid.cpp:53
 msgid "Move to the next subtitle line"
@@ -2353,6 +3267,11 @@ msgstr "Avança a la següent línia de subtítols"
 #: ../src/command/grid.cpp:65
 msgid "Move to the next subtitle line, creating a new one if needed"
 msgstr "Avança a la següent línia de subtítols, creant-ne una de nova si cal"
+
+#: ../src/command/grid.cpp:82 ../src/command/subtitle.cpp:128
+#: ../src/command/subtitle.cpp:162 ../src/command/subtitle.cpp:204
+msgid "line insertion"
+msgstr "la inserció de la línia"
 
 #: ../src/command/grid.cpp:92
 msgid "Move to the previous line"
@@ -2383,17 +3302,6 @@ msgstr "l'ordenació"
 msgid "Sort selected subtitles by their actor names"
 msgstr "Ordena els subtítols seleccionats pels seus noms d'actor"
 
-#: ../src/command/grid.cpp:133 ../src/command/grid.cpp:145
-#: ../src/dialog_search_replace.cpp:87
-msgid "&Effect"
-msgstr "&Efecte"
-
-#: ../src/command/grid.cpp:134 ../src/command/grid.cpp:146
-#: ../src/dialog_paste_over.cpp:72 ../src/subs_edit_box.cpp:145
-#: ../src/grid_column.cpp:191 ../src/grid_column.cpp:192
-msgid "Effect"
-msgstr "Efecte"
-
 #: ../src/command/grid.cpp:135
 msgid "Sort all subtitles by their effects"
 msgstr "Ordena tots els subtítols pels seus efectes"
@@ -2405,11 +3313,6 @@ msgstr "Ordena els subtítols seleccionats pels seus efectes"
 #: ../src/command/grid.cpp:157 ../src/command/grid.cpp:169
 msgid "&End Time"
 msgstr "Temps de &final"
-
-#: ../src/command/grid.cpp:158 ../src/command/grid.cpp:170
-#: ../src/dialog_paste_over.cpp:66 ../src/grid_column.cpp:147
-msgid "End Time"
-msgstr "Temps de final"
 
 #: ../src/command/grid.cpp:159
 msgid "Sort all subtitles by their end times"
@@ -2423,11 +3326,6 @@ msgstr "Ordena els subtítols seleccionats pels seus temps de final"
 msgid "&Layer"
 msgstr "&Capa"
 
-#: ../src/command/grid.cpp:182 ../src/command/grid.cpp:194
-#: ../src/dialog_paste_over.cpp:64 ../src/grid_column.cpp:107
-msgid "Layer"
-msgstr "Capa"
-
 #: ../src/command/grid.cpp:183
 msgid "Sort all subtitles by their layer number"
 msgstr "Ordena tots els subtítols pels seus números de capa"
@@ -2439,11 +3337,6 @@ msgstr "Ordena els subtítols seleccionats pels seus números de capa"
 #: ../src/command/grid.cpp:205 ../src/command/grid.cpp:217
 msgid "&Start Time"
 msgstr "Temps d'&inici"
-
-#: ../src/command/grid.cpp:206 ../src/command/grid.cpp:218
-#: ../src/dialog_paste_over.cpp:65 ../src/grid_column.cpp:129
-msgid "Start Time"
-msgstr "Temps d'inici"
 
 #: ../src/command/grid.cpp:207
 msgid "Sort all subtitles by their start times"
@@ -2458,7 +3351,7 @@ msgid "St&yle Name"
 msgstr "No&m de l'estil"
 
 #: ../src/command/grid.cpp:230 ../src/command/grid.cpp:242
-#: ../src/dialog_style_editor.cpp:177
+#: ../src/dialog_style_editor.cpp:178
 msgid "Style Name"
 msgstr "Nom de l'estil"
 
@@ -2567,559 +3460,289 @@ msgstr "Intercanvia les dues línies seleccionades"
 msgid "swap lines"
 msgstr "l'intercanvi de línies"
 
-#: ../src/command/automation.cpp:48
-msgid "&Reload Automation scripts"
-msgstr "&Recarrega els scripts d'automatització"
-
-#: ../src/command/automation.cpp:49
-msgid "Reload Automation scripts"
-msgstr "Recarrega els scripts d'automatització"
-
-#: ../src/command/automation.cpp:50
-msgid "Reload all Automation scripts and rescan the autoload folder"
-msgstr ""
-"Recarrega tots els scripts d'automatització i reescaneja la carpeta de "
-"càrrega automàtica"
-
-#: ../src/command/automation.cpp:55
-msgid "Reloaded all Automation scripts"
-msgstr "S'han recarregat tots els scripts d'automatització"
-
-#: ../src/command/automation.cpp:61
-msgid "R&eload autoload Automation scripts"
-msgstr "R&ecarrega tots els scripts d'automatització de càrrega automàtica"
-
-#: ../src/command/automation.cpp:62
-msgid "Reload autoload Automation scripts"
-msgstr "Recarrega tots els scripts d'automatització de càrrega automàtica"
-
-#: ../src/command/automation.cpp:63
-msgid "Rescan the Automation autoload folder"
-msgstr "Reescaneja la carpeta de càrrega automàtica de l'automatització"
-
-#: ../src/command/automation.cpp:67
-msgid "Reloaded autoload Automation scripts"
-msgstr "S'han recarregat els scripts d'automatització de càrrega automàtica"
-
-#: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
-msgid "&Automation..."
-msgstr "&Automatització..."
-
-#: ../src/command/automation.cpp:75 ../src/command/automation.cpp:87
-#: ../src/preferences.cpp:314
-msgid "Automation"
-msgstr "Automatització"
-
-#: ../src/command/automation.cpp:76
-msgid "Open automation manager"
-msgstr "Obre el gestor de l'automatització"
-
-#: ../src/command/automation.cpp:88
-msgid ""
-"Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
-"autoload folder and reload all automation scripts"
-msgstr ""
-"Obre el gestor de l'automatització. Control: Reescaneja la carpeta de "
-"càrrega automàtica. Control+Majús: Reescaneja la carpeta de càrrega "
-"automàtica i recarrega tots els scripts d'automatització"
-
-#: ../src/command/time.cpp:99
-msgid "adjoin"
-msgstr "l'ajuntament"
-
-#: ../src/command/time.cpp:104
-msgid "Change &End"
-msgstr "Canvia &el final"
-
-#: ../src/command/time.cpp:105
-msgid "Change End"
-msgstr "Canvia el final"
-
-#: ../src/command/time.cpp:106
-msgid "Change end times of lines to the next line's start time"
-msgstr ""
-"Canvia els temps de final de les línies al temps d'inici de la següent línia"
-
-#: ../src/command/time.cpp:115
-msgid "Change &Start"
-msgstr "Canvia l'&inici"
-
-#: ../src/command/time.cpp:116
-msgid "Change Start"
-msgstr "Canvia l'inici"
-
-#: ../src/command/time.cpp:117
-msgid "Change start times of lines to the previous line's end time"
-msgstr ""
-"Canvia els temps d'inici de les línies al temps de final de l'anterior línia"
-
-#: ../src/command/time.cpp:127
-msgid "Shift to &Current Frame"
-msgstr "Desplaça al &fotograma actual"
-
-#: ../src/command/time.cpp:128
-msgid "Shift to Current Frame"
-msgstr "Desplaça al fotograma actual"
-
-#: ../src/command/time.cpp:129
-msgid "Shift selection so that the active line starts at current frame"
-msgstr ""
-"Desplaça la selecció perquè la línia activa comenci al fotograma actual"
-
-#: ../src/command/time.cpp:145
-msgid "shift to frame"
-msgstr "el desplaçament al fotograma"
-
-#: ../src/command/time.cpp:152
-msgid "S&hift Times..."
-msgstr "Des&plaça els temps..."
-
-#: ../src/command/time.cpp:154
-msgid "Shift subtitles by time or frames"
-msgstr "Desplaça els subtítols per temps o per fotogrames"
-
-#: ../src/command/time.cpp:175 ../src/audio_timing_dialogue.cpp:512
-#: ../src/audio_timing_dialogue.cpp:518
-msgid "timing"
-msgstr "els temps"
-
-#: ../src/command/time.cpp:181
-msgid "Snap &End to Video"
-msgstr "&Enganxa el final al vídeo"
-
-#: ../src/command/time.cpp:182
-msgid "Snap End to Video"
-msgstr "Enganxa el final al vídeo"
-
-#: ../src/command/time.cpp:183
-msgid "Set end of selected subtitles to current video frame"
-msgstr "Posa el final dels subtítols al fotograma actual del vídeo"
-
-#: ../src/command/time.cpp:193
-msgid "Snap to S&cene"
-msgstr "Enganxa a l'es&cena"
-
-#: ../src/command/time.cpp:194
-msgid "Snap to Scene"
-msgstr "Enganxa a l'escena"
-
-#: ../src/command/time.cpp:195
-msgid ""
-"Set start and end of subtitles to the keyframes around current video frame"
-msgstr ""
-"Posa l'inici i el final dels subtítols als fotogrames clau al voltant del "
-"fotograma de vídeo actual"
-
-#: ../src/command/time.cpp:232
-msgid "snap to scene"
-msgstr "l'enganxament a l'escena"
-
-#: ../src/command/time.cpp:238 ../src/command/time.cpp:239
-msgid "Add lead in and out"
-msgstr "Afegeix temps d'entrada i sortida"
-
-#: ../src/command/time.cpp:240
-msgid "Add both lead in and out to the selected lines"
-msgstr "Afegeix tant temps d'entrada com de sortida a les línies seleccionades"
-
-#: ../src/command/time.cpp:252 ../src/command/time.cpp:253
-msgid "Add lead in"
-msgstr "Afegeix temps d'entrada"
-
-#: ../src/command/time.cpp:254
-msgid "Add the lead in time to the selected lines"
-msgstr "Afegeix el temps d'entrada a les línies seleccionades"
-
-#: ../src/command/time.cpp:264 ../src/command/time.cpp:265
-msgid "Add lead out"
-msgstr "Afegeix temps de sortida"
-
-#: ../src/command/time.cpp:266
-msgid "Add the lead out time to the selected lines"
-msgstr "Afegeix el temps de sortida a les línies seleccionades"
-
-#: ../src/command/time.cpp:275 ../src/command/time.cpp:276
-msgid "Increase length"
-msgstr "Augmenta la llargada"
-
-#: ../src/command/time.cpp:277
-msgid "Increase the length of the current timing unit"
-msgstr "Augmenta la llargada de la unitat de temps actual"
-
-#: ../src/command/time.cpp:286 ../src/command/time.cpp:287
-msgid "Increase length and shift"
-msgstr "Augmenta la llargada i desplaça"
-
-#: ../src/command/time.cpp:288
-msgid ""
-"Increase the length of the current timing unit and shift the following items"
-msgstr ""
-"Augmenta la llargada de la unitat de temps actual i desplaça els següents "
-"elements"
-
-#: ../src/command/time.cpp:297 ../src/command/time.cpp:298
-msgid "Decrease length"
-msgstr "Disminueix la llargada"
-
-#: ../src/command/time.cpp:299
-msgid "Decrease the length of the current timing unit"
-msgstr "Disminueix la llargada de la unitat de temps actual"
-
-#: ../src/command/time.cpp:308 ../src/command/time.cpp:309
-msgid "Decrease length and shift"
-msgstr "Disminueix la llargada i desplaça"
-
-#: ../src/command/time.cpp:310
-msgid ""
-"Decrease the length of the current timing unit and shift the following items"
-msgstr ""
-"Disminueix la llarga de la unitat de temps actual i desplaça els següents "
-"elements"
-
-#: ../src/command/time.cpp:319 ../src/command/time.cpp:320
-msgid "Shift start time forward"
-msgstr "Desplaça el temps d'inici cap endavant"
-
-#: ../src/command/time.cpp:321
-msgid "Shift the start time of the current timing unit forward"
-msgstr "Desplaça el temps d'inici de la unitat de temps actual cap endavant"
-
-#: ../src/command/time.cpp:330 ../src/command/time.cpp:331
-msgid "Shift start time backward"
-msgstr "Desplaça el temps d'inici cap endarrere"
-
-#: ../src/command/time.cpp:332
-msgid "Shift the start time of the current timing unit backward"
-msgstr "Desplaça el temps d'inici de la unitat de temps actual cap endarrere"
-
-#: ../src/command/time.cpp:342
-msgid "Snap &Start to Video"
-msgstr "E&nganxa l'inici al vídeo"
-
-#: ../src/command/time.cpp:343
-msgid "Snap Start to Video"
-msgstr "Enganxa l'inici al vídeo"
-
-#: ../src/command/time.cpp:344
-msgid "Set start of selected subtitles to current video frame"
-msgstr "Posa l'inici dels subtítols seleccionats al fotograma actual del vídeo"
-
-#: ../src/command/time.cpp:356
-msgid "Next line or syllable"
-msgstr "Línia o síl·laba següent"
-
-#: ../src/command/time.cpp:368
-msgid "Previous line or syllable"
-msgstr "Línia o síl·laba anterior"
-
-#: ../src/command/vis_tool.cpp:56 ../src/command/vis_tool.cpp:57
-msgid "Standard"
-msgstr "Estàndard"
-
-#: ../src/command/vis_tool.cpp:58
-msgid "Standard mode, double click sets position"
-msgstr "Mode estàndard, el doble clic defineix la posició"
-
-#: ../src/command/vis_tool.cpp:64 ../src/command/vis_tool.cpp:65
-#: ../src/visual_tool_vector_clip.cpp:57
-msgid "Drag"
-msgstr "Arrossega"
-
-#: ../src/command/vis_tool.cpp:66
-msgid "Drag subtitles"
-msgstr "Arrossega els subtítols"
-
-#: ../src/command/vis_tool.cpp:72 ../src/command/vis_tool.cpp:73
-msgid "Rotate Z"
-msgstr "Rota en Z"
-
-#: ../src/command/vis_tool.cpp:74
-msgid "Rotate subtitles on their Z axis"
-msgstr "Gira els subtítols en l'eix Z"
-
-#: ../src/command/vis_tool.cpp:80 ../src/command/vis_tool.cpp:81
-msgid "Rotate XY"
-msgstr "Rota en XY"
-
-#: ../src/command/vis_tool.cpp:82
-msgid "Rotate subtitles on their X and Y axes"
-msgstr "Gira els subtítols en els eixos X i Y"
-
-#: ../src/command/vis_tool.cpp:88 ../src/command/vis_tool.cpp:89
-msgid "Scale"
-msgstr "Escala"
-
-#: ../src/command/vis_tool.cpp:90
-msgid "Scale subtitles on X and Y axes"
-msgstr "Escala els subtítols en els eixos X i Y"
-
-#: ../src/command/vis_tool.cpp:96 ../src/command/vis_tool.cpp:97
-msgid "Clip"
-msgstr "Retalla"
-
-#: ../src/command/vis_tool.cpp:98
-msgid "Clip subtitles to a rectangle"
-msgstr "Retalla els subtítols a un rectangle"
-
-#: ../src/command/vis_tool.cpp:104 ../src/command/vis_tool.cpp:105
-msgid "Vector Clip"
-msgstr "Retallat vectorial"
-
-#: ../src/command/vis_tool.cpp:106
-msgid "Clip subtitles to a vectorial area"
-msgstr "Retalla els subtítols a una àrea vectorial"
-
-#: ../src/command/audio.cpp:65
+#: ../src/command/timecode.cpp:52 ../src/command/timecode.cpp:53
+msgid "Close Timecodes File"
+msgstr "Tanca el fitxer de codis de temps"
+
+#: ../src/command/timecode.cpp:54
+msgid "Close the currently open timecodes file"
+msgstr "Tanca el fitxer de codis de temps obert actualment"
+
+#: ../src/command/timecode.cpp:69
+msgid "Open Timecodes File..."
+msgstr "Obre el fitxer de codis de temps..."
+
+#: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
+msgid "Open Timecodes File"
+msgstr "Obre el fitxer de codis de temps"
+
+#: ../src/command/timecode.cpp:71
+msgid "Open a VFR timecodes v1 or v2 file"
+msgstr "Obre el fitxer de codis de temps VFR v1 o v2"
+
+#: ../src/command/timecode.cpp:84
+msgid "Save Timecodes File..."
+msgstr "Desa el fitxer de codis de temps..."
+
+#: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
+msgid "Save Timecodes File"
+msgstr "Desa el fitxer de codis de temps"
+
+#: ../src/command/timecode.cpp:86
+msgid "Save a VFR timecodes v2 file"
+msgstr "Desa el fitxer de codis de temps VFR v2"
+
+#: ../src/command/audio.cpp:66
 msgid "&Close Audio"
 msgstr "Tan&ca l'àudio"
 
-#: ../src/command/audio.cpp:66
+#: ../src/command/audio.cpp:67
 msgid "Close Audio"
 msgstr "Tanca l'àudio"
 
-#: ../src/command/audio.cpp:67
+#: ../src/command/audio.cpp:68
 msgid "Close the currently open audio file"
 msgstr "Tanca el fitxer d'àudio obert actualment"
 
-#: ../src/command/audio.cpp:77
+#: ../src/command/audio.cpp:78
 msgid "&Open Audio File..."
 msgstr "&Obre el fitxer d'àudio..."
 
-#: ../src/command/audio.cpp:78 ../src/command/audio.cpp:85
+#: ../src/command/audio.cpp:79 ../src/command/audio.cpp:86
 msgid "Open Audio File"
 msgstr "Obre el fitxer d'àudio"
 
-#: ../src/command/audio.cpp:79
+#: ../src/command/audio.cpp:80
 msgid "Open an audio file"
 msgstr "Obre el fitxer d'àudio"
 
-#: ../src/command/audio.cpp:82
+#: ../src/command/audio.cpp:83
 msgid "Audio Formats"
 msgstr "Formats d'àudio"
 
-#: ../src/command/audio.cpp:93 ../src/command/audio.cpp:94
+#: ../src/command/audio.cpp:94 ../src/command/audio.cpp:95
 msgid "Open 2h30 Blank Audio"
 msgstr "Obre un àudio de 2h 30min de silenci"
 
-#: ../src/command/audio.cpp:95
+#: ../src/command/audio.cpp:96
 msgid "Open a 150 minutes blank audio clip, for debugging"
-msgstr "Obre una peça d'àudio de 150 minuts de silenci, per fer proves"
+msgstr "Obre una peça d'àudio de 150 minuts de silenci, per a fer proves"
 
-#: ../src/command/audio.cpp:104 ../src/command/audio.cpp:105
+#: ../src/command/audio.cpp:105 ../src/command/audio.cpp:106
 msgid "Open 2h30 Noise Audio"
 msgstr "Obre un àudio de 2h 30min de soroll"
 
-#: ../src/command/audio.cpp:106
+#: ../src/command/audio.cpp:107
 msgid "Open a 150 minutes noise-filled audio clip, for debugging"
-msgstr "Obre una peça d'àudio de 150 minuts ple de soroll, per fer proves"
+msgstr "Obre una peça d'àudio de 150 minuts ple de soroll, per a fer proves"
 
-#: ../src/command/audio.cpp:116
+#: ../src/command/audio.cpp:117
 msgid "Open Audio from &Video"
 msgstr "Obre l'àudio del &vídeo"
 
-#: ../src/command/audio.cpp:117
+#: ../src/command/audio.cpp:118
 msgid "Open Audio from Video"
 msgstr "Obre l'àudio del vídeo"
 
-#: ../src/command/audio.cpp:118
+#: ../src/command/audio.cpp:119
 msgid "Open the audio from the current video file"
 msgstr "Obre l'àudio del fitxer de vídeo actual"
 
-#: ../src/command/audio.cpp:132
+#: ../src/command/audio.cpp:133
 msgid "&Spectrum Display"
 msgstr "Visualització d'e&spectre"
 
-#: ../src/command/audio.cpp:133
+#: ../src/command/audio.cpp:134
 msgid "Spectrum Display"
 msgstr "Visualització d'espectre"
 
-#: ../src/command/audio.cpp:134
+#: ../src/command/audio.cpp:135
 msgid "Display audio as a frequency-power spectrograph"
 msgstr "Mostra l'àudio com un espectrògraf de freqüència-potència"
 
-#: ../src/command/audio.cpp:148
+#: ../src/command/audio.cpp:149
 msgid "&Waveform Display"
 msgstr "Visualització en &forma d'ona"
 
-#: ../src/command/audio.cpp:149
+#: ../src/command/audio.cpp:150
 msgid "Waveform Display"
 msgstr "Visualització en forma d'ona"
 
-#: ../src/command/audio.cpp:150
+#: ../src/command/audio.cpp:151
 msgid "Display audio as a linear amplitude graph"
 msgstr "Mostra l'àudio com un gràfic d'amplitud lineal"
 
-#: ../src/command/audio.cpp:187 ../src/command/audio.cpp:188
+#: ../src/command/audio.cpp:165 ../src/command/audio.cpp:166
 msgid "Create audio clip"
 msgstr "Crea una peça d'àudio"
 
-#: ../src/command/audio.cpp:189
+#: ../src/command/audio.cpp:167
 msgid "Save an audio clip of the selected line"
 msgstr "Desa una peça d'àudio de la línia seleccionada"
 
-#: ../src/command/audio.cpp:200
+#: ../src/command/audio.cpp:178
 msgid "Save audio clip"
 msgstr "Desa una peça d'àudio"
 
-#: ../src/command/audio.cpp:247 ../src/command/audio.cpp:248
+#: ../src/command/audio.cpp:193 ../src/command/audio.cpp:194
 msgid "Play current audio selection"
 msgstr "Reprodueix la selecció d'àudio actual"
 
-#: ../src/command/audio.cpp:249
+#: ../src/command/audio.cpp:195
 msgid "Play the current audio selection, ignoring changes made while playing"
 msgstr ""
 "Reprodueix la selecció d'àudio actual, ignorant els canvis fets durant la "
 "reproducció"
 
-#: ../src/command/audio.cpp:262
+#: ../src/command/audio.cpp:208
 msgid "Play the audio for the current line"
 msgstr "Reprodueix l'àudio de la línia actual"
 
-#: ../src/command/audio.cpp:275 ../src/command/audio.cpp:276
+#: ../src/command/audio.cpp:221 ../src/command/audio.cpp:222
 msgid "Play audio selection"
 msgstr "Reprodueix la selecció de l'àudio"
 
-#: ../src/command/audio.cpp:277
+#: ../src/command/audio.cpp:223
 msgid "Play audio until the end of the selection is reached"
 msgstr "Reprodueix l'àudio fins arribar al final de la selecció"
 
-#: ../src/command/audio.cpp:287 ../src/command/audio.cpp:288
+#: ../src/command/audio.cpp:233 ../src/command/audio.cpp:234
 msgid "Play audio selection or stop"
 msgstr "Reprodueix la selecció de l'àudio o atura-la"
 
-#: ../src/command/audio.cpp:289
+#: ../src/command/audio.cpp:235
 msgid "Play selection, or stop playback if it's already playing"
 msgstr "Reprodueix la selecció, o atura la reproducció si ja s'està reproduint"
 
-#: ../src/command/audio.cpp:304 ../src/command/audio.cpp:305
+#: ../src/command/audio.cpp:250 ../src/command/audio.cpp:251
 msgid "Stop playing"
 msgstr "Atura la reproducció"
 
-#: ../src/command/audio.cpp:306
+#: ../src/command/audio.cpp:252
 msgid "Stop audio and video playback"
 msgstr "Atura la reproducció de l'àudio i el vídeo"
 
-#: ../src/command/audio.cpp:322 ../src/command/audio.cpp:323
-#: ../src/command/audio.cpp:324
+#: ../src/command/audio.cpp:268 ../src/command/audio.cpp:269
+#: ../src/command/audio.cpp:270
 msgid "Play 500 ms before selection"
 msgstr "Reprodueix 500 ms abans de la selecció"
 
-#: ../src/command/audio.cpp:336 ../src/command/audio.cpp:337
-#: ../src/command/audio.cpp:338
+#: ../src/command/audio.cpp:282 ../src/command/audio.cpp:283
+#: ../src/command/audio.cpp:284
 msgid "Play 500 ms after selection"
 msgstr "Reprodueix 500 ms després de la selecció"
 
-#: ../src/command/audio.cpp:350 ../src/command/audio.cpp:351
-#: ../src/command/audio.cpp:352
+#: ../src/command/audio.cpp:296 ../src/command/audio.cpp:297
+#: ../src/command/audio.cpp:298
 msgid "Play last 500 ms of selection"
-msgstr "Reprodueix els últims 500 ms de la selecció"
+msgstr "Reprodueix els darrers 500 ms de la selecció"
 
-#: ../src/command/audio.cpp:364 ../src/command/audio.cpp:365
-#: ../src/command/audio.cpp:366
+#: ../src/command/audio.cpp:310 ../src/command/audio.cpp:311
+#: ../src/command/audio.cpp:312
 msgid "Play first 500 ms of selection"
 msgstr "Reprodueix els primers 500 ms de la selecció"
 
-#: ../src/command/audio.cpp:380 ../src/command/audio.cpp:381
-#: ../src/command/audio.cpp:382
+#: ../src/command/audio.cpp:326 ../src/command/audio.cpp:327
+#: ../src/command/audio.cpp:328
 msgid "Play from selection start to end of file"
 msgstr "Reprodueix de l'inici de la selecció al final del fitxer"
 
-#: ../src/command/audio.cpp:393 ../src/command/audio.cpp:394
+#: ../src/command/audio.cpp:339 ../src/command/audio.cpp:340
 msgid "Commit"
 msgstr "Aplica"
 
-#: ../src/command/audio.cpp:395
+#: ../src/command/audio.cpp:341
 msgid "Commit any pending audio timing changes"
 msgstr "Aplica tots els canvis en temps d'àudio pendents"
 
-#: ../src/command/audio.cpp:409 ../src/command/audio.cpp:410
+#: ../src/command/audio.cpp:355 ../src/command/audio.cpp:356
 msgid "Commit and use default timing for next line"
 msgstr "Aplica i utilitza el temps per defecte a la següent línia"
 
-#: ../src/command/audio.cpp:411
+#: ../src/command/audio.cpp:357
 msgid ""
 "Commit any pending audio timing changes and reset the next line's times to "
 "the default"
 msgstr ""
-"Aplica tots els canvis en àudio pendents i restableix els temps de la "
-"següent línia als temps per defecte"
+"Aplica tots els canvis en temps d'àudio pendents i restableix els temps de "
+"la següent línia als temps per defecte"
 
-#: ../src/command/audio.cpp:424 ../src/command/audio.cpp:425
+#: ../src/command/audio.cpp:370 ../src/command/audio.cpp:371
 msgid "Commit and move to next line"
 msgstr "Aplica i avança a la següent línia"
 
-#: ../src/command/audio.cpp:426
+#: ../src/command/audio.cpp:372
 msgid "Commit any pending audio timing changes and move to the next line"
 msgstr ""
 "Aplica tots els canvis en temps d'àudio pendents i avança a la següent línia"
 
-#: ../src/command/audio.cpp:439 ../src/command/audio.cpp:440
+#: ../src/command/audio.cpp:385 ../src/command/audio.cpp:386
 msgid "Commit and stay on current line"
-msgstr "Aplica i queda't a la línia actual"
+msgstr "Aplica i roman a la línia actual"
 
-#: ../src/command/audio.cpp:441
+#: ../src/command/audio.cpp:387
 msgid "Commit any pending audio timing changes and stay on the current line"
 msgstr ""
-"Aplica tots els canvis en temps d'àudio pendents i es queda a la línia actual"
+"Aplica tots els canvis en temps d'àudio pendents i roman a la línia actual"
 
-#: ../src/command/audio.cpp:452 ../src/command/audio.cpp:453
+#: ../src/command/audio.cpp:398 ../src/command/audio.cpp:399
 msgid "Go to selection"
 msgstr "Vés a la selecció"
 
-#: ../src/command/audio.cpp:454
+#: ../src/command/audio.cpp:400
 msgid "Scroll the audio display to center on the current audio selection"
 msgstr ""
 "Desplaça la visualització d'àudio al centre de la selecció d'àudio actual"
 
-#: ../src/command/audio.cpp:463 ../src/command/audio.cpp:464
+#: ../src/command/audio.cpp:409 ../src/command/audio.cpp:410
 msgid "Scroll left"
 msgstr "Desplaça a l'esquerra"
 
-#: ../src/command/audio.cpp:465
+#: ../src/command/audio.cpp:411
 msgid "Scroll the audio display left"
 msgstr "Desplaça la visualització d'àudio a l'esquerra"
 
-#: ../src/command/audio.cpp:474 ../src/command/audio.cpp:475
+#: ../src/command/audio.cpp:420 ../src/command/audio.cpp:421
 msgid "Scroll right"
 msgstr "Desplaça a la dreta"
 
-#: ../src/command/audio.cpp:476
+#: ../src/command/audio.cpp:422
 msgid "Scroll the audio display right"
 msgstr "Desplaça la visualització d'àudio a la dreta"
 
-#: ../src/command/audio.cpp:490 ../src/command/audio.cpp:491
-#: ../src/command/audio.cpp:492
+#: ../src/command/audio.cpp:436 ../src/command/audio.cpp:437
+#: ../src/command/audio.cpp:438
 msgid "Auto scroll audio display to selected line"
 msgstr ""
 "Desplaça automàticament la visualització d'àudio a la línia seleccionada"
 
-#: ../src/command/audio.cpp:507 ../src/command/audio.cpp:508
-#: ../src/command/audio.cpp:509
+#: ../src/command/audio.cpp:453 ../src/command/audio.cpp:454
+#: ../src/command/audio.cpp:455
 msgid "Automatically commit all changes"
 msgstr "Aplica tots els canvis automàticament"
 
-#: ../src/command/audio.cpp:524 ../src/command/audio.cpp:525
+#: ../src/command/audio.cpp:470 ../src/command/audio.cpp:471
 msgid "Auto go to next line on commit"
 msgstr "Vés automàticament a la línia següent en aplicar"
 
-#: ../src/command/audio.cpp:526
+#: ../src/command/audio.cpp:472
 msgid "Automatically go to next line on commit"
 msgstr "Va automàticament a la línia següent en aplicar els canvis"
 
-#: ../src/command/audio.cpp:541 ../src/command/audio.cpp:542
-#: ../src/command/audio.cpp:543
+#: ../src/command/audio.cpp:487 ../src/command/audio.cpp:488
+#: ../src/command/audio.cpp:489
 msgid "Spectrum analyzer mode"
 msgstr "Mode d'analitzador d'espectre"
 
-#: ../src/command/audio.cpp:558 ../src/command/audio.cpp:559
-#: ../src/command/audio.cpp:560
+#: ../src/command/audio.cpp:504 ../src/command/audio.cpp:505
+#: ../src/command/audio.cpp:506
 msgid "Link vertical zoom and volume sliders"
 msgstr "Enllaça les barres de desplaçament de l'ampliació vertical i el volum"
 
-#: ../src/command/audio.cpp:575 ../src/command/audio.cpp:576
-#: ../src/command/audio.cpp:577
+#: ../src/command/audio.cpp:521 ../src/command/audio.cpp:522
+#: ../src/command/audio.cpp:523
 msgid "Toggle karaoke mode"
-msgstr "Activa/desactiva el mode de karaoke"
+msgstr "Commuta el mode de karaoke"
 
 #: ../src/command/help.cpp:48
 msgid "&Bug Tracker..."
@@ -3132,8 +3755,8 @@ msgstr "Sistema de seguiment d'errors"
 #: ../src/command/help.cpp:50
 msgid "Visit Aegisub's bug tracker to report bugs and request new features"
 msgstr ""
-"Visita el sistema de seguiment d'errors de l'Aegisub per avisar d'errades i "
-"demanar noves funcionalitats"
+"Visita el sistema de seguiment d'errors de l'Aegisub per a informar "
+"d'errades i demanar noves funcionalitats"
 
 #: ../src/command/help.cpp:69
 msgid "&Contents"
@@ -3148,1851 +3771,748 @@ msgid "Help topics"
 msgstr "Temes d'ajuda"
 
 #: ../src/command/help.cpp:81
-msgid "&Forums"
-msgstr "&Fòrums"
-
-#: ../src/command/help.cpp:82
-msgid "Forums"
-msgstr "Fòrums"
-
-#: ../src/command/help.cpp:83
-msgid "Visit Aegisub's forums"
-msgstr "Visita els fòrums de l'Aegisub"
-
-#: ../src/command/help.cpp:93
 msgid "&IRC Channel"
 msgstr "Canal d'&IRC"
 
-#: ../src/command/help.cpp:94
+#: ../src/command/help.cpp:82
 msgid "IRC Channel"
 msgstr "Canal d'IRC"
 
-#: ../src/command/help.cpp:95
+#: ../src/command/help.cpp:83
 msgid "Visit Aegisub's official IRC channel"
 msgstr "Visita el canal d'IRC oficial de l'Aegisub"
 
-#: ../src/command/help.cpp:105
+#: ../src/command/help.cpp:93
 msgid "&Visual Typesetting"
 msgstr "Definició d'estils &visual"
 
-#: ../src/command/help.cpp:106
+#: ../src/command/help.cpp:94
 msgid "Visual Typesetting"
 msgstr "Definició d'estils visual"
 
-#: ../src/command/help.cpp:107
+#: ../src/command/help.cpp:95
 msgid "Open the manual page for Visual Typesetting"
-msgstr "Obre la pàgina del manual per a la definició d'estils visual"
+msgstr "Obre la pàgina del manual relativa a la definició d'estils visual"
 
-#: ../src/command/help.cpp:117
+#: ../src/command/help.cpp:105
 msgid "&Website"
 msgstr "Lloc &web"
 
-#: ../src/command/help.cpp:118
+#: ../src/command/help.cpp:106
 msgid "Website"
 msgstr "Lloc web"
 
-#: ../src/command/help.cpp:119
+#: ../src/command/help.cpp:107
 msgid "Visit Aegisub's official website"
 msgstr "Visita el lloc web oficial de l'Aegisub"
 
-#: ../src/command/keyframe.cpp:49 ../src/command/keyframe.cpp:50
-msgid "Close Keyframes"
-msgstr "Tanca els fotogrames clau"
+#: ../src/command/edit.cpp:134 ../src/command/edit.cpp:842
+msgid "paste"
+msgstr "l'enganxament"
 
-#: ../src/command/keyframe.cpp:51
+#: ../src/command/edit.cpp:375
+msgid "set color"
+msgstr "la definició del color"
+
+#: ../src/command/edit.cpp:389
+msgid "Primary Color..."
+msgstr "Color primari..."
+
+#: ../src/command/edit.cpp:390
+msgid "Primary Color"
+msgstr "Color primari"
+
+#: ../src/command/edit.cpp:391
+msgid "Set the primary fill color (\\c) at the cursor position"
+msgstr "Defineix el color d'emplenat primari (\\c) a la posició del cursor"
+
+#: ../src/command/edit.cpp:401
+msgid "Secondary Color..."
+msgstr "Color secundari..."
+
+#: ../src/command/edit.cpp:402
+msgid "Secondary Color"
+msgstr "Color secundari"
+
+#: ../src/command/edit.cpp:403
+msgid "Set the secondary (karaoke) fill color (\\2c) at the cursor position"
+msgstr ""
+"Defineix el color d'emplenat secundari (de karaoke, \\2c) a la posició del "
+"cursor"
+
+#: ../src/command/edit.cpp:413
+msgid "Outline Color..."
+msgstr "Color del contorn..."
+
+#: ../src/command/edit.cpp:414
+msgid "Outline Color"
+msgstr "Color del contorn"
+
+#: ../src/command/edit.cpp:415
+msgid "Set the outline color (\\3c) at the cursor position"
+msgstr "Defineix el color del contorn (\\3c) a la posició del cursor"
+
+#: ../src/command/edit.cpp:425
+msgid "Shadow Color..."
+msgstr "Color de l'ombra..."
+
+#: ../src/command/edit.cpp:426
+msgid "Shadow Color"
+msgstr "Color de l'ombra"
+
+#: ../src/command/edit.cpp:427
+msgid "Set the shadow color (\\4c) at the cursor position"
+msgstr "Defineix el color de l'ombra (\\4c) a la posició del cursor"
+
+#: ../src/command/edit.cpp:437 ../src/command/edit.cpp:438
+msgid "Toggle Bold"
+msgstr "Commuta la negreta"
+
+#: ../src/command/edit.cpp:439
 msgid ""
-"Discard the currently loaded keyframes and use those from the video, if any"
+"Toggle bold (\\b) for the current selection or at the current cursor position"
 msgstr ""
-"Descarta els fotogrames clau carregats actualment i utilitza els del vídeo, "
-"si n'hi ha"
+"Commuta la negreta (\\b) a la selecció o a la posició del cursor actual"
 
-#: ../src/command/keyframe.cpp:66
-msgid "Open Keyframes..."
-msgstr "Obre els fotogrames clau..."
+#: ../src/command/edit.cpp:442
+msgid "toggle bold"
+msgstr "el canvi de la negreta"
 
-#: ../src/command/keyframe.cpp:67
-msgid "Open Keyframes"
-msgstr "Obre els fotogrames clau"
+#: ../src/command/edit.cpp:449 ../src/command/edit.cpp:450
+msgid "Toggle Italics"
+msgstr "Commuta la cursiva"
 
-#: ../src/command/keyframe.cpp:68
-msgid "Open a keyframe list file"
-msgstr "Obre el fitxer d'una llista de fotogrames clau"
-
-#: ../src/command/keyframe.cpp:72
-msgid "Open keyframes file"
-msgstr "Obre el fitxer de fotogrames clau"
-
-#: ../src/command/keyframe.cpp:85
-msgid "Save Keyframes..."
-msgstr "Desa els fotogrames clau..."
-
-#: ../src/command/keyframe.cpp:86
-msgid "Save Keyframes"
-msgstr "Desa els fotogrames clau"
-
-#: ../src/command/keyframe.cpp:87
-msgid "Save the current list of keyframes to a file"
-msgstr "Desa la llista actual de fotogrames clau en un fitxer"
-
-#: ../src/command/keyframe.cpp:95
-msgid "Save keyframes file"
-msgstr "Desa el fitxer de fotogrames clau"
-
-#: ../src/dialog_selected_choices.cpp:33 ../src/dialog_export.cpp:126
-msgid "Select &None"
-msgstr "&No seleccionis res"
-
-#: ../src/subtitles_provider_libass.cpp:112
-msgid "Updating font index"
-msgstr "S'està actualitzant l'índex de tipus de lletra"
-
-#: ../src/subtitles_provider_libass.cpp:113
-msgid "This may take several minutes"
-msgstr "Això pot trigar uns quants minuts"
-
-#: ../src/dialog_spellchecker.cpp:125
-msgid "Misspelled word:"
-msgstr "Paraula mal escrita:"
-
-#: ../src/dialog_spellchecker.cpp:127 ../src/dialog_search_replace.cpp:73
-msgid "Replace with:"
-msgstr "Substitueix-ho per:"
-
-#: ../src/dialog_spellchecker.cpp:182 ../src/dialog_search_replace.cpp:80
-msgid "&Skip Comments"
-msgstr "&Omet els comentaris"
-
-#: ../src/dialog_spellchecker.cpp:183
-msgid "Ignore &UPPERCASE words"
-msgstr "Ignora les paraules en &MAJÚSCULA"
-
-#: ../src/dialog_spellchecker.cpp:187
-msgid "&Replace"
-msgstr "&Substitueix"
-
-#: ../src/dialog_spellchecker.cpp:190 ../src/dialog_search_replace.cpp:95
-msgid "Replace &all"
-msgstr "Substitueix-ho &tot"
-
-#: ../src/dialog_spellchecker.cpp:197
-msgid "&Ignore"
-msgstr "&Ignora"
-
-#: ../src/dialog_spellchecker.cpp:200
-msgid "Ignore a&ll"
-msgstr "Ignora-ho t&ot"
-
-#: ../src/dialog_spellchecker.cpp:206
-msgid "Add to &dictionary"
-msgstr "Afegeix al &diccionari"
-
-#: ../src/dialog_spellchecker.cpp:212
-msgid "Remove fro&m dictionary"
-msgstr "Suprimeix de&l diccionari"
-
-#: ../src/dialog_spellchecker.cpp:279
-msgid "Aegisub has finished checking spelling of this script."
-msgstr "L'Aegisub ha finalizat la correcció ortogràfica per a aquest script."
-
-#: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
-msgid "Spell checking complete."
-msgstr "Ha finalitzat la correcció ortogràfica."
-
-#: ../src/dialog_spellchecker.cpp:283
-msgid "Aegisub has found no spelling mistakes in this script."
-msgstr "L'Aegisub no ha trobat cap errada ortogràfica en aquest script."
-
-#: ../src/dialog_spellchecker.cpp:329 ../src/dialog_spellchecker.cpp:343
-msgid "spell check replace"
-msgstr "la substitució del correcció ortogràfic"
-
-#: ../src/preferences_base.cpp:63
-msgid "Please choose the folder:"
-msgstr "Escolliu la carpeta:"
-
-#: ../src/preferences_base.cpp:209
-msgid "Browse..."
-msgstr "Navega..."
-
-#: ../src/preferences_base.cpp:244
-msgid "Choose..."
-msgstr "Selecciona..."
-
-#: ../src/preferences_base.cpp:252
-msgid "Font Size"
-msgstr "Mida de la lletra"
-
-#: ../src/dialog_properties.cpp:89
-msgid "Script Properties"
-msgstr "Propietats de l'script"
-
-#: ../src/dialog_properties.cpp:95
-msgid "Script"
-msgstr "Script"
-
-#: ../src/dialog_properties.cpp:98
-msgid "Title:"
-msgstr "Títol:"
-
-#: ../src/dialog_properties.cpp:99
-msgid "Original script:"
-msgstr "Script original:"
-
-#: ../src/dialog_properties.cpp:100
-msgid "Translation:"
-msgstr "Traducció:"
-
-#: ../src/dialog_properties.cpp:101
-msgid "Editing:"
-msgstr "Edició:"
-
-#: ../src/dialog_properties.cpp:102
-msgid "Timing:"
-msgstr "Temps:"
-
-#: ../src/dialog_properties.cpp:103
-msgid "Synch point:"
-msgstr "Punt de sincronització:"
-
-#: ../src/dialog_properties.cpp:104
-msgid "Updated by:"
-msgstr "Actualitzat per:"
-
-#: ../src/dialog_properties.cpp:105
-msgid "Update details:"
-msgstr "Detalls de l'actualització:"
-
-#: ../src/dialog_properties.cpp:114 ../src/export_framerate.cpp:70
-#: ../src/dialog_resample.cpp:141
-msgid "From &video"
-msgstr "Del &vídeo"
-
-#: ../src/dialog_properties.cpp:133
-msgid "Resolution"
-msgstr "Resolució"
-
-#: ../src/dialog_properties.cpp:141
-msgid "0: Smart wrapping, top line is wider"
-msgstr "0: Salts intel·ligents, la línia de dalt és més llarga"
-
-#: ../src/dialog_properties.cpp:142
-msgid "1: End-of-line word wrapping, only \\N breaks"
-msgstr "1: Salts de paraules a final de línia, només \\N salta"
-
-#: ../src/dialog_properties.cpp:143
-msgid "2: No word wrapping, both \\n and \\N break"
-msgstr "2: Sense salts de paraules, tant \\n com \\N salten"
-
-#: ../src/dialog_properties.cpp:144
-msgid "3: Smart wrapping, bottom line is wider"
-msgstr "3: Salts intel·ligents, la línia de baix és més llarga"
-
-#: ../src/dialog_properties.cpp:148
-msgid "Wrap Style: "
-msgstr "Estil de salt de línia:"
-
-#: ../src/dialog_properties.cpp:151
-msgid "Scale Border and Shadow"
-msgstr "Escala la vora i l'ombra"
-
-#: ../src/dialog_properties.cpp:152
+#: ../src/command/edit.cpp:451
 msgid ""
-"Scale border and shadow together with script/render resolution. If this is "
-"unchecked, relative border and shadow size will depend on renderer."
+"Toggle italics (\\i) for the current selection or at the current cursor "
+"position"
 msgstr ""
-"Escala la vora i l'ombra juntament amb la resolució de l'script. Si està "
-"desmarcat, la vora i l'ombra relatives dependran del renderitzador."
+"Commuta la cursiva (\\i) a la selecció o a la posició del cursor actual"
 
-#: ../src/dialog_properties.cpp:193
-msgid "property changes"
-msgstr "els canvis a les propietats"
+#: ../src/command/edit.cpp:454
+msgid "toggle italic"
+msgstr "el canvi de la cursiva"
 
-#: ../src/dialog_fonts_collector.cpp:107
-msgid "Symlinking fonts to folder...\n"
-msgstr "S'estan enllaçant simbòlicament els tipus de lletra a la carpeta...\n"
+#: ../src/command/edit.cpp:461 ../src/command/edit.cpp:462
+msgid "Toggle Underline"
+msgstr "Commuta el subratllat"
 
-#: ../src/dialog_fonts_collector.cpp:111
-msgid "Copying fonts to folder...\n"
-msgstr "S'estan copiant els tipus de lletra a la carpeta...\n"
-
-#: ../src/dialog_fonts_collector.cpp:114
-msgid "Copying fonts to archive...\n"
-msgstr "S'estan copiant els tipus de lletra a l'arxiu...\n"
-
-#: ../src/dialog_fonts_collector.cpp:126
-#, c-format
-msgid "* Failed to create directory '%s': %s.\n"
-msgstr "* No s'ha pogut crear el directori '%s': %s.\n"
-
-#: ../src/dialog_fonts_collector.cpp:137
-#, c-format
-msgid "* Failed to open %s.\n"
-msgstr "* No s'ha pogut obrir %s.\n"
-
-#: ../src/dialog_fonts_collector.cpp:192
-#, c-format
-msgid "* Copied %s.\n"
-msgstr "* S'ha copiat %s.\n"
-
-#: ../src/dialog_fonts_collector.cpp:194
-#, c-format
-msgid "* %s already exists on destination.\n"
-msgstr "* %s ja existeix a la destinació.\n"
-
-#: ../src/dialog_fonts_collector.cpp:196
-#, c-format
-msgid "* Symlinked %s.\n"
-msgstr "* S'ha enllaçat simbòlicament %s.\n"
-
-#: ../src/dialog_fonts_collector.cpp:198
-#, c-format
-msgid "* Failed to copy %s.\n"
-msgstr "* No s'ha pogut copiar %s.\n"
-
-#: ../src/dialog_fonts_collector.cpp:204
-msgid "Done. All fonts copied."
-msgstr "Fet. S'han copiat tots els tipus de lletra."
-
-#: ../src/dialog_fonts_collector.cpp:206
-msgid "Done. Some fonts could not be copied."
-msgstr "Fet. No s'han pogut copiar alguns tipus de lletra."
-
-#: ../src/dialog_fonts_collector.cpp:209
+#: ../src/command/edit.cpp:463
 msgid ""
-"\n"
-"Over 32 MB of fonts were copied. Some of the fonts may not be loaded by the "
-"player if they are all attached to a Matroska file."
+"Toggle underline (\\u) for the current selection or at the current cursor "
+"position"
 msgstr ""
-"\n"
-"S'han copiat més de 32 MB de tipus de lletra. És possible que el reproductor "
-"no carregui alguns dels tipus de lletra si els adjuntes tots en un fitxer "
-"Matroska."
+"Commuta el subratllat (\\u) a la selecció o a la posició del cursor actual"
 
-#: ../src/dialog_fonts_collector.cpp:224
-msgid "Check fonts for availability"
-msgstr "Comprova la disponibilitat dels tipus de lletra"
+#: ../src/command/edit.cpp:466
+msgid "toggle underline"
+msgstr "el canvi del subratllat"
 
-#: ../src/dialog_fonts_collector.cpp:225
-msgid "Copy fonts to folder"
-msgstr "Copia els tipus de lletra a una carpeta"
+#: ../src/command/edit.cpp:473 ../src/command/edit.cpp:474
+msgid "Toggle Strikeout"
+msgstr "Commuta el ratllat"
 
-#: ../src/dialog_fonts_collector.cpp:226
-msgid "Copy fonts to subtitle file's folder"
-msgstr "Copia els tipus de lletra a la carpeta del fitxer de subtítols"
-
-#: ../src/dialog_fonts_collector.cpp:227
-msgid "Copy fonts to zipped archive"
-msgstr "Copia els tipus de lletra a un arxiu comprimit"
-
-#: ../src/dialog_fonts_collector.cpp:229
-msgid "Symlink fonts to folder"
-msgstr "Enllaça simbòlicament els tipus de lletra a la carpeta"
-
-#: ../src/dialog_fonts_collector.cpp:232 ../src/dialog_selection.cpp:150
-msgid "Action"
-msgstr "Acció"
-
-#: ../src/dialog_fonts_collector.cpp:238
-msgid "Destination"
-msgstr "Destinació"
-
-#: ../src/dialog_fonts_collector.cpp:242
-msgid "&Browse..."
-msgstr "Na&vega..."
-
-#: ../src/dialog_fonts_collector.cpp:251
-msgid "Log"
-msgstr "Registre"
-
-#: ../src/dialog_fonts_collector.cpp:264
-msgid "&Start!"
-msgstr "C&omença!"
-
-#: ../src/dialog_fonts_collector.cpp:301
-msgid "Invalid destination."
-msgstr "Destinació invàlida."
-
-#: ../src/dialog_fonts_collector.cpp:301 ../src/dialog_fonts_collector.cpp:306
-#: ../src/dialog_fonts_collector.cpp:311 ../src/preferences.cpp:257
-#: ../src/dialog_kara_timing_copy.cpp:574
-#: ../src/dialog_kara_timing_copy.cpp:576
-#: ../src/dialog_kara_timing_copy.cpp:626
-msgid "Error"
-msgstr "Error"
-
-#: ../src/dialog_fonts_collector.cpp:306
-msgid "Could not create destination folder."
-msgstr "No s'ha pogut crear la carpeta de destinació."
-
-#: ../src/dialog_fonts_collector.cpp:311
-msgid "Invalid path for .zip file."
-msgstr "Camí invàlid per al fitxer .zip."
-
-#: ../src/dialog_fonts_collector.cpp:335
-msgid "Select archive file name"
-msgstr "Escolliu el nom de fitxer de l'arxiu"
-
-#: ../src/dialog_fonts_collector.cpp:342
-msgid "Select folder to save fonts on"
-msgstr "Seleccioneu la carpeta on desar els tipus de lletra"
-
-#: ../src/dialog_fonts_collector.cpp:356
-msgid "N/A"
-msgstr "N/A"
-
-#: ../src/dialog_fonts_collector.cpp:364
+#: ../src/command/edit.cpp:475
 msgid ""
-"Choose the folder where the fonts will be collected to. It will be created "
-"if it doesn't exist."
+"Toggle strikeout (\\s) for the current selection or at the current cursor "
+"position"
 msgstr ""
-"Escolliu la carpeta on es recol·lectaran els tipus de lletra. Es crearà si "
-"no existeix."
+"Commuta el ratllat (\\s) a la selecció o a la posició del cursor actual"
 
-#: ../src/dialog_fonts_collector.cpp:371
+#: ../src/command/edit.cpp:478
+msgid "toggle strikeout"
+msgstr "el canvi del ratllat"
+
+#: ../src/command/edit.cpp:485
+msgid "Font Face..."
+msgstr "Tipus de lletra..."
+
+#: ../src/command/edit.cpp:486 ../src/preferences_base.cpp:251
+msgid "Font Face"
+msgstr "Tipus de lletra"
+
+#: ../src/command/edit.cpp:487
+msgid "Select a font face and size"
+msgstr "Selecciona un tipus de lletra i una mida"
+
+#: ../src/command/edit.cpp:514
+msgid "set font"
+msgstr "la definició del tipus de lletra"
+
+#: ../src/command/edit.cpp:541
+msgid "Find and R&eplace..."
+msgstr "Cerca i &substitueix..."
+
+#: ../src/command/edit.cpp:542
+msgid "Find and Replace"
+msgstr "Cerca i substitueix"
+
+#: ../src/command/edit.cpp:543
+msgid "Find and replace words in subtitles"
+msgstr "Cerca i substitueix paraules als subtítols"
+
+#: ../src/command/edit.cpp:604
+msgid "&Copy Lines"
+msgstr "&Copia les línies"
+
+#: ../src/command/edit.cpp:605
+msgid "Copy Lines"
+msgstr "Copia les línies"
+
+#: ../src/command/edit.cpp:606
+msgid "Copy subtitles to the clipboard"
+msgstr "Copia els subtítols al porta-retalls"
+
+#: ../src/command/edit.cpp:627
+msgid "Cu&t Lines"
+msgstr "Re&talla les línies"
+
+#: ../src/command/edit.cpp:628
+msgid "Cut Lines"
+msgstr "Retalla les línies"
+
+#: ../src/command/edit.cpp:629
+msgid "Cut subtitles"
+msgstr "Retalla els subtítols"
+
+#: ../src/command/edit.cpp:636
+msgid "cut lines"
+msgstr "el retallat de les línies"
+
+#: ../src/command/edit.cpp:644
+msgid "De&lete Lines"
+msgstr "Suprimeix &les línies"
+
+#: ../src/command/edit.cpp:645
+msgid "Delete Lines"
+msgstr "Suprimeix les línies"
+
+#: ../src/command/edit.cpp:646
+msgid "Delete currently selected lines"
+msgstr "Suprimeix les línies seleccionades"
+
+#: ../src/command/edit.cpp:649
+msgid "delete lines"
+msgstr "la supressió de les línies"
+
+#: ../src/command/edit.cpp:714 ../src/command/edit.cpp:1108
+msgid "split"
+msgstr "la divisió"
+
+#: ../src/command/edit.cpp:714
+msgid "duplicate lines"
+msgstr "la duplicació de les línies"
+
+#: ../src/command/edit.cpp:721
+msgid "&Duplicate Lines"
+msgstr "&Duplica les línies"
+
+#: ../src/command/edit.cpp:722
+msgid "Duplicate Lines"
+msgstr "Duplica les línies"
+
+#: ../src/command/edit.cpp:723
+msgid "Duplicate the selected lines"
+msgstr "Duplica les línies seleccionades"
+
+#: ../src/command/edit.cpp:732 ../src/command/edit.cpp:733
+msgid "Split lines after current frame"
+msgstr "Divideix les línies després del fotograma actual"
+
+#: ../src/command/edit.cpp:734
 msgid ""
-"Enter the name of the destination zip file to collect the fonts to. If a "
-"folder is entered, a default name will be used."
+"Split the current line into a line which ends on the current frame and a "
+"line which starts on the next frame"
 msgstr ""
-"Introduïu el nom del fitxer zip de destinació on s'han de recol·lectar els "
-"tipus de lletra. Si introduïu una carpeta, s'utilitzarà un nom predefinit."
+"Divideix la línia actual en una línia que acaba al fotograma actual i una "
+"línia que comença al següent fotograma"
 
-#: ../src/audio_renderer_waveform.cpp:154
-msgid "Maximum"
-msgstr "Màxim"
+#: ../src/command/edit.cpp:744 ../src/command/edit.cpp:745
+msgid "Split lines before current frame"
+msgstr "Divideix les línies abans del fotograma actual"
 
-#: ../src/audio_renderer_waveform.cpp:155
-msgid "Maximum + Average"
-msgstr "Màxim + Mitjana"
-
-#: ../src/dialog_dummy_video.cpp:103
-msgid "Dummy video options"
-msgstr "Opcions de vídeo fictici"
-
-#: ../src/dialog_dummy_video.cpp:115
-msgid "Checkerboard &pattern"
-msgstr "&Patró de tauler d'escacs"
-
-#: ../src/dialog_dummy_video.cpp:118
-msgid "Video resolution:"
-msgstr "Resolució del vídeo:"
-
-#: ../src/dialog_dummy_video.cpp:120
-msgid "Color:"
-msgstr "Color:"
-
-#: ../src/dialog_dummy_video.cpp:121
-msgid "Frame rate (fps):"
-msgstr "Fotogrames per segon (fps):"
-
-#: ../src/dialog_dummy_video.cpp:122
-msgid "Duration (frames):"
-msgstr "Durada (fotogrames):"
-
-#: ../src/dialog_dummy_video.cpp:164
-#, c-format
-msgid "Resulting duration: %s"
-msgstr "Durada resultant: %s"
-
-#: ../src/preferences.cpp:61 ../src/preferences.cpp:63
-#: ../src/preferences.cpp:316 ../src/preferences.cpp:341
-msgid "General"
-msgstr "General"
-
-#: ../src/preferences.cpp:64
-msgid "Check for updates on startup"
-msgstr "Comprova si hi ha actualitzacions en engegar"
-
-#: ../src/preferences.cpp:65
-msgid "Show main toolbar"
-msgstr "Mostra la barra d'eines principal"
-
-#: ../src/preferences.cpp:66
-msgid "Save UI state in subtitles files"
-msgstr "Desa l'estat de la IU als fitxers de subtítols"
-
-#: ../src/preferences.cpp:69
-msgid "Toolbar Icon Size"
-msgstr "Mida de les icones de la barra d'eines"
-
-#: ../src/preferences.cpp:70 ../src/preferences.cpp:195
-msgid "Never"
-msgstr "Mai"
-
-#: ../src/preferences.cpp:70
-msgid "Always"
-msgstr "Sempre"
-
-#: ../src/preferences.cpp:70 ../src/preferences.cpp:195
-msgid "Ask"
-msgstr "Pregunta"
-
-#: ../src/preferences.cpp:72
-msgid "Automatically load linked files"
-msgstr "Carrega automàticament els fitxers enllaçats"
-
-#: ../src/preferences.cpp:73
-msgid "Undo Levels"
-msgstr "Nivells per desfer"
-
-#: ../src/preferences.cpp:75
-msgid "Recently Used Lists"
-msgstr "Llistes d'utilitzats recentment"
-
-#: ../src/preferences.cpp:76 ../src/dialog_autosave.cpp:70
-msgid "Files"
-msgstr "Fitxers"
-
-#: ../src/preferences.cpp:77
-msgid "Find/Replace"
-msgstr "Cerca/substitueix"
-
-#: ../src/preferences.cpp:83
-msgid "Default styles"
-msgstr "Estils predefinits"
-
-#: ../src/preferences.cpp:85
-msgid "Default style catalogs"
-msgstr "Catàlegs d'estils predefinits"
-
-#: ../src/preferences.cpp:89
+#: ../src/command/edit.cpp:746
 msgid ""
-"The chosen style catalogs will be loaded when you start a new file or import "
-"files in the various formats.\n"
-"\n"
-"You can set up style catalogs in the Style Manager."
+"Split the current line into a line which ends on the previous frame and a "
+"line which starts on the current frame"
 msgstr ""
-"Els catàlegs d'estils seleccionats es carregaran quan inicieu un nou fitxer "
-"o importeu fitxers en diversos formats.\n"
-"\n"
-"Podeu definir catàlegs d'estils al Gestor d'estils."
+"Divideix la línia actual en una línia que acaba al fotograma anterior i una "
+"línia que comença al fotograma actual"
 
-#: ../src/preferences.cpp:114
-msgid "New files"
-msgstr "Nous fitxers"
+#: ../src/command/edit.cpp:786
+msgid "As &Karaoke"
+msgstr "Com a &karaoke"
 
-#: ../src/preferences.cpp:115
-msgid "MicroDVD import"
-msgstr "Importació de MicroDVD"
+#: ../src/command/edit.cpp:787
+msgid "As Karaoke"
+msgstr "Com a karaoke"
 
-#: ../src/preferences.cpp:116
-msgid "SRT import"
-msgstr "Importació d'SRT"
+#: ../src/command/edit.cpp:788
+msgid "Join selected lines in a single one, as karaoke"
+msgstr "Uneix les línies seleccionades en una de sola, com a karaoke"
 
-#: ../src/preferences.cpp:117
-msgid "TTXT import"
-msgstr "Importació de TTXT"
+#: ../src/command/edit.cpp:791
+msgid "join as karaoke"
+msgstr "la unió com a karaoke"
 
-#: ../src/preferences.cpp:118
-msgid "Plain text import"
-msgstr "Importació de text pla"
+#: ../src/command/edit.cpp:797
+msgid "&Concatenate"
+msgstr "&Concatena"
 
-#: ../src/preferences.cpp:125 ../src/preferences.cpp:354
-msgid "Audio"
-msgstr "Àudio"
+#: ../src/command/edit.cpp:798
+msgid "Concatenate"
+msgstr "Concatena"
 
-#: ../src/preferences.cpp:128
-msgid "Default mouse wheel to zoom"
-msgstr "Roda del ratolí per defecte per ampliar"
+#: ../src/command/edit.cpp:799
+msgid "Join selected lines in a single one, concatenating text together"
+msgstr "Uneix les línies seleccionades en una de sola, concatenant-ne el text"
 
-#: ../src/preferences.cpp:129
-msgid "Lock scroll on cursor"
-msgstr "Bloca el desplaçament si hi ha el cursor"
+#: ../src/command/edit.cpp:802 ../src/command/edit.cpp:813
+msgid "join lines"
+msgstr "la unió de les línies"
 
-#: ../src/preferences.cpp:130
-msgid "Snap markers by default"
-msgstr "Enganxa als marcadors per defecte"
+#: ../src/command/edit.cpp:808
+msgid "Keep &First"
+msgstr "&Mantén la primera"
 
-#: ../src/preferences.cpp:131
-msgid "Auto-focus on mouse over"
-msgstr "Focus automàtic en posar el ratolí a damunt"
+#: ../src/command/edit.cpp:809
+msgid "Keep First"
+msgstr "Mantén la primera"
 
-#: ../src/preferences.cpp:132
-msgid "Play audio when stepping in video"
-msgstr "Reprodueix l'àudio en moure el vídeo"
-
-#: ../src/preferences.cpp:133
-msgid "Left-click-drag moves end marker"
-msgstr "Mou el marcador de fi en fer clic esquerre i arrossegar"
-
-#: ../src/preferences.cpp:134
-msgid "Default timing length (ms)"
-msgstr "Llargada per defecte del temps (ms)"
-
-#: ../src/preferences.cpp:135
-msgid "Default lead-in length (ms)"
-msgstr "Llargada per defecte del temps d'entrada (ms)"
-
-#: ../src/preferences.cpp:136
-msgid "Default lead-out length (ms)"
-msgstr "Llargada per defecte del temps de sortida (ms)"
-
-#: ../src/preferences.cpp:138
-msgid "Marker drag-start sensitivity (px)"
-msgstr "Sensibilitat de l'inici d'arrossegament als marcadors (px)"
-
-#: ../src/preferences.cpp:139
-msgid "Line boundary thickness (px)"
-msgstr "Gruix de la línia de límit (px)"
-
-#: ../src/preferences.cpp:140
-msgid "Maximum snap distance (px)"
-msgstr "Distància màxima per enganxar-se (px)"
-
-#: ../src/preferences.cpp:142
-msgid "Don't show"
-msgstr "No les mostris"
-
-#: ../src/preferences.cpp:142
-msgid "Show previous"
-msgstr "Mostra l'anterior"
-
-#: ../src/preferences.cpp:142
-msgid "Show previous and next"
-msgstr "Mostra l'anterior i la següent"
-
-#: ../src/preferences.cpp:142
-msgid "Show all"
-msgstr "Mostra-ho tot"
-
-#: ../src/preferences.cpp:144
-msgid "Show inactive lines"
-msgstr "Mostra les línies inactives"
-
-#: ../src/preferences.cpp:146
-msgid "Include commented inactive lines"
-msgstr "Inclou les les línies inactives comentades"
-
-#: ../src/preferences.cpp:148
-msgid "Display Visual Options"
-msgstr "Opcions visuals"
-
-#: ../src/preferences.cpp:149
-msgid "Keyframes in dialogue mode"
-msgstr "Fotogrames clau en mode diàleg"
-
-#: ../src/preferences.cpp:150
-msgid "Keyframes in karaoke mode"
-msgstr "Fotogrames clau en mode karaoke"
-
-#: ../src/preferences.cpp:151
-msgid "Cursor time"
-msgstr "Temps del cursor"
-
-#: ../src/preferences.cpp:152
-msgid "Video position"
-msgstr "Posició del vídeo"
-
-#: ../src/preferences.cpp:153 ../src/preferences.cpp:246
-msgid "Seconds boundaries"
-msgstr "Límits dels segons"
-
-#: ../src/preferences.cpp:155
-msgid "Waveform Style"
-msgstr "Estil en forma d'ona"
-
-#: ../src/preferences.cpp:157
-msgid "Audio labels"
-msgstr "Etiquetes de l'àudio"
-
-#: ../src/preferences.cpp:168
-msgid "Show keyframes in slider"
-msgstr "Mostra els fotogrames clau a la barra de desplaçament"
-
-#: ../src/preferences.cpp:170
-msgid "Only show visual tools when mouse is over video"
-msgstr "Mostra les eines visuals només quan el ratolí sigui sobre el vídeo"
-
-#: ../src/preferences.cpp:172
-msgid "Seek video to line start on selection change"
-msgstr "Mou el vídeo al temps d'inici de la línia en canviar la selecció"
-
-#: ../src/preferences.cpp:174
-msgid "Automatically open audio when opening video"
-msgstr "Obre l'àudio automàticament en obrir el vídeo"
-
-#: ../src/preferences.cpp:179
-msgid "Default Zoom"
-msgstr "Ampliació per defecte"
-
-#: ../src/preferences.cpp:181
-msgid "Fast jump step in frames"
-msgstr "Pas del salt ràpid en fotogrames"
-
-#: ../src/preferences.cpp:185
-msgid "Screenshot save path"
-msgstr "Camí on desar les captures de pantalla"
-
-#: ../src/preferences.cpp:187
-msgid "Script Resolution"
-msgstr "Resolució de l'script"
-
-#: ../src/preferences.cpp:188
-msgid "Use resolution of first video opened"
-msgstr "Utilitza la resolució del primer vídeo obert"
-
-#: ../src/preferences.cpp:191
-msgid "Default width"
-msgstr "Amplada predefinida"
-
-#: ../src/preferences.cpp:193
-msgid "Default height"
-msgstr "Alçada predefinida"
-
-#: ../src/preferences.cpp:195
-msgid "Always set"
-msgstr "Defineix sempre"
-
-#: ../src/preferences.cpp:195
-msgid "Always resample"
-msgstr "Reajusta sempre"
-
-#: ../src/preferences.cpp:197
-msgid "Match video resolution on open"
-msgstr "Encaixa la resolució del vídeo en obrir"
-
-#: ../src/preferences.cpp:204
-msgid "Interface"
-msgstr "Interfície"
-
-#: ../src/preferences.cpp:206
-msgid "Edit Box"
-msgstr "Caixa d'edició"
-
-#: ../src/preferences.cpp:207
-msgid "Enable call tips"
-msgstr "Activa els consells de crida"
-
-#: ../src/preferences.cpp:208
-msgid "Overwrite in time boxes"
-msgstr "Sobreescriptura a les capses de temps"
-
-#: ../src/preferences.cpp:210
-msgid "Enable syntax highlighting"
-msgstr "Activa el ressaltat de sintaxi"
-
-#: ../src/preferences.cpp:211
-msgid "Dictionaries path"
-msgstr "Camí dels diccionaris"
-
-#: ../src/preferences.cpp:214
-msgid "Character Counter"
-msgstr "Comptador de caràcters"
-
-#: ../src/preferences.cpp:215
-msgid "Maximum characters per line"
-msgstr "Màxim de caràcters per línia"
-
-#: ../src/preferences.cpp:216
-msgid "Characters Per Second Warning Threshold"
-msgstr "Límit d'advertència de caràcters per segon"
-
-#: ../src/preferences.cpp:217
-msgid "Characters Per Second Error Threshold"
-msgstr "Límit d'error de caràcters per segon"
-
-#: ../src/preferences.cpp:218
-msgid "Ignore whitespace"
-msgstr "Ignora els espais en blanc"
-
-#: ../src/preferences.cpp:219
-msgid "Ignore punctuation"
-msgstr "Ignora la puntuació"
-
-#: ../src/preferences.cpp:221
-msgid "Grid"
-msgstr "Graella"
-
-#: ../src/preferences.cpp:222
-msgid "Focus grid on click"
-msgstr "Posa el focus a la graella en fer-hi clic"
-
-#: ../src/preferences.cpp:223
-msgid "Highlight visible subtitles"
-msgstr "Ressalta els subtítols visibles"
-
-#: ../src/preferences.cpp:224
-msgid "Hide overrides symbol"
-msgstr "Símbol per amagar les etiquetes d'estil"
-
-#: ../src/preferences.cpp:232 ../src/dialog_style_editor.cpp:179
-msgid "Colors"
-msgstr "Colors"
-
-#: ../src/preferences.cpp:240
-msgid "Audio Display"
-msgstr "Visualització d'àudio"
-
-#: ../src/preferences.cpp:241
-msgid "Play cursor"
-msgstr "Cursor de reproducció"
-
-#: ../src/preferences.cpp:242
-msgid "Line boundary start"
-msgstr "Línia del límit d'inici"
-
-#: ../src/preferences.cpp:243
-msgid "Line boundary end"
-msgstr "Línia del límit de final"
-
-#: ../src/preferences.cpp:244
-msgid "Line boundary inactive line"
-msgstr "Línia del límit de línia inactiva"
-
-#: ../src/preferences.cpp:245
-msgid "Syllable boundaries"
-msgstr "Límits de síl·laba"
-
-#: ../src/preferences.cpp:248
-msgid "Syntax Highlighting"
-msgstr "Ressaltat de sintaxi"
-
-#: ../src/preferences.cpp:249
-msgid "Background"
-msgstr "Fons"
-
-#: ../src/preferences.cpp:250 ../src/preferences.cpp:326
-msgid "Normal"
-msgstr "Normal"
-
-#: ../src/preferences.cpp:251
-msgid "Comments"
-msgstr "Comentaris"
-
-#: ../src/preferences.cpp:252
-msgid "Drawings"
-msgstr "Dibuixos"
-
-#: ../src/preferences.cpp:253
-msgid "Brackets"
-msgstr "Claudàtors"
-
-#: ../src/preferences.cpp:254
-msgid "Slashes and Parentheses"
-msgstr "Barres i parèntesis"
-
-#: ../src/preferences.cpp:255
-msgid "Tags"
-msgstr "Etiquetes"
-
-#: ../src/preferences.cpp:256
-msgid "Parameters"
-msgstr "Paràmetres"
-
-#: ../src/preferences.cpp:258
-msgid "Error Background"
-msgstr "Fons d'error"
-
-#: ../src/preferences.cpp:259
-msgid "Line Break"
-msgstr "Salt de línia"
-
-#: ../src/preferences.cpp:260
-msgid "Karaoke templates"
-msgstr "Plantilles de karaoke"
-
-#: ../src/preferences.cpp:261
-msgid "Karaoke variables"
-msgstr "Variables de karaoke"
-
-#: ../src/preferences.cpp:267
-msgid "Audio Color Schemes"
-msgstr "Esquemes de color d'àudio:"
-
-#: ../src/preferences.cpp:269 ../src/preferences.cpp:370
-msgid "Spectrum"
-msgstr "Espectre"
-
-#: ../src/preferences.cpp:270
-msgid "Waveform"
-msgstr "Forma d'ona"
-
-#: ../src/preferences.cpp:272
-msgid "Subtitle Grid"
-msgstr "Graella dels subtítols"
-
-#: ../src/preferences.cpp:273
-msgid "Standard foreground"
-msgstr "Frontal estàndard"
-
-#: ../src/preferences.cpp:274
-msgid "Standard background"
-msgstr "Fons estàndard"
-
-#: ../src/preferences.cpp:275
-msgid "Selection foreground"
-msgstr "Frontal seleccionat"
-
-#: ../src/preferences.cpp:276
-msgid "Selection background"
-msgstr "Fons seleccionat"
-
-#: ../src/preferences.cpp:277
-msgid "Collision foreground"
-msgstr "Frontal de col·lisió"
-
-#: ../src/preferences.cpp:278
-msgid "In frame background"
-msgstr "Fons dins del fotograma"
-
-#: ../src/preferences.cpp:279
-msgid "Comment background"
-msgstr "Fons dels comentaris"
-
-#: ../src/preferences.cpp:280
-msgid "Selected comment background"
-msgstr "Fons seleccionat dels comentaris"
-
-#: ../src/preferences.cpp:281
-msgid "Header background"
-msgstr "Fons de la capçalera"
-
-#: ../src/preferences.cpp:282
-msgid "Left Column"
-msgstr "Columna esquerra"
-
-#: ../src/preferences.cpp:283
-msgid "Active Line Border"
-msgstr "Vora de la línia activa"
-
-#: ../src/preferences.cpp:284
-msgid "Lines"
-msgstr "Línies"
-
-#: ../src/preferences.cpp:285
-msgid "CPS Error"
-msgstr "Error de CPS"
-
-#: ../src/preferences.cpp:294
-msgid "Backup"
-msgstr "Còpia de seguretat"
-
-#: ../src/preferences.cpp:296
-msgid "Automatic Save"
-msgstr "Desament automàtic"
-
-#: ../src/preferences.cpp:297 ../src/preferences.cpp:305
-msgid "Enable"
-msgstr "Activa"
-
-#: ../src/preferences.cpp:300
-msgid "Interval in seconds"
-msgstr "Interval en segons"
-
-#: ../src/preferences.cpp:301 ../src/preferences.cpp:307
-#: ../src/preferences.cpp:368
-msgid "Path"
-msgstr "Camí"
-
-#: ../src/preferences.cpp:302
-msgid "Autosave after every change"
-msgstr "Desa automàticament després de cada canvi"
-
-#: ../src/preferences.cpp:304
-msgid "Automatic Backup"
-msgstr "Còpia de seguretat automàtica"
-
-#: ../src/preferences.cpp:318
-msgid "Base path"
-msgstr "Camí base"
-
-#: ../src/preferences.cpp:319
-msgid "Include path"
-msgstr "Camí d'inclusió"
-
-#: ../src/preferences.cpp:320
-msgid "Auto-load path"
-msgstr "Camí de càrrega automàtica"
-
-#: ../src/preferences.cpp:322
-msgid "0: Fatal"
-msgstr "0: Fatal"
-
-#: ../src/preferences.cpp:322
-msgid "1: Error"
-msgstr "1: Error"
-
-#: ../src/preferences.cpp:322
-msgid "2: Warning"
-msgstr "2: Advertència"
-
-#: ../src/preferences.cpp:322
-msgid "3: Hint"
-msgstr "3: Pista"
-
-#: ../src/preferences.cpp:322
-msgid "4: Debug"
-msgstr "4: Depuració"
-
-#: ../src/preferences.cpp:322
-msgid "5: Trace"
-msgstr "5: Traça"
-
-#: ../src/preferences.cpp:324
-msgid "Trace level"
-msgstr "Nivell de traça"
-
-#: ../src/preferences.cpp:326
-msgid "Below Normal (recommended)"
-msgstr "Per sota del normal (recomanat)"
-
-#: ../src/preferences.cpp:326
-msgid "Lowest"
-msgstr "El més baix"
-
-#: ../src/preferences.cpp:328
-msgid "Thread priority"
-msgstr "Prioritat dels fils"
-
-#: ../src/preferences.cpp:330
-msgid "No scripts"
-msgstr "Cap script"
-
-#: ../src/preferences.cpp:330
-msgid "Subtitle-local scripts"
-msgstr "Scripts del subtítol local"
-
-#: ../src/preferences.cpp:330
-msgid "Global autoload scripts"
-msgstr "Scripts globals de càrrega automàtica"
-
-#: ../src/preferences.cpp:330
-msgid "All scripts"
-msgstr "Tots els scripts"
-
-#: ../src/preferences.cpp:332
-msgid "Autoreload on Export"
-msgstr "Recarrega automàticament en exportar"
-
-#: ../src/preferences.cpp:339
-msgid "Advanced"
-msgstr "Avançades"
-
-#: ../src/preferences.cpp:343
+#: ../src/command/edit.cpp:810
 msgid ""
-"Changing these settings might result in bugs and/or crashes.  Do not touch "
-"these unless you know what you're doing."
+"Join selected lines in a single one, keeping text of first and discarding "
+"remaining"
 msgstr ""
-"Si canvieu aquesta configuració podeu provocar errades o bloquejos. No la "
-"modifiqueu si no sabeu què esteu fent."
+"Uneix les línies seleccionades en una de sola, mantenint el text de la "
+"primera i descartant el de la resta"
 
-#: ../src/preferences.cpp:356 ../src/preferences.cpp:419
-msgid "Expert"
-msgstr "Per a experts"
+#: ../src/command/edit.cpp:851
+msgid "&Paste Lines"
+msgstr "Engan&xa les línies"
 
-#: ../src/preferences.cpp:359
-msgid "Audio provider"
-msgstr "Proveïdor d'àudio"
+#: ../src/command/edit.cpp:852
+msgid "Paste Lines"
+msgstr "Enganxa les línies"
 
-#: ../src/preferences.cpp:362
-msgid "Audio player"
-msgstr "Reproductor d'àudio"
+#: ../src/command/edit.cpp:853
+msgid "Paste subtitles"
+msgstr "Enganxa els subtítols"
 
-#: ../src/preferences.cpp:364
-msgid "Cache"
-msgstr "Memòria cau"
+#: ../src/command/edit.cpp:882
+msgid "Paste Lines &Over..."
+msgstr "Enganxa les línies a s&obre..."
 
-#: ../src/preferences.cpp:365
-msgid "None (NOT RECOMMENDED)"
-msgstr "Cap (NO RECOMANAT)"
+#: ../src/command/edit.cpp:883
+msgid "Paste Lines Over"
+msgstr "Enganxa les línies a sobre"
 
-#: ../src/preferences.cpp:365
-msgid "RAM"
-msgstr "RAM"
+#: ../src/command/edit.cpp:884
+msgid "Paste subtitles over others"
+msgstr "Enganxa els subtítols damunt dels altres"
 
-#: ../src/preferences.cpp:365
-msgid "Hard Disk"
-msgstr "Disc dur"
+#: ../src/command/edit.cpp:967
+msgid "Recom&bine Lines"
+msgstr "Recom&bina les línies"
 
-#: ../src/preferences.cpp:367
-msgid "Cache type"
-msgstr "Tipus de memòria cau"
+#: ../src/command/edit.cpp:968
+msgid "Recombine Lines"
+msgstr "Recombina les línies"
 
-#: ../src/preferences.cpp:372
-msgid "Regular quality"
-msgstr "Qualitat regular"
+#: ../src/command/edit.cpp:969
+msgid "Recombine subtitles which have been split and merged"
+msgstr "Recombina els subtítols que han estat dividits i fusionats"
 
-#: ../src/preferences.cpp:372
-msgid "Better quality"
-msgstr "Millor qualitat"
+#: ../src/command/edit.cpp:1039
+msgid "combining"
+msgstr "la combinació"
 
-#: ../src/preferences.cpp:372
-msgid "High quality"
-msgstr "Alta qualitat"
+#: ../src/command/edit.cpp:1045 ../src/command/edit.cpp:1046
+msgid "Split Lines (by karaoke)"
+msgstr "Divideix les línies (per karaoke)"
 
-#: ../src/preferences.cpp:372
-msgid "Insane quality"
-msgstr "Qualitat exagerada"
+#: ../src/command/edit.cpp:1047
+msgid "Use karaoke timing to split line into multiple smaller lines"
+msgstr ""
+"Utilitza el temps dels karaokes per a dividir la línia en múltiples línies "
+"més petites"
 
-#: ../src/preferences.cpp:374
-msgid "Quality"
-msgstr "Qualitat"
+#: ../src/command/edit.cpp:1081
+msgid "splitting"
+msgstr "la divisió"
 
-#: ../src/preferences.cpp:376
-msgid "Cache memory max (MB)"
-msgstr "Màxim de memòria cau (MB)"
+#: ../src/command/edit.cpp:1113 ../src/command/edit.cpp:1114
+#: ../src/subs_edit_ctrl.cpp:397
+msgid "Split at cursor (estimate times)"
+msgstr "Divideix al cursor (estima els temps)"
 
-#: ../src/preferences.cpp:382
-msgid "Avisynth down-mixer"
-msgstr "Mesclador a la baixa de l'Avisynth"
-
-#: ../src/preferences.cpp:383
-msgid "Force sample rate"
-msgstr "Força el ràtio de mostreig"
-
-#: ../src/preferences.cpp:389
-msgid "Ignore"
-msgstr "Ignora"
-
-#: ../src/preferences.cpp:389
-msgid "Stop"
-msgstr "Atura"
-
-#: ../src/preferences.cpp:389
-msgid "Abort"
-msgstr "Avorta"
-
-#: ../src/preferences.cpp:391
-msgid "Audio indexing error handling mode"
-msgstr "Mode de gestió d'errors en la indexació d'àudio"
-
-#: ../src/preferences.cpp:393
-msgid "Always index all audio tracks"
-msgstr "Indexa sempre les pistes d'àudio"
-
-#: ../src/preferences.cpp:398
-msgid "Portaudio device"
-msgstr "Dispositiu Portaudio"
-
-#: ../src/preferences.cpp:403
-msgid "OSS Device"
-msgstr "Dispositiu OSS"
-
-#: ../src/preferences.cpp:408
-msgid "Buffer latency"
-msgstr "Latència de la memòria intermèdia"
-
-#: ../src/preferences.cpp:409
-msgid "Buffer length"
-msgstr "Llargada de la memòria intermèdia"
-
-#: ../src/preferences.cpp:422
-msgid "Video provider"
-msgstr "Proveïdor del vídeo"
-
-#: ../src/preferences.cpp:425
-msgid "Subtitles provider"
-msgstr "Proveïdor de subtítols"
-
-#: ../src/preferences.cpp:428
-msgid "Force BT.601"
-msgstr "Força BT.601"
-
-#: ../src/preferences.cpp:432
-msgid "Allow pre-2.56a Avisynth"
-msgstr "Permet l'Avisynth anterior a 2.56a"
-
-#: ../src/preferences.cpp:434
-msgid "Avisynth memory limit"
-msgstr "Límit de memòria de l'Avisynth"
-
-#: ../src/preferences.cpp:442
-msgid "Debug log verbosity"
-msgstr "Verbositat del registre de depuració"
-
-#: ../src/preferences.cpp:444
-msgid "Decoding threads"
-msgstr "Fils de descodificació"
-
-#: ../src/preferences.cpp:445
-msgid "Enable unsafe seeking"
-msgstr "Activa la visualització insegura"
-
-#: ../src/preferences.cpp:574
-msgid "Hotkeys"
-msgstr "Dreceres del teclat"
-
-#: ../src/preferences.cpp:672
+#: ../src/command/edit.cpp:1115
 msgid ""
-"Are you sure that you want to restore the defaults? All your settings will "
-"be overridden."
+"Split the current line at the cursor, dividing the original line's duration "
+"between the new ones"
 msgstr ""
-"Esteu segur que voleu restaurar els valors predefinits? Tota la vostra "
-"configuració se sobreescriurà."
+"Divideix la línia actual al cursor, dividint la durada de la línia original "
+"entre les noves"
 
-#: ../src/preferences.cpp:672
-msgid "Restore defaults?"
-msgstr "Voleu restaurar els valors predefinits?"
+#: ../src/command/edit.cpp:1129 ../src/command/edit.cpp:1130
+#: ../src/subs_edit_ctrl.cpp:396
+msgid "Split at cursor (preserve times)"
+msgstr "Divideix al cursor (conserva els temps)"
 
-#: ../src/preferences.cpp:690
-msgid "Preferences"
-msgstr "Preferències"
-
-#: ../src/preferences.cpp:718
-msgid "&Restore Defaults"
-msgstr "&Restableix els valors predefinits"
-
-#: ../src/subs_edit_ctrl.cpp:356
-msgid "Spell checker language"
-msgstr "Idioma del corrector ortogràfic"
-
-#: ../src/subs_edit_ctrl.cpp:365
-msgid "Cu&t"
-msgstr "Re&talla"
-
-#: ../src/subs_edit_ctrl.cpp:402
-#, c-format
-msgid "Remove \"%s\" from dictionary"
-msgstr "Suprimeix \"%s\" del diccionari"
-
-#: ../src/subs_edit_ctrl.cpp:407
-msgid "No spell checker suggestions"
-msgstr "No hi ha suggeriments del corrector ortogràfic"
-
-#: ../src/subs_edit_ctrl.cpp:413
-#, c-format
-msgid "Spell checker suggestions for \"%s\""
-msgstr "Suggeriments del corrector ortogràfic per a \"%s\""
-
-#: ../src/subs_edit_ctrl.cpp:418
-msgid "No correction suggestions"
-msgstr "No hi ha suggeriments de correcció"
-
-#: ../src/subs_edit_ctrl.cpp:424
-#, c-format
-msgid "Add \"%s\" to dictionary"
-msgstr "Afegeix \"%s\" al diccionari"
-
-#: ../src/subs_edit_ctrl.cpp:459
-#, c-format
-msgid "Thesaurus suggestions for \"%s\""
-msgstr "Suggeriments del tesaurus per a \"%s\""
-
-#: ../src/subs_edit_ctrl.cpp:462
-msgid "No thesaurus suggestions"
-msgstr "No hi ha suggeriments del tesaurus "
-
-#: ../src/subs_edit_ctrl.cpp:465
-msgid "Thesaurus language"
-msgstr "Idioma del tesaurus"
-
-#: ../src/subs_edit_ctrl.cpp:474
-msgid "Disable"
-msgstr "Desactiva"
-
-#: ../src/menu.cpp:94
-msgid "Empty"
-msgstr "Buit"
-
-#: ../src/menu.cpp:227
-msgid "&Recent"
-msgstr "&Recents"
-
-#: ../src/menu.cpp:410
-msgid "No Automation macros loaded"
-msgstr "No s'han carregat macros d'automatització"
-
-#: ../src/dialog_about.cpp:46
-msgid "Translated into LANGUAGE by PERSON\n"
-msgstr "Traduït al català per Eduard Ereza Martínez.\n"
-
-#: ../src/dialog_about.cpp:122
+#: ../src/command/edit.cpp:1131
 msgid ""
-"\n"
-"See the help file for full credits.\n"
+"Split the current line at the cursor, setting both lines to the original "
+"line's times"
 msgstr ""
-"\n"
-"Vegeu el fitxer d'ajuda per als crèdits complets.\n"
+"Divideix la línia actual al cursor, definint el temps de les dues línies al "
+"temps de la línia original"
 
-#: ../src/dialog_about.cpp:123
-#, c-format
-msgid "Built by %s on %s."
-msgstr "Muntat per %s el %s."
+#: ../src/command/edit.cpp:1140 ../src/command/edit.cpp:1141
+msgid "Split at cursor (at video frame)"
+msgstr "Divideix al cursor (al fotograma del vídeo)"
 
-#: ../src/dialog_kara_timing_copy.cpp:57
-msgid "Source: "
-msgstr "Origen:"
-
-#: ../src/dialog_kara_timing_copy.cpp:58
-msgid "Dest: "
-msgstr "Destinació:"
-
-#: ../src/dialog_kara_timing_copy.cpp:470
-msgid "Kanji timing"
-msgstr "Creació de temps per a kanjis"
-
-#: ../src/dialog_kara_timing_copy.cpp:475 ../src/dialog_paste_over.cpp:73
-#: ../src/grid_column.cpp:334 ../src/grid_column.cpp:335
-msgid "Text"
-msgstr "Text"
-
-#: ../src/dialog_kara_timing_copy.cpp:476
-msgid "Styles"
-msgstr "Estils"
-
-#: ../src/dialog_kara_timing_copy.cpp:478
-msgid "Shortcut Keys"
-msgstr "Dreceres del teclat"
-
-#: ../src/dialog_kara_timing_copy.cpp:479
-msgid "Commands"
-msgstr "Ordres"
-
-#: ../src/dialog_kara_timing_copy.cpp:487
-msgid "Attempt to &interpolate kanji."
-msgstr "Intenta inter&polar els kanjis."
-
-#: ../src/dialog_kara_timing_copy.cpp:494
+#: ../src/command/edit.cpp:1142
 msgid ""
-"When the destination textbox has focus, use the following keys:\n"
-"\n"
-"Right Arrow: Increase dest. selection length\n"
-"Left Arrow: Decrease dest. selection length\n"
-"Up Arrow: Increase source selection length\n"
-"Down Arrow: Decrease source selection length\n"
-"Enter: Link, accept line when done\n"
-"Backspace: Unlink last"
+"Split the current line at the cursor, dividing the line's duration at the "
+"current video frame"
 msgstr ""
-"Quan la capsa de text de destinació tingui el focus, utilitzeu les següents "
-"tecles:\n"
-"\n"
-"Fletxa dreta: Augmenta la llargada de la selecció de destinació\n"
-"Fletxa esquerra: Disminueix la llargada de la selecció de destinació\n"
-"Fletxa amunt: Augmenta la llargada de la selecció d'origen\n"
-"Fletxa avall: Disminueix la llargada de la selecció d'origen\n"
-"Intro: Enllaça, accepta la línia quan s'ha acabat\n"
-"Retrocés: Desenllaça l'última"
+"Divideix la línia actual al cursor, dividint la durada de la línia al "
+"fotograma actual del vídeo"
 
-#: ../src/dialog_kara_timing_copy.cpp:497
-msgid "S&tart!"
-msgstr "&Inicia!"
+#: ../src/command/edit.cpp:1158
+msgid "Redo last undone action"
+msgstr "Refés la darrera acció desfeta"
 
-#: ../src/dialog_kara_timing_copy.cpp:498
-msgid "&Link"
-msgstr "En&llaça"
+#: ../src/command/edit.cpp:1163
+msgid "Nothing to &redo"
+msgstr "No hi ha res a &refer"
 
-#: ../src/dialog_kara_timing_copy.cpp:499
-msgid "&Unlink"
-msgstr "D&esenllaça"
-
-#: ../src/dialog_kara_timing_copy.cpp:500
-msgid "Skip &Source Line"
-msgstr "Omet la línia d'&origen"
-
-#: ../src/dialog_kara_timing_copy.cpp:501
-msgid "Skip &Dest Line"
-msgstr "Omet la línia de &destinació"
-
-#: ../src/dialog_kara_timing_copy.cpp:502
-msgid "&Go Back a Line"
-msgstr "Torna e&nrere una línia"
-
-#: ../src/dialog_kara_timing_copy.cpp:503
-msgid "&Accept Line"
-msgstr "&Accepta la línia"
-
-#: ../src/dialog_kara_timing_copy.cpp:504 ../src/dialog_automation.cpp:122
-#: ../src/dialog_attachments.cpp:89 ../src/dialog_version_check.cpp:126
-msgid "&Close"
-msgstr "Tan&ca"
-
-#: ../src/dialog_kara_timing_copy.cpp:566
-msgid "kanji timing"
-msgstr "creació de temps per a kanjis"
-
-#: ../src/dialog_kara_timing_copy.cpp:574
-msgid "Select source and destination styles first."
-msgstr "Primer seleccioneu els estils d'origen i destinació."
-
-#: ../src/dialog_kara_timing_copy.cpp:576
-msgid "The source and destination styles must be different."
-msgstr "Els estils d'origen i destinació han de ser diferents."
-
-#: ../src/dialog_kara_timing_copy.cpp:626
-msgid "Group all of the source text."
-msgstr "Agrupa tot el text d'origen."
-
-#: ../src/hotkey.cpp:175
-msgid "Invalid command name for hotkey"
-msgstr "Nom d'ordre vàlid per a la drecera de teclat"
-
-#: ../src/dialog_paste_over.cpp:55
-msgid "Select Fields to Paste Over"
-msgstr "Selecciona els camps per enganxar-hi a sobre"
-
-#: ../src/dialog_paste_over.cpp:58
-msgid "Fields"
-msgstr "Camps"
-
-#: ../src/dialog_paste_over.cpp:59
-msgid "Please select the fields that you want to paste over:"
-msgstr "Escolliu els camps sobre els quals voleu enganxar:"
-
-#: ../src/dialog_paste_over.cpp:63
-msgid "Comment"
-msgstr "Comenta"
-
-#: ../src/dialog_paste_over.cpp:67 ../src/grid_column.cpp:177
-#: ../src/grid_column.cpp:178
-msgid "Style"
-msgstr "Estil"
-
-#: ../src/dialog_paste_over.cpp:68 ../src/subs_edit_box.cpp:140
-#: ../src/grid_column.cpp:205 ../src/grid_column.cpp:206
-msgid "Actor"
-msgstr "Actor"
-
-#: ../src/dialog_paste_over.cpp:69
-msgid "Margin Left"
-msgstr "Marge esquerre"
-
-#: ../src/dialog_paste_over.cpp:70
-msgid "Margin Right"
-msgstr "Marge dret"
-
-#: ../src/dialog_paste_over.cpp:71
-msgid "Margin Vertical"
-msgstr "Marge vertical"
-
-#: ../src/dialog_paste_over.cpp:92
-msgid "&Times"
-msgstr "&Temps"
-
-#: ../src/dialog_paste_over.cpp:94
-msgid "T&ext"
-msgstr "T&ext"
-
-#: ../src/main.cpp:274
+#: ../src/command/edit.cpp:1164
 #, c-format
-msgid ""
-"Oops, Aegisub has crashed!\n"
-"\n"
-"An attempt has been made to save a copy of your file to:\n"
-"\n"
-"%s\n"
-"\n"
-"Aegisub will now close."
+msgid "&Redo %s"
+msgstr "&Refés %s"
+
+#: ../src/command/edit.cpp:1168
+msgid "Nothing to redo"
+msgstr "No hi ha res a refer"
+
+#: ../src/command/edit.cpp:1169
+#, c-format
+msgid "Redo %s"
+msgstr "Refés %s"
+
+#: ../src/command/edit.cpp:1184
+msgid "Undo last action"
+msgstr "Desfés la darrera acció"
+
+#: ../src/command/edit.cpp:1189
+msgid "Nothing to &undo"
+msgstr "No hi ha res a &desfer"
+
+#: ../src/command/edit.cpp:1190
+#, c-format
+msgid "&Undo %s"
+msgstr "&Desfés %s"
+
+#: ../src/command/edit.cpp:1194
+msgid "Nothing to undo"
+msgstr "No hi ha res a desfer"
+
+#: ../src/command/edit.cpp:1195
+#, c-format
+msgid "Undo %s"
+msgstr "Desfés %s"
+
+#: ../src/command/edit.cpp:1209 ../src/command/edit.cpp:1210
+msgid "Revert"
+msgstr "Reverteix"
+
+#: ../src/command/edit.cpp:1211
+msgid "Revert the active line to its initial state (shown in the upper editor)"
 msgstr ""
-"Ups, l'Aegisub s'ha bloquejat!\n"
-"\n"
-"S'ha intentat desar una còpia del vostre fitxer a:\n"
-"\n"
-"%s\n"
-"\n"
-"L'Aegisub es tancarà."
+"Reverteix la línia activa al seu estat inicial (mostrat a l'editor de dalt)"
 
-#: ../src/main.cpp:302
-msgid ""
-"Do you want Aegisub to check for updates whenever it starts? You can still "
-"do it manually via the Help menu."
+#: ../src/command/edit.cpp:1216
+msgid "revert line"
+msgstr "la reversió de la línia"
+
+#: ../src/command/edit.cpp:1224
+msgid "Clear the current line's text"
+msgstr "Esborra el text de la línia actual"
+
+#: ../src/command/edit.cpp:1229 ../src/command/edit.cpp:1248
+msgid "clear line"
+msgstr "l'esborrat de la línia"
+
+#: ../src/command/edit.cpp:1236 ../src/command/edit.cpp:1237
+msgid "Clear Text"
+msgstr "Esborra el text"
+
+#: ../src/command/edit.cpp:1238
+msgid "Clear the current line's text, leaving override tags"
+msgstr "Esborra el text de la línia actual, deixant-ne les etiquetes d'estil"
+
+#: ../src/command/edit.cpp:1256
+msgid "Insert the original line text at the cursor"
+msgstr "Insereix la línia de text original al cursor"
+
+#: ../src/command/edit.cpp:1264
+msgid "insert original"
+msgstr "la inserció de l'original"
+
+#: ../src/command/subtitle.cpp:80
+msgid "A&ttachments..."
+msgstr "Ad&juncions..."
+
+#: ../src/command/subtitle.cpp:81
+msgid "Attachments"
+msgstr "Adjuncions"
+
+#: ../src/command/subtitle.cpp:82
+msgid "Open the attachment manager dialog"
+msgstr "Obre el diàleg del gestor d'adjuncions"
+
+#: ../src/command/subtitle.cpp:93
+msgid "&Find..."
+msgstr "C&erca..."
+
+#: ../src/command/subtitle.cpp:95
+msgid "Search for text in the subtitles"
+msgstr "Cerca text als subtítols"
+
+#: ../src/command/subtitle.cpp:106
+msgid "Find &Next"
+msgstr "Cerca el següe&nt"
+
+#: ../src/command/subtitle.cpp:107
+msgid "Find Next"
+msgstr "Cerca el següent"
+
+#: ../src/command/subtitle.cpp:108
+msgid "Find next match of last search"
+msgstr "Cerca la següent coincidència de la darrera cerca"
+
+#: ../src/command/subtitle.cpp:135
+msgid "&After Current"
+msgstr "Després de l'&actual"
+
+#: ../src/command/subtitle.cpp:136
+msgid "After Current"
+msgstr "Després de l'actual"
+
+#: ../src/command/subtitle.cpp:137
+msgid "Insert a new line after the current one"
+msgstr "Insereix una línia nova després de l'actual"
+
+#: ../src/command/subtitle.cpp:169 ../src/command/subtitle.cpp:170
+msgid "After Current, at Video Time"
+msgstr "Després de l'actual, al temps del vídeo"
+
+#: ../src/command/subtitle.cpp:171
+msgid "Insert a new line after the current one, starting at video time"
 msgstr ""
-"Voleu que l'Aegisub comprovi si hi ha actualitzacions cada cop que s'iniciï? "
-"Podreu fer-ho manualment des del menú d'Ajuda."
+"Insereix una línia nova després de l'actual, començant al temps del vídeo"
 
-#: ../src/main.cpp:302
-msgid "Check for updates?"
-msgstr "Voleu comprovar si hi ha actualitzacions?"
+#: ../src/command/subtitle.cpp:180
+msgid "&Before Current"
+msgstr "A&bans de l'actual"
 
-#: ../src/main.cpp:387 ../src/main.cpp:392
-msgid "Program error"
-msgstr "S'ha produït un error al programa"
+#: ../src/command/subtitle.cpp:181
+msgid "Before Current"
+msgstr "Abans de l'actual"
 
-#: ../src/main.cpp:406
-#, c-format
-msgid ""
-"An unexpected error has occurred. Please save your work and restart "
-"Aegisub.\n"
-"\n"
-"Error Message: %s"
+#: ../src/command/subtitle.cpp:182
+msgid "Insert a new line before the current one"
+msgstr "Insereix una línia nova abans de l'actual"
+
+#: ../src/command/subtitle.cpp:211 ../src/command/subtitle.cpp:212
+msgid "Before Current, at Video Time"
+msgstr "Abans de l'actual, al temps del vídeo"
+
+#: ../src/command/subtitle.cpp:213
+msgid "Insert a new line before the current one, starting at video time"
 msgstr ""
-"S'ha produït un error inesperat. Deseu la vostra feina i reinicieu "
-"l'Aegisub.\n"
-"\n"
-"Missatge d'error: %s"
+"Insereix una línia nova abans de l'actual, començant al temps del vídeo"
 
-#: ../src/subs_edit_box.cpp:119
-msgid "&Comment"
-msgstr "&Comenta"
+#: ../src/command/subtitle.cpp:239
+msgid "&New Subtitles"
+msgstr "&Nous subtítols"
 
-#: ../src/subs_edit_box.cpp:120
-msgid "Comment this line out. Commented lines don't show up on screen."
+#: ../src/command/subtitle.cpp:240
+msgid "New Subtitles"
+msgstr "Nous subtítols"
+
+#: ../src/command/subtitle.cpp:241
+msgid "New subtitles"
+msgstr "Nous subtítols"
+
+#: ../src/command/subtitle.cpp:268
+msgid "&Open Subtitles..."
+msgstr "&Obre els subtítols..."
+
+#: ../src/command/subtitle.cpp:269
+msgid "Open Subtitles"
+msgstr "Obre els subtítols"
+
+#: ../src/command/subtitle.cpp:270
+msgid "Open a subtitles file"
+msgstr "Obre el fitxer de subtítols"
+
+#: ../src/command/subtitle.cpp:283
+msgid "Open A&utosaved Subtitles..."
+msgstr "Obre els subtítols desats a&utomàticament..."
+
+#: ../src/command/subtitle.cpp:284
+msgid "Open Autosaved Subtitles"
+msgstr "Obre els subtítols desats automàticament"
+
+#: ../src/command/subtitle.cpp:285
+msgid "Open a previous version of a file which was autosaved by Aegisub"
 msgstr ""
-"Comenta aquesta línia. Les línies comentades no es mostren a la pantalla"
+"Obre una versió anterior d'un fitxer que hagi estat desat automàticament per "
+"l'Aegisub"
 
-#: ../src/subs_edit_box.cpp:127
-msgid "Style for this line"
-msgstr "Estil per a aquesta línia"
+#: ../src/command/subtitle.cpp:298
+msgid "Open Subtitles with &Charset..."
+msgstr "Obre els subtítols amb &codificació..."
 
-#: ../src/subs_edit_box.cpp:129 ../src/subs_edit_box.cpp:130
-msgid "Edit"
-msgstr "Edita"
+#: ../src/command/subtitle.cpp:299
+msgid "Open Subtitles with Charset"
+msgstr "Obre els subtítols amb codificació"
 
-#: ../src/subs_edit_box.cpp:140
-msgid ""
-"Actor name for this speech. This is only for reference, and is mainly "
-"useless."
+#: ../src/command/subtitle.cpp:300
+msgid "Open a subtitles file with a specific file encoding"
+msgstr "Obre el fitxer de subtítols amb una codificació de fitxer concreta"
+
+#: ../src/command/subtitle.cpp:308
+msgid "Choose charset code:"
+msgstr "Trieu el codi de la codificació:"
+
+#: ../src/command/subtitle.cpp:308
+msgid "Charset"
+msgstr "Codificació"
+
+#: ../src/command/subtitle.cpp:317
+msgid "Open Subtitles from &Video"
+msgstr "Obre els subtítols del &vídeo"
+
+#: ../src/command/subtitle.cpp:318
+msgid "Open Subtitles from Video"
+msgstr "Obre els subtítols del vídeo"
+
+#: ../src/command/subtitle.cpp:319
+msgid "Open the subtitles from the current video file"
+msgstr "Obre els subtítols del fitxer de vídeo actual"
+
+#: ../src/command/subtitle.cpp:335
+msgid "&Properties..."
+msgstr "&Propietats..."
+
+#: ../src/command/subtitle.cpp:336
+msgid "Properties"
+msgstr "Propietats"
+
+#: ../src/command/subtitle.cpp:337
+msgid "Open script properties window"
+msgstr "Obre la finestra de propietats de l'script"
+
+#: ../src/command/subtitle.cpp:348
+msgid "Save subtitles file"
+msgstr "Desa el fitxer de subtítols"
+
+#: ../src/command/subtitle.cpp:368
+msgid "&Save Subtitles"
+msgstr "De&sa els subtítols"
+
+#: ../src/command/subtitle.cpp:369
+msgid "Save Subtitles"
+msgstr "Desa els subtítols"
+
+#: ../src/command/subtitle.cpp:370
+msgid "Save the current subtitles"
+msgstr "Desa els subtítols actuals"
+
+#: ../src/command/subtitle.cpp:385
+msgid "Save Subtitles &as..."
+msgstr "&Anomena i desa els subtítols..."
+
+#: ../src/command/subtitle.cpp:386
+msgid "Save Subtitles as"
+msgstr "Anomena i desa els subtítols"
+
+#: ../src/command/subtitle.cpp:387
+msgid "Save subtitles with another name"
+msgstr "Desa els subtítols amb un altre nom"
+
+#: ../src/command/subtitle.cpp:397
+msgid "Select All"
+msgstr "Selecciona-ho tot"
+
+#: ../src/command/subtitle.cpp:398
+msgid "Select all dialogue lines"
+msgstr "Selecciona totes les línies de diàleg"
+
+#: ../src/command/subtitle.cpp:410 ../src/command/subtitle.cpp:411
+msgid "Select Visible"
+msgstr "Selecciona les visibles"
+
+#: ../src/command/subtitle.cpp:412
+msgid "Select all dialogue lines that are visible on the current video frame"
 msgstr ""
-"Nom de l'actor que diu aquest text. Només és una referència, i normalment és "
-"inútil."
+"Selecciona totes les línies de diàleg que són visibles al fotograma actual "
+"del vídeo"
 
-#: ../src/subs_edit_box.cpp:145
-msgid ""
-"Effect for this line. This can be used to store extra information for "
-"karaoke scripts, or for the effects supported by the renderer."
-msgstr ""
-"Efecte per a aquesta línia. Es pot utilitzar per emmagatzemar informació "
-"extra als scripts de karaoke, o per a efectes suportats pel programa "
-"renderitzador."
+#: ../src/command/subtitle.cpp:442
+msgid "Spell &Checker..."
+msgstr "&Corrector ortogràfic..."
 
-#: ../src/subs_edit_box.cpp:151
-msgid "Number of characters in the longest line of this subtitle."
-msgstr "Nombre de caràcters a la línia més llarga d'aquest subtítol."
+#: ../src/command/subtitle.cpp:443 ../src/dialog_spellchecker.cpp:103
+msgid "Spell Checker"
+msgstr "Corrector ortogràfic"
 
-#: ../src/subs_edit_box.cpp:158
-msgid "Layer number"
-msgstr "Número de capa"
+#: ../src/command/subtitle.cpp:444
+msgid "Open spell checker"
+msgstr "Obre el corrector ortogràfic"
 
-#: ../src/subs_edit_box.cpp:162
-msgid "Start time"
-msgstr "Temps d'inici"
+#: ../src/timeedit_ctrl.cpp:209 ../src/subs_edit_ctrl.cpp:389
+msgid "&Paste"
+msgstr "Engan&xa"
 
-#: ../src/subs_edit_box.cpp:163
-msgid "End time"
-msgstr "Temps de final"
+#: ../src/font_file_lister_fontconfig.cpp:56
+#: ../src/font_file_lister_gdi.cpp:139
+msgid "Updating font cache\n"
+msgstr "S'està actualitzant la memòria cau dels tipus de lletra\n"
 
-#: ../src/subs_edit_box.cpp:165
-msgid "Line duration"
-msgstr "Durada de la línia"
+#: ../src/dialog_video_details.cpp:45
+msgid "Video Details"
+msgstr "Detalls del vídeo"
 
-#: ../src/subs_edit_box.cpp:168
-msgid "Left Margin (0 = default from style)"
-msgstr "Marge esquerre (0 = predefinit per l'estil)"
+#: ../src/dialog_video_details.cpp:59
+msgid "File name:"
+msgstr "Nom del fitxer:"
 
-#: ../src/subs_edit_box.cpp:168
-msgid "left margin change"
-msgstr "el canvi al marge esquerre"
+#: ../src/dialog_video_details.cpp:60
+msgid "FPS:"
+msgstr "FPS:"
 
-#: ../src/subs_edit_box.cpp:169
-msgid "Right Margin (0 = default from style)"
-msgstr "Marge dret (0 = predefinit per l'estil)"
+#: ../src/dialog_video_details.cpp:61
+msgid "Resolution:"
+msgstr "Resolució:"
 
-#: ../src/subs_edit_box.cpp:169
-msgid "right margin change"
-msgstr "el canvi al marge dret"
+#: ../src/dialog_video_details.cpp:62
+msgid "Length:"
+msgstr "Durada:"
 
-#: ../src/subs_edit_box.cpp:170
-msgid "Vertical Margin (0 = default from style)"
-msgstr "Marge vertical (0 = predefinit per l'estil)"
-
-#: ../src/subs_edit_box.cpp:170
-msgid "vertical margin change"
-msgstr "el canvi al marge vertical"
-
-#: ../src/subs_edit_box.cpp:189
-msgid "T&ime"
-msgstr "T&emps"
-
-#: ../src/subs_edit_box.cpp:189
-msgid "Time by h:mm:ss.cs"
-msgstr "Temps en h:mm:ss:cs"
-
-#: ../src/subs_edit_box.cpp:190
-msgid "F&rame"
-msgstr "Fotog&rama"
-
-#: ../src/subs_edit_box.cpp:190
-msgid "Time by frame number"
-msgstr "Temps per número de fotograma"
-
-#: ../src/subs_edit_box.cpp:193
-msgid "Show Original"
-msgstr "Mostra l'original"
-
-#: ../src/subs_edit_box.cpp:194
-msgid ""
-"Show the contents of the subtitle line when it was first selected above the "
-"edit box. This is sometimes useful when editing subtitles or translating "
-"subtitles into another language."
-msgstr ""
-"Mostra el contingut de la línia de subtítol quan la vau seleccionar per "
-"primer cop a la capsa d'edició. De vegades és útil quan s'editen els "
-"subtítols o es tradueixen a un altre idioma."
-
-#: ../src/subs_edit_box.cpp:441
-msgid "modify text"
-msgstr "la modificació del text"
-
-#: ../src/subs_edit_box.cpp:516
-msgid "modify times"
-msgstr "la modificació dels temps"
-
-#: ../src/subs_edit_box.cpp:590 ../src/dialog_style_editor.cpp:453
-msgid "style change"
-msgstr "el canvi d'estil"
-
-#: ../src/subs_edit_box.cpp:596
-msgid "actor change"
-msgstr "el canvi d'actor"
-
-#: ../src/subs_edit_box.cpp:601
-msgid "layer change"
-msgstr "el canvi de capa"
-
-#: ../src/subs_edit_box.cpp:606
-msgid "effect change"
-msgstr "el canvi d'efecte"
-
-#: ../src/subs_edit_box.cpp:611
-msgid "comment change"
-msgstr "el canvi de comentari"
-
-#: ../src/dialog_selection.cpp:106
-msgid "Select"
-msgstr "Selecciona"
-
-#: ../src/dialog_selection.cpp:117
-msgid "Match"
-msgstr "Coincidència"
-
-#: ../src/dialog_selection.cpp:121
-msgid "&Matches"
-msgstr "C&oincideix"
-
-#: ../src/dialog_selection.cpp:122
-msgid "&Doesn't Match"
-msgstr "&No coincideix"
-
-#: ../src/dialog_selection.cpp:123
-msgid "Match c&ase"
-msgstr "Coincideix amb &majúscules/minúscules"
-
-#: ../src/dialog_selection.cpp:132
-msgid "&Exact match"
-msgstr "Coincidència &exacta"
-
-#: ../src/dialog_selection.cpp:132
-msgid "&Contains"
-msgstr "C&onté"
-
-#: ../src/dialog_selection.cpp:132
-msgid "&Regular Expression match"
-msgstr "Coincidència amb l'expressió &regular"
-
-#: ../src/dialog_selection.cpp:133
-msgid "Mode"
-msgstr "Mode"
-
-#: ../src/dialog_selection.cpp:137 ../src/dialog_search_replace.cpp:87
-msgid "&Text"
-msgstr "&Text"
-
-#: ../src/dialog_selection.cpp:137
-msgid "&Style"
-msgstr "E&stil"
-
-#: ../src/dialog_selection.cpp:137
-msgid "Act&or"
-msgstr "Acto&r"
-
-#: ../src/dialog_selection.cpp:137
-msgid "E&ffect"
-msgstr "E&fecte"
-
-#: ../src/dialog_selection.cpp:138 ../src/dialog_search_replace.cpp:90
-msgid "In Field"
-msgstr "Al camp"
-
-#: ../src/dialog_selection.cpp:142
-msgid "Match dialogues/comments"
-msgstr "Coincideix amb diàlegs/comentaris"
-
-#: ../src/dialog_selection.cpp:143
-msgid "D&ialogues"
-msgstr "D&iàlegs"
-
-#: ../src/dialog_selection.cpp:144
-msgid "Comme&nts"
-msgstr "Comen&taris"
-
-#: ../src/dialog_selection.cpp:149
-msgid "Set se&lection"
-msgstr "D&efineix la selecció"
-
-#: ../src/dialog_selection.cpp:149
-msgid "&Add to selection"
-msgstr "&Afegeix a la selecció"
-
-#: ../src/dialog_selection.cpp:149
-msgid "S&ubtract from selection"
-msgstr "T&reu de la selecció"
-
-#: ../src/dialog_selection.cpp:149
-msgid "Intersect &with selection"
-msgstr "Interseca am&b la selecció"
-
-#: ../src/dialog_selection.cpp:211
+#: ../src/dialog_video_details.cpp:62
 #, c-format
-msgid "Selection was set to one line"
-msgid_plural "Selection was set to %u lines"
-msgstr[0] "S'ha seleccionat una línia"
-msgstr[1] "S'han seleccionat %u línies"
+msgid "1 frame"
+msgid_plural "%d frames (%s)"
+msgstr[0] "1 fotograma"
+msgstr[1] "%d fotogrames (%s)"
 
-#: ../src/dialog_selection.cpp:212
-msgid "Selection was set to no lines"
-msgstr "No s'ha seleccionat cap línia"
-
-#: ../src/dialog_selection.cpp:218
-#, c-format
-msgid "One line was added to selection"
-msgid_plural "%u lines were added to selection"
-msgstr[0] "S'ha afegit una línia a la selecció"
-msgstr[1] "S'han afegit %u línies a la selecció"
-
-#: ../src/dialog_selection.cpp:219
-msgid "No lines were added to selection"
-msgstr "No s'ha afegit cap línia a la selecció"
-
-#: ../src/dialog_selection.cpp:230
-#, c-format
-msgid "One line was removed from selection"
-msgid_plural "%u lines were removed from selection"
-msgstr[0] "S'ha tret una línia de la selecció"
-msgstr[1] "S'han tret %u línies de la selecció"
-
-#: ../src/dialog_selection.cpp:231
-msgid "No lines were removed from selection"
-msgstr "No s'ha tret cap línia de la selecció"
-
-#: ../src/dialog_selection.cpp:236
-msgid "Selection"
-msgstr "Selecció"
-
-#: ../src/font_file_lister.cpp:72
-#, c-format
-msgid "Style '%s' does not exist\n"
-msgstr "L'estil '%s' no existeix\n"
-
-#: ../src/font_file_lister.cpp:138
-#, c-format
-msgid "Could not find font '%s'\n"
-msgstr "No s'ha pogut trobar el tipus de lletra '%s'\n"
-
-#: ../src/font_file_lister.cpp:145
-#, c-format
-msgid "Found '%s' at '%s'\n"
-msgstr "S'ha trobat '%s' a '%s'\n"
-
-#: ../src/font_file_lister.cpp:149
-#, c-format
-msgid "'%s' does not have a bold variant.\n"
-msgstr "'%s' no té cap variant en negreta.\n"
-
-#: ../src/font_file_lister.cpp:151
-#, c-format
-msgid "'%s' does not have an italic variant.\n"
-msgstr "'%s' no té cap variant en cursiva.\n"
-
-#: ../src/font_file_lister.cpp:155
-#, c-format
-msgid "'%s' is missing %d glyphs used.\n"
-msgstr "A '%s' li falten %d glifs utilitzats.\n"
-
-#: ../src/font_file_lister.cpp:157
-#, c-format
-msgid "'%s' is missing the following glyphs used: %s\n"
-msgstr "A '%s' li falten els següents glifs utilitzats: %s\n"
-
-#: ../src/font_file_lister.cpp:168
-msgid "Used in styles:\n"
-msgstr "Utilitzat als estils:\n"
-
-#: ../src/font_file_lister.cpp:174
-msgid "Used on lines:"
-msgstr "Utilitzat a les línies:"
-
-#: ../src/font_file_lister.cpp:186
-msgid "Parsing file\n"
-msgstr "S'està analitzant el fitxer\n"
-
-#: ../src/font_file_lister.cpp:200
-msgid "Searching for font files\n"
-msgstr "S'estan cercant fitxers de tipus de lletra\n"
-
-#: ../src/font_file_lister.cpp:202
-msgid ""
-"Done\n"
-"\n"
-msgstr ""
-"Fet.\n"
-"\n"
-
-#: ../src/font_file_lister.cpp:209
-msgid "All fonts found.\n"
-msgstr "S'han trobat tots els tipus de lletra.\n"
-
-#: ../src/font_file_lister.cpp:211
-#, c-format
-msgid "One font could not be found\n"
-msgid_plural "%d fonts could not be found.\n"
-msgstr[0] "No s'ha pogut trobar un tipus de lletra.\n"
-msgstr[1] "No s'han pogut trobar %d tipus de lletra.\n"
-
-#: ../src/font_file_lister.cpp:214
-#, c-format
-msgid "One font was found, but was missing glyphs used in the script.\n"
-msgid_plural ""
-"%d fonts were found, but were missing glyphs used in the script.\n"
-msgstr[0] ""
-"S'ha trobat un tipus de lletra, però li falten glifs utilitzats a l'script.\n"
-msgstr[1] ""
-"S'han trobat %d tipus de lletra, però els falten glifs utilitzats a "
-"l'script.\n"
-
-#: ../src/export_framerate.cpp:52
-msgid "Transform Framerate"
-msgstr "Transforma la velocitat dels fotogrames"
-
-#: ../src/export_framerate.cpp:53
-msgid ""
-"Transform subtitle times, including those in override tags, from an input "
-"framerate to an output framerate.\n"
-"\n"
-"This is useful for converting regular time subtitles to VFRaC time subtitles "
-"for hardsubbing.\n"
-"It can also be used to convert subtitles to a different speed video, such as "
-"NTSC to PAL speedup."
-msgstr ""
-"Transforma els temps dels subtítols, incloent els de les etiquetes d'estils, "
-"des d'una velocitat de fotogrames a una altra.\n"
-"\n"
-"Això serveix si convertiu uns subtítols per temps normals a subtítols per "
-"temps VFRaC per incrustar-los al vídeo.\n"
-"També es pot utilitzar per convertir subtítols a un vídeo a diferent "
-"velocitat, com per exemple per a un increment de velocitat d'NTSC a PAL."
-
-#: ../src/export_framerate.cpp:92
-msgid "V&ariable"
-msgstr "V&ariable"
-
-#: ../src/export_framerate.cpp:96
-msgid "&Constant: "
-msgstr "&Constant:"
-
-#: ../src/export_framerate.cpp:108
-msgid "&Reverse transformation"
-msgstr "Inve&rteix la transformació"
-
-#: ../src/export_framerate.cpp:116
-msgid "Input framerate: "
-msgstr "Velocitat de fotogrames d'entrada:"
-
-#: ../src/export_framerate.cpp:118
-msgid "Output: "
-msgstr "Sortida:"
-
-#: ../src/audio_display.cpp:677
-#, c-format
-msgid "%d%%, %d pixel/second"
-msgstr "%d%%, %d píxels/segon"
+#: ../src/dialog_video_details.cpp:64
+msgid "Decoder:"
+msgstr "Descodificador:"
 
 #: ../src/dialog_progress.cpp:197
 msgid "Cancel"
@@ -5002,243 +4522,218 @@ msgstr "Cancel·la"
 msgid "Cancelling..."
 msgstr "S'està cancel·lant..."
 
-#: ../src/visual_tool_vector_clip.cpp:57
+#: ../src/dialog_about.cpp:46
+msgid "Translated into LANGUAGE by PERSON\n"
+msgstr "Traduït al català per Eduard Ereza Martínez\n"
+
+#: ../src/dialog_about.cpp:124
+msgid ""
+"\n"
+"See the help file for full credits.\n"
+msgstr ""
+"\n"
+"Vegeu el fitxer d'ajuda per als crèdits complets.\n"
+
+#: ../src/dialog_about.cpp:126
+#, c-format
+msgid "Built by %s on %s."
+msgstr "Compilat per %s el %s."
+
+#: ../src/audio_renderer_waveform.cpp:155
+msgid "Maximum"
+msgstr "Màxim"
+
+#: ../src/audio_renderer_waveform.cpp:156
+msgid "Maximum + Average"
+msgstr "Màxim + Mitjana"
+
+#: ../src/audio_timing_karaoke.cpp:241
+msgid "karaoke timing"
+msgstr "el temps de karaoke"
+
+#: ../src/ass_style.cpp:195
+msgid "ANSI"
+msgstr "ANSI"
+
+#: ../src/ass_style.cpp:197
+msgid "Symbol"
+msgstr "Símbol"
+
+#: ../src/ass_style.cpp:198
+msgid "Mac"
+msgstr "Mac"
+
+#: ../src/ass_style.cpp:199
+msgid "Shift_JIS"
+msgstr "Shift_JIS"
+
+#: ../src/ass_style.cpp:200
+msgid "Hangeul"
+msgstr "Hangul"
+
+#: ../src/ass_style.cpp:201
+msgid "Johab"
+msgstr "Johab"
+
+#: ../src/ass_style.cpp:202
+msgid "GB2312"
+msgstr "GB2312"
+
+#: ../src/ass_style.cpp:203
+msgid "Chinese BIG5"
+msgstr "Xinès BIG5"
+
+#: ../src/ass_style.cpp:204
+msgid "Greek"
+msgstr "Grec"
+
+#: ../src/ass_style.cpp:205
+msgid "Turkish"
+msgstr "Turc"
+
+#: ../src/ass_style.cpp:206
+msgid "Vietnamese"
+msgstr "Vietnamita"
+
+#: ../src/ass_style.cpp:207
+msgid "Hebrew"
+msgstr "Hebreu"
+
+#: ../src/ass_style.cpp:208
+msgid "Arabic"
+msgstr "Àrab"
+
+#: ../src/ass_style.cpp:209
+msgid "Baltic"
+msgstr "Bàltic"
+
+#: ../src/ass_style.cpp:210
+msgid "Russian"
+msgstr "Rus"
+
+#: ../src/ass_style.cpp:211
+msgid "Thai"
+msgstr "Tailandès"
+
+#: ../src/ass_style.cpp:212
+msgid "East European"
+msgstr "Europa oriental"
+
+#: ../src/ass_style.cpp:213
+msgid "OEM"
+msgstr "OEM"
+
+#: ../src/subs_edit_ctrl.cpp:377
+msgid "Spell checker language"
+msgstr "Llengua del corrector ortogràfic"
+
+#: ../src/subs_edit_ctrl.cpp:387
+msgid "Cu&t"
+msgstr "Re&talla"
+
+#: ../src/subs_edit_ctrl.cpp:424
+#, c-format
+msgid "Remove \"%s\" from dictionary"
+msgstr "Suprimeix \"%s\" del diccionari"
+
+#: ../src/subs_edit_ctrl.cpp:429
+msgid "No spell checker suggestions"
+msgstr "No hi ha cap suggeriment del corrector ortogràfic"
+
+#: ../src/subs_edit_ctrl.cpp:435
+#, c-format
+msgid "Spell checker suggestions for \"%s\""
+msgstr "Suggeriments del corrector ortogràfic per a \"%s\""
+
+#: ../src/subs_edit_ctrl.cpp:440
+msgid "No correction suggestions"
+msgstr "No hi ha cap suggeriment de correcció"
+
+#: ../src/subs_edit_ctrl.cpp:446
+#, c-format
+msgid "Add \"%s\" to dictionary"
+msgstr "Afegeix \"%s\" al diccionari"
+
+#: ../src/subs_edit_ctrl.cpp:481
+#, c-format
+msgid "Thesaurus suggestions for \"%s\""
+msgstr "Suggeriments del tesaurus per a \"%s\""
+
+#: ../src/subs_edit_ctrl.cpp:484
+msgid "No thesaurus suggestions"
+msgstr "No hi ha cap suggeriment del tesaurus"
+
+#: ../src/subs_edit_ctrl.cpp:487
+msgid "Thesaurus language"
+msgstr "Llengua del tesaurus"
+
+#: ../src/subs_edit_ctrl.cpp:496
+msgid "Disable"
+msgstr "Desactiva"
+
+#: ../src/visual_tool_vector_clip.cpp:58
 msgid "Drag control points"
 msgstr "Arrossega els punts de control"
 
-#: ../src/visual_tool_vector_clip.cpp:58
+#: ../src/visual_tool_vector_clip.cpp:59
 msgid "Line"
 msgstr "Línia"
 
-#: ../src/visual_tool_vector_clip.cpp:58
+#: ../src/visual_tool_vector_clip.cpp:59
 msgid "Appends a line"
 msgstr "Afegeix una línia"
 
-#: ../src/visual_tool_vector_clip.cpp:59
+#: ../src/visual_tool_vector_clip.cpp:60
 msgid "Bicubic"
 msgstr "Bicúbica"
 
-#: ../src/visual_tool_vector_clip.cpp:59
+#: ../src/visual_tool_vector_clip.cpp:60
 msgid "Appends a bezier bicubic curve"
-msgstr "Afegeix una corba Bézier bicúbia"
+msgstr "Afegeix una corba de Bézier bicúbica"
 
-#: ../src/visual_tool_vector_clip.cpp:61
+#: ../src/visual_tool_vector_clip.cpp:62
 msgid "Convert"
 msgstr "Converteix"
 
-#: ../src/visual_tool_vector_clip.cpp:61
+#: ../src/visual_tool_vector_clip.cpp:62
 msgid "Converts a segment between line and bicubic"
 msgstr "Converteix un segment entre una línia i bicúbic"
 
-#: ../src/visual_tool_vector_clip.cpp:62
+#: ../src/visual_tool_vector_clip.cpp:63
 msgid "Insert"
 msgstr "Insereix"
 
-#: ../src/visual_tool_vector_clip.cpp:62
+#: ../src/visual_tool_vector_clip.cpp:63
 msgid "Inserts a control point"
 msgstr "Insereix un punt de control"
 
-#: ../src/visual_tool_vector_clip.cpp:63
+#: ../src/visual_tool_vector_clip.cpp:64
 msgid "Remove"
 msgstr "Suprimeix"
 
-#: ../src/visual_tool_vector_clip.cpp:63
+#: ../src/visual_tool_vector_clip.cpp:64
 msgid "Removes a control point"
 msgstr "Suprimeix un punt de control"
 
-#: ../src/visual_tool_vector_clip.cpp:65
+#: ../src/visual_tool_vector_clip.cpp:66
 msgid "Freehand"
 msgstr "Mà alçada"
 
-#: ../src/visual_tool_vector_clip.cpp:65
+#: ../src/visual_tool_vector_clip.cpp:66
 msgid "Draws a freehand shape"
 msgstr "Dibuixa una forma a mà alçada"
 
-#: ../src/visual_tool_vector_clip.cpp:66
+#: ../src/visual_tool_vector_clip.cpp:67
 msgid "Freehand smooth"
 msgstr "Mà alçada suavitzada"
 
-#: ../src/visual_tool_vector_clip.cpp:66
+#: ../src/visual_tool_vector_clip.cpp:67
 msgid "Draws a smoothed freehand shape"
 msgstr "Dibuixa una forma suavitzada a mà alçada"
 
-#: ../src/visual_tool_vector_clip.cpp:265
+#: ../src/visual_tool_vector_clip.cpp:272
 msgid "delete control point"
-msgstr "l'eliminació d'un punt de control"
-
-#: ../src/dialog_automation.cpp:106
-msgid "Automation Manager"
-msgstr "Gestor de l'automatització"
-
-#: ../src/dialog_automation.cpp:117
-msgid "&Add"
-msgstr "&Afegeix"
-
-#: ../src/dialog_automation.cpp:118
-msgid "&Remove"
-msgstr "Sup&rimeix"
-
-#: ../src/dialog_automation.cpp:119
-msgid "Re&load"
-msgstr "Recarre&ga"
-
-#: ../src/dialog_automation.cpp:120
-msgid "Show &Info"
-msgstr "Mostra la &informació"
-
-#: ../src/dialog_automation.cpp:121
-msgid "Re&scan Autoload Dir"
-msgstr "Ree&scaneja el directori de càrrega automàtica"
-
-#: ../src/dialog_automation.cpp:134
-msgid "Name"
-msgstr "Nom"
-
-#: ../src/dialog_automation.cpp:135
-msgid "Filename"
-msgstr "Nom del fitxer"
-
-#: ../src/dialog_automation.cpp:136
-msgid "Description"
-msgstr "Descripció"
-
-#: ../src/dialog_automation.cpp:222
-msgid "Add Automation script"
-msgstr "Afegeix un script d'automatització"
-
-#: ../src/dialog_automation.cpp:277
-#, c-format
-msgid ""
-"Total scripts loaded: %d\n"
-"Global scripts loaded: %d\n"
-"Local scripts loaded: %d\n"
-msgstr ""
-"Total d'scripts carregats: %d\n"
-"Scripts globals carregats: %d\n"
-"Scripts locals carregats: %d\n"
-
-#: ../src/dialog_automation.cpp:282
-msgid "Scripting engines installed:"
-msgstr "Motors d'script instal·lats:"
-
-#: ../src/dialog_automation.cpp:295
-msgid "Correctly loaded"
-msgstr "S'ha carregat correctament"
-
-#: ../src/dialog_automation.cpp:295
-msgid "Failed to load"
-msgstr "No s'ha pogut carregar"
-
-#: ../src/dialog_automation.cpp:289
-#, c-format
-msgid ""
-"\n"
-"Script info:\n"
-"Name: %s\n"
-"Description: %s\n"
-"Author: %s\n"
-"Version: %s\n"
-"Full path: %s\n"
-"State: %s\n"
-"\n"
-"Features provided by script:"
-msgstr ""
-"\n"
-"Informació de l'script:\n"
-"Nom: %s\n"
-"Descripció: %s\n"
-"Autor: %s\n"
-"Versió: %s\n"
-"Camí complet: %s\n"
-"Estat: %s\n"
-"\n"
-"Característiques proporcionades per l'script:"
-
-#: ../src/dialog_automation.cpp:298
-#, c-format
-msgid "    Macro: %s (%s)"
-msgstr "    Macro: %s (%s)"
-
-#: ../src/dialog_automation.cpp:301
-#, c-format
-msgid "    Export filter: %s"
-msgstr "    Filtre d'exportació: %s"
-
-#: ../src/dialog_automation.cpp:305
-msgid "Automation Script Info"
-msgstr "Informació de l'script d'automatització"
-
-#: ../src/dialog_export.cpp:102
-msgid "Export"
-msgstr "Exporta"
-
-#: ../src/dialog_export.cpp:123
-msgid "Move &Up"
-msgstr "Mou am&unt"
-
-#: ../src/dialog_export.cpp:124
-msgid "Move &Down"
-msgstr "Mou a&vall"
-
-#: ../src/dialog_export.cpp:142
-msgid "Text encoding:"
-msgstr "Codificació del text:"
-
-#: ../src/dialog_export.cpp:150
-msgid "Filters"
-msgstr "Filtres"
-
-#: ../src/dialog_export.cpp:157
-msgid "Export..."
-msgstr "Exporta..."
-
-#: ../src/dialog_export.cpp:189
-msgid "Export subtitles file"
-msgstr "Exporta el fitxer de subtítols"
-
-#: ../src/dialog_search_replace.cpp:46
-msgid "Replace"
-msgstr "Substitueix"
-
-#: ../src/dialog_search_replace.cpp:67
-msgid "Find what:"
-msgstr "Cerca això:"
-
-#: ../src/dialog_search_replace.cpp:78
-msgid "&Match case"
-msgstr "Coincideix amb &majúscules/minúscules"
-
-#: ../src/dialog_search_replace.cpp:79
-msgid "&Use regular expressions"
-msgstr "&Utilitza expressions regulars"
-
-#: ../src/dialog_search_replace.cpp:81
-msgid "S&kip Override Tags"
-msgstr "O&met les etiquetes d'estil"
-
-#: ../src/dialog_search_replace.cpp:87
-msgid "St&yle"
-msgstr "Est&il"
-
-#: ../src/dialog_search_replace.cpp:87
-msgid "A&ctor"
-msgstr "A&ctor"
-
-#: ../src/dialog_search_replace.cpp:88
-msgid "A&ll rows"
-msgstr "&Totes les línies"
-
-#: ../src/dialog_search_replace.cpp:91
-msgid "Limit to"
-msgstr "Limita a"
-
-#: ../src/dialog_search_replace.cpp:93
-msgid "&Find next"
-msgstr "C&erca el següent"
-
-#: ../src/dialog_search_replace.cpp:94
-msgid "Replace &next"
-msgstr "&Substitueix el següent"
+msgstr "la supressió d'un punt de control"
 
 #: ../src/dialog_autosave.cpp:66
 msgid "Open autosave file"
@@ -5262,6 +4757,92 @@ msgstr "%s [CÒPIA DE SEGURETAT DE L'ORIGINAL]"
 msgid "%s [RECOVERED]"
 msgstr "%s [RECUPERAT]"
 
+#: ../src/dialog_properties.cpp:89
+msgid "Script Properties"
+msgstr "Propietats de l'script"
+
+#: ../src/dialog_properties.cpp:103
+msgid "Script"
+msgstr "Script"
+
+#: ../src/dialog_properties.cpp:106
+msgid "Title:"
+msgstr "Títol:"
+
+#: ../src/dialog_properties.cpp:107
+msgid "Original script:"
+msgstr "Script original:"
+
+#: ../src/dialog_properties.cpp:108
+msgid "Translation:"
+msgstr "Traducció:"
+
+#: ../src/dialog_properties.cpp:109
+msgid "Editing:"
+msgstr "Edició:"
+
+#: ../src/dialog_properties.cpp:110
+msgid "Timing:"
+msgstr "Temps:"
+
+#: ../src/dialog_properties.cpp:111
+msgid "Synch point:"
+msgstr "Punt de sincronització:"
+
+#: ../src/dialog_properties.cpp:112
+msgid "Updated by:"
+msgstr "Actualitzat per:"
+
+#: ../src/dialog_properties.cpp:113
+msgid "Update details:"
+msgstr "Detalls de l'actualització:"
+
+#: ../src/dialog_properties.cpp:122 ../src/export_framerate.cpp:70
+#: ../src/dialog_resample.cpp:141
+msgid "From &video"
+msgstr "Del &vídeo"
+
+#: ../src/dialog_properties.cpp:141
+msgid "Resolution"
+msgstr "Resolució"
+
+#: ../src/dialog_properties.cpp:149
+msgid "0: Smart wrapping, top line is wider"
+msgstr "0: Ajustament intel·ligent, la línia de dalt és més llarga"
+
+#: ../src/dialog_properties.cpp:150
+msgid "1: End-of-line word wrapping, only \\N breaks"
+msgstr "1: Ajustament de final de línia, només \\N salta"
+
+#: ../src/dialog_properties.cpp:151
+msgid "2: No word wrapping, both \\n and \\N break"
+msgstr "2: Sense ajustament de línia, tant \\n com \\N salten"
+
+#: ../src/dialog_properties.cpp:152
+msgid "3: Smart wrapping, bottom line is wider"
+msgstr "3: Ajustament intel·ligent, la línia de baix és més llarga"
+
+#: ../src/dialog_properties.cpp:156
+msgid "Wrap Style: "
+msgstr "Estil d'ajustament de línies: "
+
+#: ../src/dialog_properties.cpp:159
+msgid "Scale Border and Shadow"
+msgstr "Escala la vora i l'ombra"
+
+#: ../src/dialog_properties.cpp:160
+msgid ""
+"Scale border and shadow together with script/render resolution. If this is "
+"unchecked, relative border and shadow size will depend on renderer."
+msgstr ""
+"Escala la vora i l'ombra juntament amb la resolució de l'script/"
+"renderització. Si ho desmarqueu, la vora i l'ombra relatives dependran del "
+"renderitzador."
+
+#: ../src/dialog_properties.cpp:196
+msgid "property changes"
+msgstr "els canvis a les propietats"
+
 #: ../src/audio_box.cpp:73
 msgid "Horizontal zoom"
 msgstr "Ampliació horitzontal"
@@ -5274,351 +4855,699 @@ msgstr "Ampliació vertical"
 msgid "Audio Volume"
 msgstr "Volum de l'àudio"
 
-#: ../src/grid_column.cpp:82
-msgid "#"
-msgstr "N"
+#: ../src/font_file_lister.cpp:67
+#, c-format
+msgid "Style '%s' does not exist\n"
+msgstr "L'estil '%s' no existeix\n"
 
-#: ../src/grid_column.cpp:83
-msgid "Line Number"
-msgstr "Número de línia"
+#: ../src/font_file_lister.cpp:154
+#, c-format
+msgid "Could not find font '%s'\n"
+msgstr "No s'ha pogut trobar el tipus de lletra '%s'\n"
 
-#: ../src/grid_column.cpp:106
-msgid "L"
-msgstr "C"
+#: ../src/font_file_lister.cpp:162
+#, c-format
+msgid "Found '%s' at '%s'\n"
+msgstr "S'ha trobat '%s' a '%s'\n"
 
-#: ../src/grid_column.cpp:128
-msgid "Start"
-msgstr "Inici"
+#: ../src/font_file_lister.cpp:168
+#, c-format
+msgid "'%s' does not have a bold variant.\n"
+msgstr "'%s' no té cap variant en negreta.\n"
 
-#: ../src/grid_column.cpp:146
-msgid "End"
-msgstr "Fi"
+#: ../src/font_file_lister.cpp:170
+#, c-format
+msgid "'%s' does not have an italic variant.\n"
+msgstr "'%s' no té cap variant en cursiva.\n"
 
-#: ../src/grid_column.cpp:237 ../src/dialog_style_editor.cpp:288
-msgid "Left"
-msgstr "Esq."
+#: ../src/font_file_lister.cpp:174
+#, c-format
+msgid "'%s' is missing %d glyphs used.\n"
+msgstr "A '%s' li manquen %d glifs utilitzats.\n"
 
-#: ../src/grid_column.cpp:238
-msgid "Left Margin"
-msgstr "Marge esquerre"
+#: ../src/font_file_lister.cpp:176
+#, c-format
+msgid "'%s' is missing the following glyphs used: %s\n"
+msgstr "A '%s' li manquen els següents glifs utilitzats: %s\n"
 
-#: ../src/grid_column.cpp:242 ../src/dialog_style_editor.cpp:288
-msgid "Right"
-msgstr "Dreta"
+#: ../src/font_file_lister.cpp:187
+msgid "Used in styles:\n"
+msgstr "Utilitzat als estils:\n"
 
-#: ../src/grid_column.cpp:243
-msgid "Right Margin"
-msgstr "Marge dret"
+#: ../src/font_file_lister.cpp:193
+msgid "Used on lines:"
+msgstr "Utilitzat a les línies:"
 
-#: ../src/grid_column.cpp:247 ../src/dialog_style_editor.cpp:288
-msgid "Vert"
-msgstr "Vert."
+#: ../src/font_file_lister.cpp:205
+msgid "Parsing file\n"
+msgstr "S'està analitzant el fitxer\n"
 
-#: ../src/grid_column.cpp:248
-msgid "Vertical Margin"
-msgstr "Marge vertical"
+#: ../src/font_file_lister.cpp:219
+msgid "Searching for font files\n"
+msgstr "S'estan cercant fitxers de tipus de lletra\n"
 
-#: ../src/grid_column.cpp:266
-msgid "CPS"
-msgstr "CPS"
-
-#: ../src/grid_column.cpp:267
-msgid "Characters Per Second"
-msgstr "Caràcters per segon"
-
-#: ../src/dialog_text_import.cpp:47
-msgid "Text import options"
-msgstr "Options d'importació de text"
-
-#: ../src/dialog_text_import.cpp:54
-msgid "Actor separator:"
-msgstr "Separador d'actor:"
-
-#: ../src/dialog_text_import.cpp:56
-msgid "Comment starter:"
-msgstr "Inici dels comentaris:"
-
-#: ../src/dialog_text_import.cpp:61
-msgid "Include blank lines"
-msgstr "Inclou les línies en blanc"
-
-#: ../src/video_box.cpp:57
-msgid "Seek video"
-msgstr "Mou el vídeo"
-
-#: ../src/video_box.cpp:62
-msgid "Current frame time and number"
-msgstr "Temps i número del fotograma actual"
-
-#: ../src/video_box.cpp:65
-msgid "Time of this frame relative to start and end of current subs"
+#: ../src/font_file_lister.cpp:221
+msgid ""
+"Done\n"
+"\n"
 msgstr ""
-"Temps d'aquest fotograma relatiu a l'inici i al final dels subtítols actuals"
+"Fet.\n"
+"\n"
 
-#: ../src/ass_style.cpp:193
-msgid "ANSI"
-msgstr "ANSI"
+#: ../src/font_file_lister.cpp:228
+msgid "All fonts found.\n"
+msgstr "S'han trobat tots els tipus de lletra.\n"
 
-#: ../src/ass_style.cpp:195
-msgid "Symbol"
-msgstr "Símbol"
+#: ../src/font_file_lister.cpp:230
+#, c-format
+msgid "One font could not be found\n"
+msgid_plural "%d fonts could not be found.\n"
+msgstr[0] "No s'ha pogut trobar un tipus de lletra.\n"
+msgstr[1] "No s'han pogut trobar %d tipus de lletra.\n"
 
-#: ../src/ass_style.cpp:196
-msgid "Mac"
-msgstr "Mac"
+#: ../src/font_file_lister.cpp:233
+#, c-format
+msgid "One font was found, but was missing glyphs used in the script.\n"
+msgid_plural ""
+"%d fonts were found, but were missing glyphs used in the script.\n"
+msgstr[0] ""
+"S'ha trobat un tipus de lletra, però li manquen glifs utilitzats a "
+"l'script.\n"
+msgstr[1] ""
+"S'han trobat %d tipus de lletra, però els manquen glifs utilitzats a "
+"l'script.\n"
 
-#: ../src/ass_style.cpp:197
-msgid "Shift_JIS"
-msgstr "Shift_JIS"
+#: ../src/resolution_resampler.cpp:289
+msgid "resolution resampling"
+msgstr "el reajustament de la resolució"
 
-#: ../src/ass_style.cpp:198
-msgid "Hangeul"
-msgstr "Hangul"
+#: ../src/visual_tool.cpp:122
+msgid "visual typesetting"
+msgstr "la definició d'estils visual"
 
-#: ../src/ass_style.cpp:199
-msgid "Johab"
-msgstr "Johab"
+#: ../src/export_framerate.cpp:52
+msgid "Transform Framerate"
+msgstr "Transforma la taxa de fotogrames"
 
-#: ../src/ass_style.cpp:200
-msgid "GB2312"
-msgstr "GB2312"
+#: ../src/export_framerate.cpp:53
+msgid ""
+"Transform subtitle times, including those in override tags, from an input "
+"framerate to an output framerate.\n"
+"\n"
+"This is useful for converting regular time subtitles to VFRaC time subtitles "
+"for hardsubbing.\n"
+"It can also be used to convert subtitles to a different speed video, such as "
+"NTSC to PAL speedup."
+msgstr ""
+"Transforma els temps dels subtítols, incloent els de les etiquetes d'estils, "
+"d'una taxa de fotogrames a una altra.\n"
+"\n"
+"Això és útil si convertiu uns subtítols per temps normals a subtítols per "
+"temps VFRaC per a incrustar-los al vídeo.\n"
+"També es pot utilitzar per a convertir subtítols a un vídeo a diferent "
+"velocitat, com per exemple per a un increment de velocitat d'NTSC a PAL."
 
-#: ../src/ass_style.cpp:201
-msgid "Chinese BIG5"
-msgstr "Xinès BIG5"
+#: ../src/export_framerate.cpp:92
+msgid "V&ariable"
+msgstr "V&ariable"
 
-#: ../src/ass_style.cpp:202
-msgid "Greek"
-msgstr "Grec"
+#: ../src/export_framerate.cpp:96
+msgid "&Constant: "
+msgstr "&Constant: "
 
-#: ../src/ass_style.cpp:203
-msgid "Turkish"
-msgstr "Turc"
+#: ../src/export_framerate.cpp:108
+msgid "&Reverse transformation"
+msgstr "Inve&rteix la transformació"
 
-#: ../src/ass_style.cpp:204
-msgid "Vietnamese"
-msgstr "Vietnamita"
+#: ../src/export_framerate.cpp:116
+msgid "Input framerate: "
+msgstr "Taxa de fotogrames d'entrada: "
 
-#: ../src/ass_style.cpp:205
-msgid "Hebrew"
-msgstr "Hebreu"
+#: ../src/export_framerate.cpp:118
+msgid "Output: "
+msgstr "Sortida: "
 
-#: ../src/ass_style.cpp:206
-msgid "Arabic"
-msgstr "Àrab"
+#: ../src/dialog_spellchecker.cpp:125
+msgid "Misspelled word:"
+msgstr "Paraula mal escrita:"
 
-#: ../src/ass_style.cpp:207
-msgid "Baltic"
-msgstr "Bàltic"
+#: ../src/dialog_spellchecker.cpp:183
+msgid "Ignore &UPPERCASE words"
+msgstr "Ignora les paraules en &MAJÚSCULA"
 
-#: ../src/ass_style.cpp:208
-msgid "Russian"
-msgstr "Rus"
+#: ../src/dialog_spellchecker.cpp:187
+msgid "&Replace"
+msgstr "&Substitueix"
 
-#: ../src/ass_style.cpp:209
-msgid "Thai"
-msgstr "Tailandès"
+#: ../src/dialog_spellchecker.cpp:197
+msgid "&Ignore"
+msgstr "&Ignora"
 
-#: ../src/ass_style.cpp:210
-msgid "East European"
-msgstr "Europeu de l'est"
+#: ../src/dialog_spellchecker.cpp:200
+msgid "Ignore a&ll"
+msgstr "Ignora-ho t&ot"
 
-#: ../src/ass_style.cpp:211
-msgid "OEM"
-msgstr "OEM"
+#: ../src/dialog_spellchecker.cpp:206
+msgid "Add to &dictionary"
+msgstr "Afegeix al &diccionari"
 
-#: ../src/dialog_colorpicker.cpp:542
+#: ../src/dialog_spellchecker.cpp:212
+msgid "Remove fro&m dictionary"
+msgstr "Suprimeix de&l diccionari"
+
+#: ../src/dialog_spellchecker.cpp:279
+msgid "Aegisub has finished checking spelling of this script."
+msgstr "L'Aegisub ha finalitzat la correcció ortogràfica d'aquest script."
+
+#: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
+msgid "Spell checking complete."
+msgstr "Ha finalitzat la correcció ortogràfica."
+
+#: ../src/dialog_spellchecker.cpp:283
+msgid "Aegisub has found no spelling mistakes in this script."
+msgstr "L'Aegisub no ha trobat cap errada ortogràfica en aquest script."
+
+#: ../src/dialog_spellchecker.cpp:329 ../src/dialog_spellchecker.cpp:343
+msgid "spell check replace"
+msgstr "la substitució del corrector ortogràfic"
+
+#: ../src/dialog_colorpicker.cpp:539
 msgid "Select Color"
 msgstr "Seleccioneu un color"
 
-#: ../src/dialog_colorpicker.cpp:556
+#: ../src/dialog_colorpicker.cpp:553
 msgid "Color spectrum"
 msgstr "Espectre de colors"
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "RGB/R"
 msgstr "RGB/R"
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "RGB/G"
 msgstr "RGB/G"
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "RGB/B"
 msgstr "RGB/B"
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "HSL/L"
 msgstr "HSL/L"
 
-#: ../src/dialog_colorpicker.cpp:560
+#: ../src/dialog_colorpicker.cpp:557
 msgid "HSV/H"
 msgstr "HSV/H"
 
-#: ../src/dialog_colorpicker.cpp:567
+#: ../src/dialog_colorpicker.cpp:564
 msgid "RGB color"
 msgstr "Color RGB"
 
-#: ../src/dialog_colorpicker.cpp:568
+#: ../src/dialog_colorpicker.cpp:565
 msgid "HSL color"
 msgstr "Color HSL"
 
-#: ../src/dialog_colorpicker.cpp:569
+#: ../src/dialog_colorpicker.cpp:566
 msgid "HSV color"
 msgstr "Color HSV"
 
-#: ../src/dialog_colorpicker.cpp:594
+#: ../src/dialog_colorpicker.cpp:591
 msgid "Spectrum mode:"
 msgstr "Mode d'espectre:"
 
-#: ../src/dialog_colorpicker.cpp:611
+#: ../src/dialog_colorpicker.cpp:608
 msgid "Red:"
 msgstr "Vermell:"
 
-#: ../src/dialog_colorpicker.cpp:611
+#: ../src/dialog_colorpicker.cpp:608
 msgid "Green:"
 msgstr "Verd:"
 
-#: ../src/dialog_colorpicker.cpp:611
+#: ../src/dialog_colorpicker.cpp:608
 msgid "Blue:"
 msgstr "Blau:"
 
-#: ../src/dialog_colorpicker.cpp:614
+#: ../src/dialog_colorpicker.cpp:611
 msgid "Alpha:"
 msgstr "Alfa:"
 
-#: ../src/dialog_colorpicker.cpp:621 ../src/dialog_colorpicker.cpp:624
+#: ../src/dialog_colorpicker.cpp:618 ../src/dialog_colorpicker.cpp:621
 msgid "Hue:"
 msgstr "To:"
 
-#: ../src/dialog_colorpicker.cpp:621 ../src/dialog_colorpicker.cpp:624
+#: ../src/dialog_colorpicker.cpp:618 ../src/dialog_colorpicker.cpp:621
 msgid "Sat.:"
 msgstr "Sat.:"
 
-#: ../src/dialog_colorpicker.cpp:621
+#: ../src/dialog_colorpicker.cpp:618
 msgid "Lum.:"
 msgstr "Llum.:"
 
-#: ../src/dialog_colorpicker.cpp:624
+#: ../src/dialog_colorpicker.cpp:621
 msgid "Value:"
 msgstr "Valor:"
 
-#: ../src/charset_detect.cpp:80
+#: ../src/dialog_styling_assistant.cpp:65
+#: ../src/dialog_styling_assistant.cpp:66
+msgid "Current line"
+msgstr "Línia actual"
+
+#: ../src/dialog_styling_assistant.cpp:72
+msgid "Styles available"
+msgstr "Estils disponibles"
+
+#: ../src/dialog_styling_assistant.cpp:80
+msgid "Set style"
+msgstr "Defineix l'estil"
+
+#: ../src/dialog_styling_assistant.cpp:87 ../src/dialog_translation.cpp:110
+msgid "Keys"
+msgstr "Tecles"
+
+#: ../src/dialog_styling_assistant.cpp:92 ../src/dialog_translation.cpp:115
+msgid "Previous line"
+msgstr "Línia anterior"
+
+#: ../src/dialog_styling_assistant.cpp:93 ../src/dialog_translation.cpp:116
+msgid "Next line"
+msgstr "Línia següent"
+
+#: ../src/dialog_styling_assistant.cpp:94 ../src/dialog_translation.cpp:118
+msgid "Play video"
+msgstr "Reprodueix el vídeo"
+
+#: ../src/dialog_styling_assistant.cpp:95 ../src/dialog_translation.cpp:119
+msgid "Play audio"
+msgstr "Reprodueix l'àudio"
+
+#: ../src/dialog_styling_assistant.cpp:96
+msgid "Click on list"
+msgstr "Clic a la llista"
+
+#: ../src/dialog_styling_assistant.cpp:97
+msgid "Select style"
+msgstr "Selecciona l'estil"
+
+#: ../src/dialog_styling_assistant.cpp:101
+msgid "&Seek video to line start time"
+msgstr "&Mou el vídeo al temps d'inici de la línia"
+
+#: ../src/dialog_styling_assistant.cpp:110 ../src/dialog_translation.cpp:131
+msgid "Actions"
+msgstr "Accions"
+
+#: ../src/dialog_styling_assistant.cpp:113 ../src/dialog_translation.cpp:133
+msgid "Play &Audio"
+msgstr "Reprodueix l'à&udio"
+
+#: ../src/dialog_styling_assistant.cpp:117 ../src/dialog_translation.cpp:138
+msgid "Play &Video"
+msgstr "Reprodueix el &vídeo"
+
+#: ../src/dialog_styling_assistant.cpp:175
+msgid "styling assistant"
+msgstr "l'auxiliar d'estils"
+
+#: ../src/dialog_style_editor.cpp:128
+msgid "Style Editor"
+msgstr "Editor d'estils"
+
+#: ../src/dialog_style_editor.cpp:179
+msgid "Font"
+msgstr "Tipus de lletra"
+
+#: ../src/dialog_style_editor.cpp:181
+msgid "Margins"
+msgstr "Marges"
+
+#: ../src/dialog_style_editor.cpp:182 ../src/dialog_style_editor.cpp:278
+msgid "Outline"
+msgstr "Contorn"
+
+#: ../src/dialog_style_editor.cpp:183
+msgid "Miscellaneous"
+msgstr "Miscel·lània"
+
+#: ../src/dialog_style_editor.cpp:184
+msgid "Preview"
+msgstr "Previsualització"
+
+#: ../src/dialog_style_editor.cpp:190
+msgid "&Bold"
+msgstr "&Negreta"
+
+#: ../src/dialog_style_editor.cpp:191
+msgid "&Italic"
+msgstr "C&ursiva"
+
+#: ../src/dialog_style_editor.cpp:192
+msgid "&Underline"
+msgstr "&Subratllat"
+
+#: ../src/dialog_style_editor.cpp:193
+msgid "&Strikeout"
+msgstr "Ra&tllat"
+
+#: ../src/dialog_style_editor.cpp:205
+msgid "Alignment"
+msgstr "Alineació"
+
+#: ../src/dialog_style_editor.cpp:208
+msgid "&Opaque box"
+msgstr "Capsa &opaca"
+
+#: ../src/dialog_style_editor.cpp:216
+msgid "Style name"
+msgstr "Nom de l'estil"
+
+#: ../src/dialog_style_editor.cpp:217
+msgid "Font face"
+msgstr "Tipus de lletra"
+
+#: ../src/dialog_style_editor.cpp:218
+msgid "Font size"
+msgstr "Mida de la lletra"
+
+#: ../src/dialog_style_editor.cpp:219
+msgid "Choose primary color"
+msgstr "Trieu el color primari"
+
+#: ../src/dialog_style_editor.cpp:220
+msgid "Choose secondary color"
+msgstr "Trieu el color secundari"
+
+#: ../src/dialog_style_editor.cpp:221
+msgid "Choose outline color"
+msgstr "Trieu el color del contorn"
+
+#: ../src/dialog_style_editor.cpp:222
+msgid "Choose shadow color"
+msgstr "Trieu el color de l'ombra"
+
+#: ../src/dialog_style_editor.cpp:223
+msgid "Distance from left edge, in pixels"
+msgstr "Distància de la vora esquerra, en píxels"
+
+#: ../src/dialog_style_editor.cpp:224
+msgid "Distance from right edge, in pixels"
+msgstr "Distància de la vora dreta, en píxels"
+
+#: ../src/dialog_style_editor.cpp:225
+msgid "Distance from top/bottom edge, in pixels"
+msgstr "Distància de la vora superior/inferior, en píxels"
+
+#: ../src/dialog_style_editor.cpp:226
 msgid ""
-"Aegisub could not narrow down the character set to a single one.\n"
-"Please pick one below:"
+"When selected, display an opaque box behind the subtitles instead of an "
+"outline around the text"
 msgstr ""
-"L'Aegisub no ha pogut decidir un sol joc de caràcters.\n"
-"Escolliu-ne un a continuació:"
+"Quan estigui seleccionat, es mostrarà una capsa opaca darrere els subtítols "
+"en lloc d'un contorn al voltant del text"
 
-#: ../src/charset_detect.cpp:81
-msgid "Choose character set"
-msgstr "Escolliu la codificació"
+#: ../src/dialog_style_editor.cpp:227
+msgid "Outline width, in pixels"
+msgstr "Mida del contorn, en píxels"
 
-#: ../src/dialog_detached_video.cpp:66 ../src/dialog_detached_video.cpp:134
-#, c-format
-msgid "Video: %s"
-msgstr "Vídeo: %s"
+#: ../src/dialog_style_editor.cpp:228
+msgid "Shadow distance, in pixels"
+msgstr "Distància de l'ombra, en píxels"
 
-#: ../src/subtitle_format.cpp:100
-#, c-format
-msgid "From video (%g)"
-msgstr "Del vídeo (%g)"
+#: ../src/dialog_style_editor.cpp:229
+msgid "Scale X, in percentage"
+msgstr "Escalat X, en percentatge"
 
-#: ../src/subtitle_format.cpp:102
-msgid "From video (VFR)"
-msgstr "Del vídeo (VFR)"
+#: ../src/dialog_style_editor.cpp:230
+msgid "Scale Y, in percentage"
+msgstr "Escalat Y, en percentatge"
 
-#: ../src/subtitle_format.cpp:108
-msgid "15.000 FPS"
-msgstr "15,000 FPS"
+#: ../src/dialog_style_editor.cpp:231
+msgid "Angle to rotate in Z axis, in degrees"
+msgstr "Angle de gir en l'eix Z, en graus"
 
-#: ../src/subtitle_format.cpp:109
-msgid "23.976 FPS (Decimated NTSC)"
-msgstr "23,976 FPS (NTSC decimat)"
+#: ../src/dialog_style_editor.cpp:232
+msgid ""
+"Encoding, only useful in unicode if the font doesn't have the proper unicode "
+"mapping"
+msgstr ""
+"Codificació, només útil en Unicode si la lletra no té el mapatge Unicode "
+"correcte"
 
-#: ../src/subtitle_format.cpp:110
-msgid "24.000 FPS (FILM)"
-msgstr "24,000 FPS (FILM)"
+#: ../src/dialog_style_editor.cpp:233
+msgid "Character spacing, in pixels"
+msgstr "Espaiat dels caràcters, en píxels"
 
-#: ../src/subtitle_format.cpp:111
-msgid "25.000 FPS (PAL)"
-msgstr "25,000 FPS (PAL)"
+#: ../src/dialog_style_editor.cpp:234
+msgid "Alignment in screen, in numpad style"
+msgstr "Alineació a la pantalla, segons el teclat numèric"
 
-#: ../src/subtitle_format.cpp:112
-msgid "29.970 FPS (NTSC)"
-msgstr "29,970 FPS (NTSC)"
+#: ../src/dialog_style_editor.cpp:278
+msgid "Primary"
+msgstr "Primari"
 
-#: ../src/subtitle_format.cpp:114
-msgid "29.970 FPS (NTSC with SMPTE dropframe)"
-msgstr "29,970 FPS (NTSC amb caiguda de fotogrames SMPTE)"
+#: ../src/dialog_style_editor.cpp:278
+msgid "Secondary"
+msgstr "Secundari"
 
-#: ../src/subtitle_format.cpp:115
-msgid "30.000 FPS"
-msgstr "30,000 FPS"
+#: ../src/dialog_style_editor.cpp:278
+msgid "Shadow"
+msgstr "Ombra"
 
-#: ../src/subtitle_format.cpp:116
-msgid "50.000 FPS (PAL x2)"
-msgstr "50,000 FPS (PAL x2)"
+#: ../src/dialog_style_editor.cpp:307
+msgid "Outline:"
+msgstr "Contorn:"
 
-#: ../src/subtitle_format.cpp:117
-msgid "59.940 FPS (NTSC x2)"
-msgstr "59,940 FPS (NTSC x2)"
+#: ../src/dialog_style_editor.cpp:308
+msgid "Shadow:"
+msgstr "Ombra:"
 
-#: ../src/subtitle_format.cpp:118
-msgid "60.000 FPS"
-msgstr "60,000 FPS"
+#: ../src/dialog_style_editor.cpp:313
+msgid "Scale X%:"
+msgstr "Escalat X%:"
 
-#: ../src/subtitle_format.cpp:119
-msgid "119.880 FPS (NTSC x4)"
-msgstr "119,880 FPS (NTSC x4)"
+#: ../src/dialog_style_editor.cpp:314
+msgid "Scale Y%:"
+msgstr "Escalat Y%:"
 
-#: ../src/subtitle_format.cpp:120
-msgid "120.000 FPS"
-msgstr "120,000 FPS"
+#: ../src/dialog_style_editor.cpp:315
+msgid "Rotation:"
+msgstr "Rotació:"
 
-#: ../src/subtitle_format.cpp:124
-msgid "Please choose the appropriate FPS for the subtitles:"
-msgstr "Escolliu els FPS apropiats per als subtítols:"
+#: ../src/dialog_style_editor.cpp:316
+msgid "Spacing:"
+msgstr "Espaiat:"
 
-#: ../src/subtitle_format.cpp:124
-msgid "FPS"
-msgstr "FPS"
+#: ../src/dialog_style_editor.cpp:319
+msgid "Encoding:"
+msgstr "Codificació:"
 
-#: ../src/ffmpegsource_common.cpp:94
+#: ../src/dialog_style_editor.cpp:329
+msgid "Preview of current style"
+msgstr "Previsualització de l'estil actual"
+
+#: ../src/dialog_style_editor.cpp:332
+msgid "Text to be used for the preview"
+msgstr "Text que s'utilitzarà a la previsualització"
+
+#: ../src/dialog_style_editor.cpp:333
+msgid "Color of preview background"
+msgstr "Color de fons de la previsualització"
+
+#: ../src/dialog_style_editor.cpp:414
+msgid "There is already a style with this name. Please choose another name."
+msgstr "Ja hi ha un estil amb aquest nom. Trieu un altre nom."
+
+#: ../src/dialog_style_editor.cpp:414
+msgid "Style name conflict"
+msgstr "Conflicte de nom d'estil"
+
+#: ../src/dialog_style_editor.cpp:426
+msgid ""
+"Do you want to change all instances of this style in the script to this new "
+"name?"
+msgstr ""
+"Voleu canviar totes les instàncies d'aquest estil a l'script a aquest nom "
+"nou?"
+
+#: ../src/dialog_style_editor.cpp:427
+msgid "Update script?"
+msgstr "Voleu actualitzar l'script?"
+
+#: ../src/dialog_style_editor.cpp:454 ../src/subs_edit_box.cpp:593
+msgid "style change"
+msgstr "el canvi d'estil"
+
+#: ../src/subs_edit_box.cpp:118
+msgid "&Comment"
+msgstr "&Comenta"
+
+#: ../src/subs_edit_box.cpp:119
+msgid "Comment this line out. Commented lines don't show up on screen."
+msgstr ""
+"Comenta aquesta línia. Les línies comentades no es mostren a la pantalla."
+
+#: ../src/subs_edit_box.cpp:126
+msgid "Style for this line"
+msgstr "Estil per a aquesta línia"
+
+#: ../src/subs_edit_box.cpp:128 ../src/subs_edit_box.cpp:129
+msgid "Edit"
+msgstr "Edita"
+
+#: ../src/subs_edit_box.cpp:139
+msgid ""
+"Actor name for this speech. This is only for reference, and is mainly "
+"useless."
+msgstr ""
+"Nom de l'actor que diu aquest text. Només és una referència, i normalment no "
+"té utilitat."
+
+#: ../src/subs_edit_box.cpp:144
+msgid ""
+"Effect for this line. This can be used to store extra information for "
+"karaoke scripts, or for the effects supported by the renderer."
+msgstr ""
+"Efecte per a aquesta línia. Es pot utilitzar per a emmagatzemar informació "
+"extra als scripts de karaoke, o per a efectes admesos pel programa "
+"renderitzador."
+
+#: ../src/subs_edit_box.cpp:150
+msgid "Number of characters in the longest line of this subtitle."
+msgstr "Nombre de caràcters a la línia més llarga d'aquest subtítol."
+
+#: ../src/subs_edit_box.cpp:157
+msgid "Layer number"
+msgstr "Número de capa"
+
+#: ../src/subs_edit_box.cpp:161
+msgid "Start time"
+msgstr "Temps d'inici"
+
+#: ../src/subs_edit_box.cpp:162
+msgid "End time"
+msgstr "Temps de final"
+
+#: ../src/subs_edit_box.cpp:164
+msgid "Line duration"
+msgstr "Durada de la línia"
+
+#: ../src/subs_edit_box.cpp:167
+msgid "Left Margin (0 = default from style)"
+msgstr "Marge esquerre (0 = per defecte de l'estil)"
+
+#: ../src/subs_edit_box.cpp:167
+msgid "left margin change"
+msgstr "el canvi al marge esquerre"
+
+#: ../src/subs_edit_box.cpp:168
+msgid "Right Margin (0 = default from style)"
+msgstr "Marge dret (0 = per defecte de l'estil)"
+
+#: ../src/subs_edit_box.cpp:168
+msgid "right margin change"
+msgstr "el canvi al marge dret"
+
+#: ../src/subs_edit_box.cpp:169
+msgid "Vertical Margin (0 = default from style)"
+msgstr "Marge vertical (0 = per defecte de l'estil)"
+
+#: ../src/subs_edit_box.cpp:169
+msgid "vertical margin change"
+msgstr "el canvi al marge vertical"
+
+#: ../src/subs_edit_box.cpp:188
+msgid "T&ime"
+msgstr "T&emps"
+
+#: ../src/subs_edit_box.cpp:188
+msgid "Time by h:mm:ss.cs"
+msgstr "Temps en h:mm:ss:cs"
+
+#: ../src/subs_edit_box.cpp:189
+msgid "F&rame"
+msgstr "Fotog&rama"
+
+#: ../src/subs_edit_box.cpp:189
+msgid "Time by frame number"
+msgstr "Temps per número de fotograma"
+
+#: ../src/subs_edit_box.cpp:192
+msgid "Show Original"
+msgstr "Mostra l'original"
+
+#: ../src/subs_edit_box.cpp:193
+msgid ""
+"Show the contents of the subtitle line when it was first selected above the "
+"edit box. This is sometimes useful when editing subtitles or translating "
+"subtitles into another language."
+msgstr ""
+"Mostra el contingut de la línia de subtítol quan l'heu seleccionada per "
+"primer cop a la capsa d'edició. De vegades és útil quan s'editen els "
+"subtítols o es tradueixen a un altre idioma."
+
+#: ../src/subs_edit_box.cpp:441
+msgid "modify text"
+msgstr "la modificació del text"
+
+#: ../src/subs_edit_box.cpp:519
+msgid "modify times"
+msgstr "la modificació dels temps"
+
+#: ../src/subs_edit_box.cpp:599
+msgid "actor change"
+msgstr "el canvi d'actor"
+
+#: ../src/subs_edit_box.cpp:604
+msgid "layer change"
+msgstr "el canvi de capa"
+
+#: ../src/subs_edit_box.cpp:609
+msgid "effect change"
+msgstr "el canvi d'efecte"
+
+#: ../src/subs_edit_box.cpp:614
+msgid "comment change"
+msgstr "el canvi de comentari"
+
+#: ../src/menu.cpp:96
+msgid "Empty"
+msgstr "Buit"
+
+#: ../src/menu.cpp:233
+msgid "&Recent"
+msgstr "&Recents"
+
+#: ../src/menu.cpp:464
+msgid "No Automation macros loaded"
+msgstr "No s'ha carregat cap macro d'automatització"
+
+#: ../src/ffmpegsource_common.cpp:91
 msgid "Indexing"
 msgstr "S'està indexant"
 
-#: ../src/ffmpegsource_common.cpp:95
+#: ../src/ffmpegsource_common.cpp:92
 msgid "Reading timecodes and frame/sample data"
 msgstr "S'estan llegint els codis de temps i les dades dels fotogrames/mostres"
 
-#: ../src/ffmpegsource_common.cpp:141
+#: ../src/ffmpegsource_common.cpp:155
 #, c-format
 msgid "Track %02d: %s"
 msgstr "Pista %02d: %s"
 
-#: ../src/ffmpegsource_common.cpp:146
+#: ../src/ffmpegsource_common.cpp:160
 msgid "Multiple video tracks detected, please choose the one you wish to load:"
-msgstr ""
-"S'han detectat múltiples pistes de vídeo, escolliu la que vulgueu carregar:"
+msgstr "S'han detectat múltiples pistes de vídeo, trieu quina voleu carregar:"
 
-#: ../src/ffmpegsource_common.cpp:146
+#: ../src/ffmpegsource_common.cpp:160
 msgid "Multiple audio tracks detected, please choose the one you wish to load:"
-msgstr ""
-"S'han detectat múltiples pistes d'àudio, escolliu la que vulgueu carregar:"
+msgstr "S'han detectat múltiples pistes d'àudio, trieu quina voleu carregar:"
 
-#: ../src/ffmpegsource_common.cpp:147
+#: ../src/ffmpegsource_common.cpp:161
 msgid "Choose video track"
-msgstr "Escolliu la pista de vídeo"
+msgstr "Trieu la pista de vídeo"
 
-#: ../src/ffmpegsource_common.cpp:147
+#: ../src/ffmpegsource_common.cpp:161
 msgid "Choose audio track"
-msgstr "Escolliu la pista d'àudio"
-
-#: ../src/resolution_resampler.cpp:287
-msgid "resolution resampling"
-msgstr "el reajust de resolució"
+msgstr "Trieu la pista d'àudio"
 
 #: ../src/project.cpp:187
 msgid "Do you want to load/unload the associated files?"
@@ -5687,221 +5616,46 @@ msgid ""
 "\n"
 "The following providers were tried:\n"
 msgstr ""
-"Cap dels proveïdors d'àudio disponibles té un còdec disponible per gestionar "
-"el fitxer seleccionat.\n"
+"Cap dels proveïdors d'àudio disponibles té un còdec disponible per a "
+"gestionar el fitxer seleccionat.\n"
 "\n"
 "S'han provat els següents proveïdors:\n"
 
-#: ../src/dialog_style_editor.cpp:127
-msgid "Style Editor"
-msgstr "Editor d'estils"
+#: ../src/video_box.cpp:57
+msgid "Seek video"
+msgstr "Desplaça el vídeo"
 
-#: ../src/dialog_style_editor.cpp:178
-msgid "Font"
-msgstr "Tipus de lletra"
+#: ../src/video_box.cpp:62
+msgid "Current frame time and number"
+msgstr "Temps i número del fotograma actual"
 
-#: ../src/dialog_style_editor.cpp:180
-msgid "Margins"
-msgstr "Marges"
-
-#: ../src/dialog_style_editor.cpp:181 ../src/dialog_style_editor.cpp:277
-msgid "Outline"
-msgstr "Contorn"
-
-#: ../src/dialog_style_editor.cpp:182
-msgid "Miscellaneous"
-msgstr "Miscel·lània"
-
-#: ../src/dialog_style_editor.cpp:183
-msgid "Preview"
-msgstr "Previsualitza"
-
-#: ../src/dialog_style_editor.cpp:189
-msgid "&Bold"
-msgstr "&Negreta"
-
-#: ../src/dialog_style_editor.cpp:190
-msgid "&Italic"
-msgstr "C&ursiva"
-
-#: ../src/dialog_style_editor.cpp:191
-msgid "&Underline"
-msgstr "&Subratllat"
-
-#: ../src/dialog_style_editor.cpp:192
-msgid "&Strikeout"
-msgstr "&Tatxat"
-
-#: ../src/dialog_style_editor.cpp:204
-msgid "Alignment"
-msgstr "Alineació"
-
-#: ../src/dialog_style_editor.cpp:207
-msgid "&Opaque box"
-msgstr "Capsa &opaca"
-
-#: ../src/dialog_style_editor.cpp:215
-msgid "Style name"
-msgstr "Nom de l'estil"
-
-#: ../src/dialog_style_editor.cpp:216
-msgid "Font face"
-msgstr "Tipus de lletra"
-
-#: ../src/dialog_style_editor.cpp:217
-msgid "Font size"
-msgstr "Mida de la lletra"
-
-#: ../src/dialog_style_editor.cpp:218
-msgid "Choose primary color"
-msgstr "Escolliu el color primari"
-
-#: ../src/dialog_style_editor.cpp:219
-msgid "Choose secondary color"
-msgstr "Escolliu el color secundari"
-
-#: ../src/dialog_style_editor.cpp:220
-msgid "Choose outline color"
-msgstr "Escolliu el color del contorn"
-
-#: ../src/dialog_style_editor.cpp:221
-msgid "Choose shadow color"
-msgstr "Escolliu el color de l'ombra"
-
-#: ../src/dialog_style_editor.cpp:222
-msgid "Distance from left edge, in pixels"
-msgstr "Distància des de la vora esquerra, en píxels"
-
-#: ../src/dialog_style_editor.cpp:223
-msgid "Distance from right edge, in pixels"
-msgstr "Distància des de la vora dreta, en píxels"
-
-#: ../src/dialog_style_editor.cpp:224
-msgid "Distance from top/bottom edge, in pixels"
-msgstr "Distància des de la vora superior/inferior, en píxels"
-
-#: ../src/dialog_style_editor.cpp:225
-msgid ""
-"When selected, display an opaque box behind the subtitles instead of an "
-"outline around the text"
+#: ../src/video_box.cpp:65
+msgid "Time of this frame relative to start and end of current subs"
 msgstr ""
-"Quan estigui seleccionat, es mostrarà una capsa opaca darrere els subtítols "
-"en lloc d'un contorn al voltant del text"
+"Temps d'aquest fotograma relatiu a l'inici i al final dels subtítols actuals"
 
-#: ../src/dialog_style_editor.cpp:226
-msgid "Outline width, in pixels"
-msgstr "Mida del contorn, en píxels"
+#: ../src/mkv_wrap.cpp:213
+msgid "Choose which track to read:"
+msgstr "Trieu quina pista voleu llegir:"
 
-#: ../src/dialog_style_editor.cpp:227
-msgid "Shadow distance, in pixels"
-msgstr "Distància de l'ombra, en píxels"
+#: ../src/mkv_wrap.cpp:213
+msgid "Multiple subtitle tracks found"
+msgstr "S'han trobat múltiples pistes de subtítols"
 
-#: ../src/dialog_style_editor.cpp:228
-msgid "Scale X, in percentage"
-msgstr "Escalat X, en percentatge"
+#: ../src/mkv_wrap.cpp:251
+msgid "Parsing Matroska"
+msgstr "S'està analitzant el fitxer Matroska"
 
-#: ../src/dialog_style_editor.cpp:229
-msgid "Scale Y, in percentage"
-msgstr "Escalat Y, en percentatge"
-
-#: ../src/dialog_style_editor.cpp:230
-msgid "Angle to rotate in Z axis, in degrees"
-msgstr "Angle a rotar en l'eix Z, en graus"
-
-#: ../src/dialog_style_editor.cpp:231
-msgid ""
-"Encoding, only useful in unicode if the font doesn't have the proper unicode "
-"mapping"
-msgstr ""
-"Codificació, només útil en Unicode si la lletra no té el mapeig Unicode "
-"correcte"
-
-#: ../src/dialog_style_editor.cpp:232
-msgid "Character spacing, in pixels"
-msgstr "Espaiat dels caràcters, en píxels"
-
-#: ../src/dialog_style_editor.cpp:233
-msgid "Alignment in screen, in numpad style"
-msgstr "Alineació a la pantalla, segons el teclat numèric"
-
-#: ../src/dialog_style_editor.cpp:277
-msgid "Primary"
-msgstr "Primari"
-
-#: ../src/dialog_style_editor.cpp:277
-msgid "Secondary"
-msgstr "Secundari"
-
-#: ../src/dialog_style_editor.cpp:277
-msgid "Shadow"
-msgstr "Ombra"
-
-#: ../src/dialog_style_editor.cpp:306
-msgid "Outline:"
-msgstr "Contorn:"
-
-#: ../src/dialog_style_editor.cpp:307
-msgid "Shadow:"
-msgstr "Ombra:"
-
-#: ../src/dialog_style_editor.cpp:312
-msgid "Scale X%:"
-msgstr "Escalat X%:"
-
-#: ../src/dialog_style_editor.cpp:313
-msgid "Scale Y%:"
-msgstr "Escalat Y%:"
-
-#: ../src/dialog_style_editor.cpp:314
-msgid "Rotation:"
-msgstr "Rotació:"
-
-#: ../src/dialog_style_editor.cpp:315
-msgid "Spacing:"
-msgstr "Espaiat:"
-
-#: ../src/dialog_style_editor.cpp:318
-msgid "Encoding:"
-msgstr "Codificació:"
-
-#: ../src/dialog_style_editor.cpp:328
-msgid "Preview of current style"
-msgstr "Previsualització de l'estil actual"
-
-#: ../src/dialog_style_editor.cpp:331
-msgid "Text to be used for the preview"
-msgstr "Text que s'utilitzarà a la previsualització"
-
-#: ../src/dialog_style_editor.cpp:332
-msgid "Color of preview background"
-msgstr "Color de fons de la previsualització"
-
-#: ../src/dialog_style_editor.cpp:413
-msgid "There is already a style with this name. Please choose another name."
-msgstr "Ja hi ha un estil amb aquest nom. Escolliu un altre nom."
-
-#: ../src/dialog_style_editor.cpp:413
-msgid "Style name conflict"
-msgstr "Conflicte de nom d'estil"
-
-#: ../src/dialog_style_editor.cpp:425
-msgid ""
-"Do you want to change all instances of this style in the script to this new "
-"name?"
-msgstr ""
-"Voleu canviar totes les instàncies d'aquest estil a l'script a aquest nou "
-"nom?"
-
-#: ../src/dialog_style_editor.cpp:426
-msgid "Update script?"
-msgstr "Voleu actualitzar l'script?"
+#: ../src/mkv_wrap.cpp:251
+msgid "Reading subtitles from Matroska file."
+msgstr "S'estan llegint els subtítols del fitxer Matroska."
 
 #: ../src/dialog_export_ebu3264.cpp:84
 msgid ""
 "Time code offset in incorrect format. Ensure it is entered as four groups of "
 "two digits separated by colons."
 msgstr ""
-"La compensació dels codis de temps té un format erroni. Assegureu-vos que "
+"El desplaçament dels codis de temps té un format erroni. Assegureu-vos que "
 "l'introduïu com a quatre grups de dos dígits separats per dos punts."
 
 #: ../src/dialog_export_ebu3264.cpp:84
@@ -5914,7 +5668,7 @@ msgstr "Exporta al format EBU STL"
 
 #: ../src/dialog_export_ebu3264.cpp:103
 msgid "23.976 fps (non-standard, STL24.01)"
-msgstr "23,976 fps (no estàndard, STL24.01)"
+msgstr "23.976 fps (no estàndard, STL24.01)"
 
 #: ../src/dialog_export_ebu3264.cpp:104
 msgid "24 fps (non-standard, STL24.01)"
@@ -5974,11 +5728,11 @@ msgstr "Codificació del text"
 
 #: ../src/dialog_export_ebu3264.cpp:126
 msgid "Automatically wrap long lines (ASS)"
-msgstr "Fes saltar les línies llargues automàticament (ASS)"
+msgstr "Ajusta les línies llargues automàticament (ASS)"
 
 #: ../src/dialog_export_ebu3264.cpp:127
 msgid "Automatically wrap long lines (Balanced)"
-msgstr "Fes saltar les línies llargues automàticament (equilibrat)"
+msgstr "Ajusta les línies llargues automàticament (equilibrat)"
 
 #: ../src/dialog_export_ebu3264.cpp:128
 msgid "Abort if any lines are too long"
@@ -6010,7 +5764,7 @@ msgstr "Llargada màxima de la línia:"
 
 #: ../src/dialog_export_ebu3264.cpp:151
 msgid "Time code offset:"
-msgstr "Compensació dels codis de temps:"
+msgstr "Desplaçament dels codis de temps:"
 
 #: ../src/dialog_export_ebu3264.cpp:154
 msgid "Text formatting"
@@ -6024,164 +5778,480 @@ msgstr "Codis de temps"
 msgid "Display standard"
 msgstr "Mostra l'estàndard"
 
-#: ../src/subs_controller.cpp:158
-#, c-format
-msgid "File backup saved as \"%s\"."
-msgstr "S'ha desat una còpia de seguretat del fitxer com a \"%s\"."
-
-#: ../src/subs_controller.cpp:260
-#, c-format
-msgid "Do you want to save changes to %s?"
-msgstr "Voleu desar els canvis a %s?"
-
-#: ../src/subs_controller.cpp:260
-msgid "Unsaved changes"
-msgstr "Canvis no desats"
-
-#: ../src/subs_controller.cpp:395
-msgid "Untitled"
-msgstr "Sense títol"
-
-#: ../src/subs_controller.cpp:397
-msgid "untitled"
-msgstr "sense títol"
-
-#: ../src/dialog_video_properties.cpp:44
-msgid "Resolution mismatch"
-msgstr "Resolució no coincident"
-
-#: ../src/dialog_video_properties.cpp:46
+#: ../src/main.cpp:276
 #, c-format
 msgid ""
-"The resolution of the loaded video and the resolution specified for the "
-"subtitles don't match.\n"
+"Oops, Aegisub has crashed!\n"
 "\n"
-"Video resolution:\t%d x %d\n"
-"Script resolution:\t%d x %d\n"
+"An attempt has been made to save a copy of your file to:\n"
 "\n"
-"Change subtitles resolution to match video?"
+"%s\n"
+"\n"
+"Aegisub will now close."
 msgstr ""
-"La resolució del vídeo carregat i la resolució especificada als subtítols no "
-"coincideixen.\n"
+"Ups, l'Aegisub ha patit un error!\n"
 "\n"
-"Resolució del vídeo: %d x %d\n"
-"Resolució de l'script: %d x %d\n"
+"S'ha mirat de desar una còpia del vostre fitxer a:\n"
 "\n"
-"Voleu canviar la resolució dels subtítols perquè coincideixi amb la del "
-"vídeo?"
+"%s\n"
+"\n"
+"L'Aegisub es tancarà."
 
-#: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
-msgid "Set to video resolution"
-msgstr "Defineix a la resolució del vídeo"
+#: ../src/main.cpp:303
+msgid ""
+"Do you want Aegisub to check for updates whenever it starts? You can still "
+"do it manually via the Help menu."
+msgstr ""
+"Voleu que l'Aegisub comprovi si hi ha actualitzacions cada cop que s'iniciï? "
+"Podeu fer-ho manualment al menú d'Ajuda."
 
-#: ../src/dialog_video_properties.cpp:55
-msgid "Resample script (stretch to new aspect ratio)"
-msgstr "Reajusta l'script (estira a una nova relació d'aspecte)"
+#: ../src/main.cpp:303
+msgid "Check for updates?"
+msgstr "Voleu comprovar si hi ha actualitzacions?"
 
-#: ../src/dialog_video_properties.cpp:56
-msgid "Resample script (add borders)"
-msgstr "Reajusta l'script (afegeix vores)'"
+#: ../src/main.cpp:420 ../src/main.cpp:423
+msgid "Program error"
+msgstr "S'ha produït un error al programa"
 
-#: ../src/dialog_video_properties.cpp:57
-msgid "Resample script (remove borders)"
-msgstr "Reajusta l'script (elimina vores)"
+#: ../src/main.cpp:437
+#, c-format
+msgid ""
+"An unexpected error has occurred. Please save your work and restart "
+"Aegisub.\n"
+"\n"
+"Error Message: %s"
+msgstr ""
+"S'ha produït un error inesperat. Deseu la feina i reinicieu l'Aegisub.\n"
+"\n"
+"Missatge d'error: %s"
 
-#: ../src/dialog_video_properties.cpp:64
-msgid "Resample script"
-msgstr "Reajusta l'script"
+#: ../src/subtitle_format_ebu3264.cpp:396
+#, c-format
+msgid "Line over maximum length: %s"
+msgstr "Línia per sobre de la llargada màxima: %s"
 
-#: ../src/dialog_video_properties.cpp:163
-msgid "change script resolution"
-msgstr "el canvi de resolució de l'script"
+#: ../src/dialog_shift_times.cpp:92
+msgid "unsaved"
+msgstr "no desat"
 
-#: ../src/dialog_attachments.cpp:68
-msgid "Attachment List"
-msgstr "Llista d'adjuncions"
+#: ../src/dialog_shift_times.cpp:96
+#, c-format
+msgid "%s frames"
+msgstr "%s fotogrames"
 
-#: ../src/dialog_attachments.cpp:76
-msgid "Attach &Font"
-msgstr "Adjunta tipus de &lletra"
+#: ../src/dialog_shift_times.cpp:98
+msgid "backward"
+msgstr "endarrere"
 
-#: ../src/dialog_attachments.cpp:77
-msgid "Attach &Graphics"
-msgstr "Adjunta &gràfics"
+#: ../src/dialog_shift_times.cpp:98
+msgid "forward"
+msgstr "endavant"
 
-#: ../src/dialog_attachments.cpp:78
-msgid "E&xtract"
-msgstr "E&xtreu"
+#: ../src/dialog_shift_times.cpp:102
+msgid "s+e"
+msgstr "i+f"
 
-#: ../src/dialog_attachments.cpp:110
-msgid "Attachment name"
-msgstr "Nom de l'adjunció"
+#: ../src/dialog_shift_times.cpp:103
+msgid "s"
+msgstr "i"
 
-#: ../src/dialog_attachments.cpp:111
-msgid "Size"
-msgstr "Mida"
+#: ../src/dialog_shift_times.cpp:104
+msgid "e"
+msgstr "f"
 
-#: ../src/dialog_attachments.cpp:112
-msgid "Group"
-msgstr "Grup"
+#: ../src/dialog_shift_times.cpp:111
+msgid "all"
+msgstr "tot"
 
-#: ../src/dialog_attachments.cpp:138 ../src/dialog_attachments.cpp:147
-msgid "Choose file to be attached"
-msgstr "Escolliu el fitxer que voleu adjuntar"
+#: ../src/dialog_shift_times.cpp:114
+#, c-format
+msgid "from %d onward"
+msgstr "de %d en endavant"
 
-#: ../src/dialog_attachments.cpp:142
-msgid "attach font file"
-msgstr "l'adjunció del fitxer de tipus de lletra"
+#: ../src/dialog_shift_times.cpp:117
+msgid "sel "
+msgstr "sel "
 
-#: ../src/dialog_attachments.cpp:152
-msgid "attach graphics file"
-msgstr "l'adjunció del fitxer de gràfics"
+#: ../src/dialog_shift_times.cpp:144
+msgid "&Time: "
+msgstr "&Temps: "
 
-#: ../src/dialog_attachments.cpp:164
-msgid "Select the path to save the files to:"
-msgstr "Seleccioneu el camí on desar els fitxers:"
+#: ../src/dialog_shift_times.cpp:145
+msgid "Shift by time"
+msgstr "Desplaça per temps"
 
-#: ../src/dialog_attachments.cpp:167
-msgid "Select the path to save the file to:"
-msgstr "Seleccioneu el camí on desar el fitxer:"
+#: ../src/dialog_shift_times.cpp:148
+msgid "&Frames: "
+msgstr "&Fotogrames: "
 
-#: ../src/dialog_attachments.cpp:189
-msgid "remove attachment"
-msgstr "l'eliminació de l'adjunció"
+#: ../src/dialog_shift_times.cpp:149
+msgid "Shift by frames"
+msgstr "Desplaça per fotogrames"
 
-#: ../src/dialog_translation.cpp:77
+#: ../src/dialog_shift_times.cpp:153
+msgid "Enter time in h:mm:ss.cs notation"
+msgstr "Introduïu el temps en notació h:mm:ss.cs"
+
+#: ../src/dialog_shift_times.cpp:156
+msgid "Enter number of frames to shift by"
+msgstr "Introduïu el nombre de fotogrames a desplaçar"
+
+#: ../src/dialog_shift_times.cpp:158
+msgid "For&ward"
+msgstr "&Endavant"
+
+#: ../src/dialog_shift_times.cpp:159
+msgid ""
+"Shifts subs forward, making them appear later. Use if they are appearing too "
+"soon."
+msgstr ""
+"Desplaça els subtítols cap endavant, fent que apareguin més tard. Utilitzeu "
+"això si apareixen massa aviat."
+
+#: ../src/dialog_shift_times.cpp:161
+msgid "&Backward"
+msgstr "End&arrere"
+
+#: ../src/dialog_shift_times.cpp:162
+msgid ""
+"Shifts subs backward, making them appear earlier. Use if they are appearing "
+"too late."
+msgstr ""
+"Desplaça els subtítols cap endarrere, fent que apareguin més aviat. "
+"Utilitzeu això si apareixen massa tard."
+
+#: ../src/dialog_shift_times.cpp:164
+msgid "&All rows"
+msgstr "T&otes les línies"
+
+#: ../src/dialog_shift_times.cpp:164
+msgid "Selection &onward"
+msgstr "De &la selecció cap endavant"
+
+#: ../src/dialog_shift_times.cpp:165
+msgid "Affect"
+msgstr "Afecta"
+
+#: ../src/dialog_shift_times.cpp:167
+msgid "Start a&nd End times"
+msgstr "Te&mps d'inici i de final"
+
+#: ../src/dialog_shift_times.cpp:167
+msgid "&Start times only"
+msgstr "Només els temps d'&inici"
+
+#: ../src/dialog_shift_times.cpp:167
+msgid "&End times only"
+msgstr "Només els tem&ps de final"
+
+#: ../src/dialog_shift_times.cpp:168
+msgid "Times"
+msgstr "Temps"
+
+#: ../src/dialog_shift_times.cpp:172
+msgid "&Clear"
+msgstr "&Neteja"
+
+#: ../src/dialog_shift_times.cpp:203
+msgid "Shift by"
+msgstr "Desplaça per"
+
+#: ../src/dialog_shift_times.cpp:212
+msgid "Load from history"
+msgstr "Carrega de l'historial"
+
+#: ../src/dialog_shift_times.cpp:410
+msgid "shifting"
+msgstr "el desplaçament"
+
+#: ../src/dialog_dummy_video.cpp:105
+msgid "Dummy video options"
+msgstr "Opcions de vídeo fictici"
+
+#: ../src/dialog_dummy_video.cpp:117
+msgid "Checkerboard &pattern"
+msgstr "&Patró de tauler d'escacs"
+
+#: ../src/dialog_dummy_video.cpp:120
+msgid "Video resolution:"
+msgstr "Resolució del vídeo:"
+
+#: ../src/dialog_dummy_video.cpp:122
+msgid "Color:"
+msgstr "Color:"
+
+#: ../src/dialog_dummy_video.cpp:123
+msgid "Frame rate (fps):"
+msgstr "Fotogrames per segon (fps):"
+
+#: ../src/dialog_dummy_video.cpp:124
+msgid "Duration (frames):"
+msgstr "Durada (fotogrames):"
+
+#: ../src/dialog_dummy_video.cpp:170
+#, c-format
+msgid "Resulting duration: %s"
+msgstr "Durada resultant: %s"
+
+#: ../src/audio_display.cpp:707
+#, c-format
+msgid "%d%%, %d pixel/second"
+msgstr "%d%%, %d píxels/segon"
+
+#: ../src/dialog_kara_timing_copy.cpp:57
+msgid "Source: "
+msgstr "Origen: "
+
+#: ../src/dialog_kara_timing_copy.cpp:58
+msgid "Dest: "
+msgstr "Destinació: "
+
+#: ../src/dialog_kara_timing_copy.cpp:470
+msgid "Kanji timing"
+msgstr "Creació de temps per a kanjis"
+
+#: ../src/dialog_kara_timing_copy.cpp:476
+msgid "Styles"
+msgstr "Estils"
+
+#: ../src/dialog_kara_timing_copy.cpp:478
+msgid "Shortcut Keys"
+msgstr "Dreceres del teclat"
+
+#: ../src/dialog_kara_timing_copy.cpp:479
+msgid "Commands"
+msgstr "Ordres"
+
+#: ../src/dialog_kara_timing_copy.cpp:487
+msgid "Attempt to &interpolate kanji."
+msgstr "Mira d'inter&polar els kanjis."
+
+#: ../src/dialog_kara_timing_copy.cpp:494
+msgid ""
+"When the destination textbox has focus, use the following keys:\n"
+"\n"
+"Right Arrow: Increase dest. selection length\n"
+"Left Arrow: Decrease dest. selection length\n"
+"Up Arrow: Increase source selection length\n"
+"Down Arrow: Decrease source selection length\n"
+"Enter: Link, accept line when done\n"
+"Backspace: Unlink last"
+msgstr ""
+"Quan la capsa del text de destinació tingui el focus, utilitzeu les següents "
+"tecles:\n"
+"\n"
+"Fletxa dreta: Augmenta la llargada de la selecció de destinació\n"
+"Fletxa esquerra: Disminueix la llargada de la selecció de destinació\n"
+"Fletxa amunt: Augmenta la llargada de la selecció d'origen\n"
+"Fletxa avall: Disminueix la llargada de la selecció d'origen\n"
+"Retorn: Enllaça, accepta la línia quan s'ha acabat\n"
+"Retrocés: Desenllaça la darrera"
+
+#: ../src/dialog_kara_timing_copy.cpp:497
+msgid "S&tart!"
+msgstr "&Inicia!"
+
+#: ../src/dialog_kara_timing_copy.cpp:498
+msgid "&Link"
+msgstr "En&llaça"
+
+#: ../src/dialog_kara_timing_copy.cpp:499
+msgid "&Unlink"
+msgstr "D&esenllaça"
+
+#: ../src/dialog_kara_timing_copy.cpp:500
+msgid "Skip &Source Line"
+msgstr "Omet la línia d'&origen"
+
+#: ../src/dialog_kara_timing_copy.cpp:501
+msgid "Skip &Dest Line"
+msgstr "Omet la línia de &destinació"
+
+#: ../src/dialog_kara_timing_copy.cpp:502
+msgid "&Go Back a Line"
+msgstr "Torna e&nrere una línia"
+
+#: ../src/dialog_kara_timing_copy.cpp:503
+msgid "&Accept Line"
+msgstr "&Accepta la línia"
+
+#: ../src/dialog_kara_timing_copy.cpp:566
+msgid "kanji timing"
+msgstr "la creació de temps per a kanjis"
+
+#: ../src/dialog_kara_timing_copy.cpp:574
+msgid "Select source and destination styles first."
+msgstr "Primer seleccioneu els estils d'origen i destinació."
+
+#: ../src/dialog_kara_timing_copy.cpp:576
+msgid "The source and destination styles must be different."
+msgstr "Els estils d'origen i destinació han de ser diferents."
+
+#: ../src/dialog_kara_timing_copy.cpp:626
+msgid "Group all of the source text."
+msgstr "Agrupa tot el text d'origen."
+
+#: ../src/dialog_selection.cpp:106
+msgid "Select"
+msgstr "Selecciona"
+
+#: ../src/dialog_selection.cpp:117
+msgid "Match"
+msgstr "Coincidència"
+
+#: ../src/dialog_selection.cpp:121
+msgid "&Matches"
+msgstr "C&oincideix"
+
+#: ../src/dialog_selection.cpp:122
+msgid "&Doesn't Match"
+msgstr "&No coincideix"
+
+#: ../src/dialog_selection.cpp:123
+msgid "Match c&ase"
+msgstr "Distingeix entre &majúscules i minúscules"
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Exact match"
+msgstr "Coincidència &exacta"
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Contains"
+msgstr "C&onté"
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Regular Expression match"
+msgstr "Coincidència d'expressió &regular"
+
+#: ../src/dialog_selection.cpp:133
+msgid "Mode"
+msgstr "Mode"
+
+#: ../src/dialog_selection.cpp:137
+msgid "&Style"
+msgstr "E&stil"
+
+#: ../src/dialog_selection.cpp:137
+msgid "Act&or"
+msgstr "Acto&r"
+
+#: ../src/dialog_selection.cpp:137
+msgid "E&ffect"
+msgstr "E&fecte"
+
+#: ../src/dialog_selection.cpp:142
+msgid "Match dialogues/comments"
+msgstr "Coincideix amb diàlegs/comentaris"
+
+#: ../src/dialog_selection.cpp:143
+msgid "D&ialogues"
+msgstr "D&iàlegs"
+
+#: ../src/dialog_selection.cpp:144
+msgid "Comme&nts"
+msgstr "Comen&taris"
+
+#: ../src/dialog_selection.cpp:149
+msgid "Set se&lection"
+msgstr "D&efineix la selecció"
+
+#: ../src/dialog_selection.cpp:149
+msgid "&Add to selection"
+msgstr "&Afegeix a la selecció"
+
+#: ../src/dialog_selection.cpp:149
+msgid "S&ubtract from selection"
+msgstr "T&reu de la selecció"
+
+#: ../src/dialog_selection.cpp:149
+msgid "Intersect &with selection"
+msgstr "Interseca am&b la selecció"
+
+#: ../src/dialog_selection.cpp:211
+#, c-format
+msgid "Selection was set to one line"
+msgid_plural "Selection was set to %u lines"
+msgstr[0] "S'ha seleccionat una línia"
+msgstr[1] "S'han seleccionat %u línies"
+
+#: ../src/dialog_selection.cpp:212
+msgid "Selection was set to no lines"
+msgstr "No s'ha seleccionat cap línia"
+
+#: ../src/dialog_selection.cpp:218
+#, c-format
+msgid "One line was added to selection"
+msgid_plural "%u lines were added to selection"
+msgstr[0] "S'ha afegit una línia a la selecció"
+msgstr[1] "S'han afegit %u línies a la selecció"
+
+#: ../src/dialog_selection.cpp:219
+msgid "No lines were added to selection"
+msgstr "No s'ha afegit cap línia a la selecció"
+
+#: ../src/dialog_selection.cpp:230
+#, c-format
+msgid "One line was removed from selection"
+msgid_plural "%u lines were removed from selection"
+msgstr[0] "S'ha tret una línia de la selecció"
+msgstr[1] "S'han tret %u línies de la selecció"
+
+#: ../src/dialog_selection.cpp:231
+msgid "No lines were removed from selection"
+msgstr "No s'ha tret cap línia de la selecció"
+
+#: ../src/dialog_selection.cpp:236
+msgid "Selection"
+msgstr "Selecció"
+
+#: ../src/preferences_base.cpp:63
+msgid "Please choose the folder:"
+msgstr "Trieu la carpeta:"
+
+#: ../src/preferences_base.cpp:209
+msgid "Browse..."
+msgstr "Navega..."
+
+#: ../src/preferences_base.cpp:244
+msgid "Choose..."
+msgstr "Selecciona..."
+
+#: ../src/preferences_base.cpp:252
+msgid "Font Size"
+msgstr "Mida de la lletra"
+
+#: ../src/dialog_translation.cpp:79
 msgid "Original"
 msgstr "Original"
 
-#: ../src/dialog_translation.cpp:100
+#: ../src/dialog_translation.cpp:102
 msgid "Translation"
 msgstr "Traducció"
 
-#: ../src/dialog_translation.cpp:115
+#: ../src/dialog_translation.cpp:117
 msgid "Insert original"
 msgstr "Insereix l'original"
 
-#: ../src/dialog_translation.cpp:118
+#: ../src/dialog_translation.cpp:120
 msgid "Delete line"
 msgstr "Suprimeix la línia"
 
-#: ../src/dialog_translation.cpp:121
+#: ../src/dialog_translation.cpp:123
 msgid "Enable &preview"
 msgstr "Activa la &previsualització"
 
-#: ../src/dialog_translation.cpp:178 ../src/dialog_translation.cpp:278
+#: ../src/dialog_translation.cpp:180 ../src/dialog_translation.cpp:280
 msgid "No more lines to translate."
-msgstr "No hi ha més línies per traduir."
+msgstr "No hi ha més línies a traduir."
 
-#: ../src/dialog_translation.cpp:186 ../src/dialog_translation.cpp:236
+#: ../src/dialog_translation.cpp:188 ../src/dialog_translation.cpp:238
 #, c-format
 msgid "Current line: %d/%d"
 msgstr "Línia actual: %d/%d"
 
-#: ../src/dialog_translation.cpp:273
+#: ../src/dialog_translation.cpp:275
 msgid "translation assistant"
 msgstr "l'auxiliar de traducció"
-
-#: ../src/visual_tool.cpp:122
-msgid "visual typesetting"
-msgstr "la definició d'estils visual"
 
 #: ../src/dialog_resample.cpp:119
 msgid "&Symmetrical"
@@ -6213,7 +6283,7 @@ msgstr "Gestió de la relació d'aspecte"
 
 #: ../src/dialog_resample.cpp:162
 msgid "Margin offset"
-msgstr "Compensació del marge"
+msgstr "Desplaçament del marge"
 
 #: ../src/dialog_resample.cpp:167 ../src/dialog_resample.cpp:181
 msgid "x"
@@ -6231,64 +6301,17 @@ msgstr "Resolució d'origen"
 msgid "Destination Resolution"
 msgstr "Resolució de destinació"
 
-#: ../src/dialog_version_check.cpp:94
-msgid "Version Checker"
-msgstr "Comprovador de versió"
+#: ../src/subtitles_provider_libass.cpp:107
+msgid "Updating font index"
+msgstr "S'està actualitzant l'índex de tipus de lletra"
 
-#: ../src/dialog_version_check.cpp:119
-msgid "&Auto Check for Updates"
-msgstr "Comprova &automàticament si hi ha actualitzacions"
+#: ../src/subtitles_provider_libass.cpp:108
+msgid "This may take several minutes"
+msgstr "Això pot tardar uns quants minuts"
 
-#: ../src/dialog_version_check.cpp:124
-msgid "Remind me again in a &week"
-msgstr "Recorda-m'ho en una &setmana"
-
-#: ../src/dialog_version_check.cpp:288
-msgid "Could not connect to updates server."
-msgstr "No s'ha pogut connectar al servidor d'actualitzacions."
-
-#: ../src/dialog_version_check.cpp:310
-msgid "Could not download from updates server."
-msgstr "No s'ha pogut descarregar del servidor d'actualitzacions."
-
-#: ../src/dialog_version_check.cpp:312
-#, c-format
-msgid "HTTP request failed, got HTTP response %d."
-msgstr "La petició HTTP ha fallat, s'ha obtingut la resposta HTTP %d."
-
-#: ../src/dialog_version_check.cpp:343
-msgid "An update to Aegisub was found."
-msgstr "S'ha trobat una actualització de l'Aegisub."
-
-#: ../src/dialog_version_check.cpp:345
-msgid "Several possible updates to Aegisub were found."
-msgstr "S'han trobat diverses possibles actualitzacions de l'Aegisub."
-
-#: ../src/dialog_version_check.cpp:347
-msgid "There are no updates to Aegisub."
-msgstr "No hi ha actualitzacions de l'Aegisub."
-
-#: ../src/dialog_version_check.cpp:375
-#, c-format
-msgid ""
-"There was an error checking for updates to Aegisub:\n"
-"%s\n"
-"\n"
-"If other applications can access the Internet fine, this is probably a "
-"temporary server problem on our end."
-msgstr ""
-"S'ha produït un error en comprovar les actualitzacions de l'Aegisub:\n"
-"%s\n"
-"\n"
-"Si hi ha altres aplicacions que poden accedir correctament a Internet, "
-"probablement estigui causat per un problema temporal en els nostres "
-"servidors."
-
-#: ../src/dialog_version_check.cpp:379
-msgid "An unknown error occurred while checking for updates to Aegisub."
-msgstr ""
-"S'ha produït un error desconegut en comprovar les actualitzacions de "
-"l'Aegisub."
+#: ../src/hotkey.cpp:259
+msgid "Invalid command name for hotkey"
+msgstr "Nom d'ordre invàlid per a la drecera de teclat"
 
 #: default_menu.json:0
 msgid "&Insert (before)"
@@ -6332,7 +6355,7 @@ msgstr "&Fitxer"
 
 #: default_menu.json:0
 msgid "&Subtitle"
-msgstr "&Subtítol"
+msgstr "&Subtítols"
 
 #: default_menu.json:0
 msgid "&Timing"
@@ -6384,15 +6407,35 @@ msgstr "Defineix l'&ampliació"
 
 #: default_menu.json:0
 msgid "Override &AR"
-msgstr "Imposa la relació d'as&pecte"
+msgstr "Força la relació d'as&pecte"
 
 #: default_menu.json:0
-msgid "&Export As..."
-msgstr "&Exporta com a..."
+msgid "Window"
+msgstr "Finestra"
 
-#: default_hotkey.json:602:
+#: default_menu.json:0
+msgid "Open..."
+msgstr "Obre..."
+
+#: default_menu.json:0
+msgid "Open Recent"
+msgstr "Obre un fitxer recent"
+
+#: default_menu.json:0
+msgid "Save"
+msgstr "Desa"
+
+#: default_menu.json:0
+msgid "Save As..."
+msgstr "Anomena i desa..."
+
+#: default_menu.json:0
+msgid "Export As..."
+msgstr "Exporta com a..."
+
+#: default_hotkey.json:244:
 msgid "Subtitle Edit Box"
-msgstr "Caixa d'edició dels subtítols"
+msgstr "Capsa d'edició dels subtítols"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:6
 msgid "Add edgeblur"
@@ -6408,61 +6451,6 @@ msgstr ""
 msgid "Adds \\be1 tags to all selected lines"
 msgstr "Afegeix etiquetes \\be1 a totes les línies seleccionades"
 
-#: ../automation/autoload/karaoke-auto-leadin.lua:32
-msgid "Automatic karaoke lead-in"
-msgstr "Temps d'entrada automàtic al karaoke"
-
-#: ../automation/autoload/karaoke-auto-leadin.lua:33
-msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
-msgstr ""
-"Uneix els finals de les línies seleccionades i afegeix etiquetes \\k per "
-"desplaçar el karaoke"
-
-#: ../automation/autoload/cleantags-autoload.lua:31
-msgid "Clean Tags"
-msgstr "Neteja les etiquetes"
-
-#: ../automation/autoload/cleantags-autoload.lua:32
-msgid ""
-"Clean subtitle lines by re-arranging ASS tags and override blocks within the "
-"lines"
-msgstr ""
-"Neteja les línies de subtítols recol·locant les etiquetes ASS i els blocs "
-"d'etiquetes d'estils entre les línies"
-
-#: ../automation/autoload/kara-templater.lua:36
-msgid "Karaoke Templater"
-msgstr "Creador de plantilles de karaoke"
-
-#: ../automation/autoload/kara-templater.lua:37
-msgid ""
-"Macro and export filter to apply karaoke effects using the template language"
-msgstr ""
-"Macro i filtre d'exportació per aplicar efectes de karaoke utilitzant el "
-"llenguatge de plantilles"
-
-#: ../automation/autoload/kara-templater.lua:858
-msgid "Apply karaoke template"
-msgstr "Aplica les plantilles de karaoke"
-
-#: ../automation/autoload/kara-templater.lua:858
-msgid "Applies karaoke effects from templates"
-msgstr "Aplica els efectes de karaoke de les plantilles"
-
-#: ../automation/autoload/kara-templater.lua:859
-msgid "Karaoke template"
-msgstr "Plantilla de karaoke"
-
-#: ../automation/autoload/kara-templater.lua:859
-msgid ""
-"Apply karaoke effect templates to the subtitles.\n"
-"\n"
-"See the help file for information on how to use this."
-msgstr ""
-"Aplica les plantilles d'efectes de karaoke als subtítols.\n"
-"\n"
-"Vegeu el fitxer d'ajuda per obtenir més informació sobre com utilitzar-ho."
-
 #: ../automation/autoload/strip-tags.lua:17
 msgid "Strip tags"
 msgstr "Elimina les etiquetes"
@@ -6475,6 +6463,18 @@ msgstr "Elimina totes les etiquetes d'estils de les línies seleccionades"
 msgid "strip tags"
 msgstr "l'eliminació d'etiquetes"
 
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:6
+msgid "Make text fullwidth"
+msgstr "Fes el text d'amplada completa"
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:7
+msgid ""
+"Shows how to use the unicode include to iterate over characters and a lookup "
+"table to convert those characters to something else."
+msgstr ""
+"Mostra com utilitzar el fitxer d'inclusió unicode per a iterar els caràcters "
+"i una taula de cerca per a convertir aquests caràcters en una altra cosa."
+
 #: ../automation/autoload/macro-2-mkfullwitdh.lua:77
 msgid "Make fullwidth"
 msgstr "Fes d'amplada completa"
@@ -6482,6 +6482,71 @@ msgstr "Fes d'amplada completa"
 #: ../automation/autoload/macro-2-mkfullwitdh.lua:80
 msgid "Convert Latin letters to SJIS fullwidth letters"
 msgstr "Converteix les lletres llatines a lletres SJIS d'amplada completa"
+
+#: ../automation/autoload/cleantags-autoload.lua:31
+msgid "Clean Tags"
+msgstr "Endreça les etiquetes"
+
+#: ../automation/autoload/cleantags-autoload.lua:32
+msgid ""
+"Clean subtitle lines by re-arranging ASS tags and override blocks within the "
+"lines"
+msgstr ""
+"Endreça les línies de subtítols recol·locant les etiquetes ASS i els blocs "
+"d'etiquetes d'estils entre les línies"
+
+#: ../automation/autoload/kara-templater.lua:36
+msgid "Karaoke Templater"
+msgstr "Creador de plantilles de karaoke"
+
+#: ../automation/autoload/kara-templater.lua:37
+msgid ""
+"Macro and export filter to apply karaoke effects using the template language"
+msgstr ""
+"Macro i filtre d'exportació per a aplicar efectes de karaoke utilitzant el "
+"llenguatge de plantilles"
+
+#: ../automation/autoload/kara-templater.lua:860
+msgid "Apply karaoke template"
+msgstr "Aplica les plantilles de karaoke"
+
+#: ../automation/autoload/kara-templater.lua:860
+msgid "Applies karaoke effects from templates"
+msgstr "Aplica els efectes de karaoke de les plantilles"
+
+#: ../automation/autoload/kara-templater.lua:861
+msgid "Karaoke template"
+msgstr "Plantilla de karaoke"
+
+#: ../automation/autoload/kara-templater.lua:861
+msgid ""
+"Apply karaoke effect templates to the subtitles.\n"
+"\n"
+"See the help file for information on how to use this."
+msgstr ""
+"Aplica les plantilles d'efectes de karaoke als subtítols.\n"
+"\n"
+"Vegeu el fitxer d'ajuda per a obtenir més informació de com utilitzar-ho."
+
+#: ../automation/autoload/karaoke-auto-leadin.lua:32
+msgid "Automatic karaoke lead-in"
+msgstr "Temps d'entrada automàtic al karaoke"
+
+#: ../automation/autoload/karaoke-auto-leadin.lua:33
+msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
+msgstr ""
+"Uneix els finals de les línies seleccionades i afegeix etiquetes \\k per a "
+"desplaçar el karaoke"
+
+#: ../automation/autoload/select-overlaps.moon:17
+msgid "Select overlaps"
+msgstr "Selecciona les superposicions"
+
+#: ../automation/autoload/select-overlaps.moon:18
+msgid "Select lines which begin while another non-comment line is active"
+msgstr ""
+"Selecciona les línies que comencen mentre una altra línia no comentada està "
+"activa"
 
 #: aegisub.desktop:4
 msgid "Aegisub"
@@ -6493,7 +6558,11 @@ msgstr "Editor de subtítols"
 
 #: aegisub.desktop:6
 msgid "Create and edit subtitles for film and videos."
-msgstr "Creeu i editeu subtítols per a pel·lícules i vídeos."
+msgstr "Creeu i editeu subtítols per a films i vídeos."
+
+#: aegisub.desktop:12
+msgid "subtitles;subtitle;captions;captioning;video;audio;"
+msgstr "subtítols;subtitular;subtitulat;subtitulació;vídeo;àudio;"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Installing runtime libraries..."
@@ -6505,7 +6574,7 @@ msgstr "Crea una icona al menú Inicia"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Automatically check for new versions of Aegisub"
-msgstr "Comprova si hi ha noves versions de l'Aegisub automàticament"
+msgstr "Comprova automàticament si hi ha noves versions de l'Aegisub"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Update Checker:"
@@ -6519,12 +6588,33 @@ msgid ""
 "warranties of any kind are given either.%n%nSee the Aegisub website for "
 "information on obtaining the source code."
 msgstr ""
-"S'instal·larà l'Aegisub {#BUILD_GIT_VERSION_STRING} al vostre ordinador.%n"
+"S'instal·larà l'Aegisub {#BUILD_GIT_VERSION_STRING} a l'ordinador.%n"
 "%nL'Aegisub està cobert per la Llicència Pública General de GNU versió 2. "
-"Això vol dir que podeu utilitzar l'aplicació per a qualsevol propòsit sense "
-"càrrecs, però també que  no es proporciona cap tipus de garantia.%n%nVegeu "
-"el lloc web de l'Aegisub per obtenir informació sobre com obtenir-ne el codi "
+"Això vol dir que podeu utilitzar l'aplicació per a qualsevol finalitat sense "
+"càrrecs, però també que no es proporciona cap mena de garantia.%n%nVegeu el "
+"lloc web de l'Aegisub per a obtenir informació de com obtenir-ne el codi "
 "font."
+
+#~ msgid "&Forums"
+#~ msgstr "&Fòrums"
+
+#~ msgid "Forums"
+#~ msgstr "Fòrums"
+
+#~ msgid "Visit Aegisub's forums"
+#~ msgstr "Visita els fòrums de l'Aegisub"
+
+#~ msgid "Below Normal (recommended)"
+#~ msgstr "Per sota del normal (recomanat)"
+
+#~ msgid "Lowest"
+#~ msgstr "El més baix"
+
+#~ msgid "Thread priority"
+#~ msgstr "Prioritat dels fils"
+
+#~ msgid "Force BT.601"
+#~ msgstr "Força BT.601"
 
 #~ msgid "Move up"
 #~ msgstr "Mou amunt"
@@ -6534,9 +6624,6 @@ msgstr ""
 
 #~ msgid "Select all"
 #~ msgstr "Selecciona-ho tot"
-
-#~ msgid "Select none"
-#~ msgstr "No seleccionis res"
 
 #~ msgid "All"
 #~ msgstr "Tot"
@@ -7320,9 +7407,6 @@ msgstr ""
 
 #~ msgid "Commit?"
 #~ msgstr "Aplicar?"
-
-#~ msgid "Save"
-#~ msgstr "Desa"
 
 #~ msgid "Save subtitles"
 #~ msgstr "Desa els subtítols"

--- a/po/make_pot.sh
+++ b/po/make_pot.sh
@@ -39,6 +39,12 @@ find ../automation -name *.lua \
   | sed 's/\\/\\\\\\\\/g' \
   | maybe_append
 
+find ../automation -name *.moon \
+  | xargs grep tr\"[^\"]\*\" -o -n \
+  | sed 's/\(.*\):\([0-9]\+\):tr\(".*"\)/\1|\2|\3/' \
+  | sed 's/\\/\\\\\\\\/g' \
+  | maybe_append
+
 for i in 'Name' 'GenericName' 'Comment' 'Keywords'
 do
   grep ^_$i -n ../packages/desktop/aegisub.desktop.template.in \


### PR DESCRIPTION
The POT file was not updated since 2014 and there have been several changes in localizable strings. I updated and made a pair of changes to code so it catches more localizable strings.

This PR includes:
* Modified `make_pot.sh` so it also includes `*.moon` files
* Modified `macro-2-mkfullwitdh.lua` so it uses `tr"<string>"` instead of `tr("<string>")` (otherwise, the script didn't catch those strings)
* Updated POT file (the result of running `make_pot.sh`)
* Updated the Catalan translation (the one I'm responsible for) using this generated POT.