### PR TITLE
Use target name without directory in $*_OBJ macro

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -112,7 +112,7 @@ POST_FLAGS = $($@_FLAGS) -c -o $@ $<
 # Libraries contain all object files they depend on (but they may depend on other files)
 # Not using libtool on OS X because it has an unsilenceable warning about a
 # compatibility issue with BSD 4.3 (wtf)
-lib%.a: $$($$*_OBJ)
+lib%.a: $$($$(*F)_OBJ)
 	@$(BIN_MKDIR_P) $(dir $@)
 	$(BIN_AR) cru $@ $(filter %.o,$^)
 	$(BIN_RANLIB) $@


### PR DESCRIPTION
The `$*` macro in https://github.com/Aegisub/Aegisub/blob/6f546951b4f004da16ce19ba638bf3eedefb9f31/Makefile.target#L115 will expand to `/build/aegisub/aegisub` for target `libaegisub.a`, and `$(/build/aegisub/aegisub_OBJ)` is not defined and expands to nothing. Instead, we want to get `aegisub_OBJ` here, so we should drop the directory part by using `$(*F)` instead. I'm not exactly sure how it worked in make<4.3, but it broke in make 4.3.

This fix is tested in both make 4.3 and 4.2.1 on ArchLinux. It is also tested on Travis CI which runs make 4.1 on Ubuntu 18.04.3.

Fix Aegisub/Aegisub#171