### PR TITLE
export multiple WAV chunks

### DIFF
--- a/src/libresrc/libresrc.cpp
+++ b/src/libresrc/libresrc.cpp
@@ -23,8 +23,8 @@
 wxBitmap libresrc_getimage(const unsigned char *buff, size_t size, double scale, int dir) {
 	wxMemoryInputStream mem(buff, size);
 	if (dir != wxLayout_RightToLeft)
-		return wxBitmap(wxImage(mem), -1, scale);
-	return wxBitmap(wxImage(mem).Mirror(), -1, scale);
+		return wxBitmap(wxImage(mem), -1);
+	return wxBitmap(wxImage(mem).Mirror(), -1);
 }
 
 wxIcon libresrc_geticon(const unsigned char *buff, size_t size) {


### PR DESCRIPTION
Hi,

I made this simple modification to export multiple audio chunks instead of a single one.
I dunno it's of any interest to you guys, but I figured I could create a PR.
Feel free to close it :)

I'm actually using this feature to make datasets for machine learning.

Cheers