### PR TITLE
po/de: Update German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3\n"
-"Report-Msgid-Bugs-To: erokawaii@yandex.ru\n"
-"POT-Creation-Date: 2013-07-17 02:17+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-07-01 10:53-0700\n"
 "PO-Revision-Date: 2013-07-17 22:15+0100\n"
 "Last-Translator: Shimapan <erokawaii@yandex.ru>\n"
 "Language-Team: Pantsu ga daisuki <erokawaii@yandex.ru>\n"
@@ -17,1742 +17,881 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../src/preferences_base.cpp:65
-msgid "Please choose the folder:"
-msgstr "Bitte wählen Sie den Ordner:"
+#: ../src/dialog_shift_times.cpp:92
+msgid "unsaved"
+msgstr "ungespeichert"
 
-#: ../src/preferences_base.cpp:211
-msgid "Browse..."
-msgstr "Durchsuchen..."
+#: ../src/dialog_shift_times.cpp:96
+#, c-format
+msgid "%s frames"
+msgstr "%s Frames"
 
-#: ../src/preferences_base.cpp:246
-msgid "Choose..."
-msgstr "Auswählen"
+#: ../src/dialog_shift_times.cpp:98
+msgid "backward"
+msgstr "früher"
 
-#: ../src/preferences_base.cpp:253 ../src/command/edit.cpp:407
-msgid "Font Face"
-msgstr "Schriftart"
+#: ../src/dialog_shift_times.cpp:98
+msgid "forward"
+msgstr "später"
 
-#: ../src/preferences_base.cpp:254
-msgid "Font Size"
-msgstr "Schriftgröße"
+#: ../src/dialog_shift_times.cpp:102
+msgid "s+e"
+msgstr "S+E"
 
-#: ../src/visual_tool_vector_clip.cpp:63 ../src/command/vis_tool.cpp:71
-#: ../src/command/vis_tool.cpp:72
-msgid "Drag"
-msgstr "Ziehen"
+#: ../src/dialog_shift_times.cpp:103
+msgid "s"
+msgstr "S"
 
-#: ../src/visual_tool_vector_clip.cpp:63
-msgid "Drag control points"
-msgstr "Ziehe Kontrollpunkte"
+#: ../src/dialog_shift_times.cpp:104
+msgid "e"
+msgstr "E"
 
-#: ../src/visual_tool_vector_clip.cpp:64
-msgid "Line"
-msgstr "Zeile"
+#: ../src/dialog_shift_times.cpp:111
+msgid "all"
+msgstr "Alle"
 
-#: ../src/visual_tool_vector_clip.cpp:64
-msgid "Appends a line"
-msgstr "Fügt eine Zeile hinzu"
+#: ../src/dialog_shift_times.cpp:113
+#, c-format
+msgid "from %d onward"
+msgstr "ab %d "
 
-#: ../src/visual_tool_vector_clip.cpp:65
-msgid "Bicubic"
-msgstr "Bikubisch"
+#: ../src/dialog_shift_times.cpp:115
+msgid "sel "
+msgstr "Ausw."
 
-#: ../src/visual_tool_vector_clip.cpp:65
-msgid "Appends a bezier bicubic curve"
-msgstr "Hängt eine bikubische Bezier-Kurve an"
+#: ../src/dialog_shift_times.cpp:133 ../src/command/time.cpp:153
+msgid "Shift Times"
+msgstr "Timings verschieben"
 
-#: ../src/visual_tool_vector_clip.cpp:67
-msgid "Convert"
-msgstr "Konvertieren"
+#: ../src/dialog_shift_times.cpp:142
+msgid "&Time: "
+msgstr "Zeit: "
 
-#: ../src/visual_tool_vector_clip.cpp:67
-msgid "Converts a segment between line and bicubic"
-msgstr "Konvertiert ein Segment zwischen Linie und bikubischer Kurve"
+#: ../src/dialog_shift_times.cpp:143
+msgid "Shift by time"
+msgstr "Um Zeitbetrag verschieben"
 
-#: ../src/visual_tool_vector_clip.cpp:68
-msgid "Insert"
-msgstr "Einfügen"
+#: ../src/dialog_shift_times.cpp:146
+msgid "&Frames: "
+msgstr "Frames: "
 
-#: ../src/visual_tool_vector_clip.cpp:68
-msgid "Inserts a control point"
-msgstr "Einen Kontrollpunkt hinzufügen"
+#: ../src/dialog_shift_times.cpp:147
+msgid "Shift by frames"
+msgstr "Um Frames verschieben"
 
-#: ../src/visual_tool_vector_clip.cpp:69
-msgid "Remove"
-msgstr "Entfernen"
+#: ../src/dialog_shift_times.cpp:151
+msgid "Enter time in h:mm:ss.cs notation"
+msgstr "Zeit als h:mm:ss.cs eingeben"
 
-#: ../src/visual_tool_vector_clip.cpp:69
-msgid "Removes a control point"
-msgstr "Einen Kontrollpunkt entfernen"
+#: ../src/dialog_shift_times.cpp:154
+msgid "Enter number of frames to shift by"
+msgstr "Anzahl der Frames eingeben, um die verschoben werden soll"
 
-#: ../src/visual_tool_vector_clip.cpp:71
-msgid "Freehand"
-msgstr "Freihand"
+#: ../src/dialog_shift_times.cpp:156
+msgid "For&ward"
+msgstr "Vorwärts"
 
-#: ../src/visual_tool_vector_clip.cpp:71
-msgid "Draws a freehand shape"
-msgstr "Zeichne eine Freihand-Form"
+#: ../src/dialog_shift_times.cpp:157
+msgid ""
+"Shifts subs forward, making them appear later. Use if they are appearing too "
+"soon."
+msgstr "Untertitel vorwärts verschieben, sodaß sie später angezeigt werden."
 
-#: ../src/visual_tool_vector_clip.cpp:72
-msgid "Freehand smooth"
-msgstr "Weiche Freihand-Kurve"
+#: ../src/dialog_shift_times.cpp:159
+msgid "&Backward"
+msgstr "Rückwärts"
 
-#: ../src/visual_tool_vector_clip.cpp:72
-msgid "Draws a smoothed freehand shape"
-msgstr "Zeichnet eine geglättete Freihand-Kurve"
+#: ../src/dialog_shift_times.cpp:160
+msgid ""
+"Shifts subs backward, making them appear earlier. Use if they are appearing "
+"too late."
+msgstr "Untertitel rückwärts verschieben, sodaß sie früher angezeigt werden."
 
-#: ../src/visual_tool_vector_clip.cpp:236
-msgid "delete control point"
-msgstr "Einen Kontrollpunkt entfernen"
+#: ../src/dialog_shift_times.cpp:162
+msgid "&All rows"
+msgstr "Alle Zeilen"
 
-#: ../src/subs_edit_ctrl.cpp:329
-msgid "Spell checker language"
-msgstr "Sprache für Rechtschreibprüfung"
+#: ../src/dialog_shift_times.cpp:162 ../src/dialog_search_replace.cpp:88
+msgid "Selected &rows"
+msgstr "Ausgewählte Zeilen"
 
-#: ../src/subs_edit_ctrl.cpp:338
-msgid "Cu&t"
-msgstr "&Ausschneiden"
+#: ../src/dialog_shift_times.cpp:162
+msgid "Selection &onward"
+msgstr "Auswahl"
 
-#: ../src/subs_edit_ctrl.cpp:339 ../src/dialog_style_manager.cpp:104
-#: ../src/timeedit_ctrl.cpp:212
+#: ../src/dialog_shift_times.cpp:163
+msgid "Affect"
+msgstr "Anwenden auf"
+
+#: ../src/dialog_shift_times.cpp:165
+msgid "Start a&nd End times"
+msgstr "Start- und Endzeiten"
+
+#: ../src/dialog_shift_times.cpp:165
+msgid "&Start times only"
+msgstr "Nur Anfangszeiten"
+
+#: ../src/dialog_shift_times.cpp:165
+msgid "&End times only"
+msgstr "Nur Endzeiten"
+
+#: ../src/dialog_shift_times.cpp:166
+msgid "Times"
+msgstr "Anzahl"
+
+#: ../src/dialog_shift_times.cpp:170
+msgid "&Clear"
+msgstr "Löschen"
+
+#: ../src/dialog_shift_times.cpp:201
+msgid "Shift by"
+msgstr "Verschieben um"
+
+#: ../src/dialog_shift_times.cpp:210
+msgid "Load from history"
+msgstr "Aus dem Verlauf laden"
+
+#: ../src/dialog_shift_times.cpp:405
+msgid "shifting"
+msgstr "verschieben"
+
+#: ../src/export_fixstyle.cpp:46
+msgid "Fix Styles"
+msgstr "Stile korrigieren"
+
+#: ../src/export_fixstyle.cpp:46
+msgid ""
+"Fixes styles by replacing any style that isn't available on file with "
+"Default."
+msgstr ""
+"Korrigiert Stil-Angaben, indem nicht vorhandene Stile durch \"Default\" "
+"ersetzt werden."
+
+#: ../src/audio_karaoke.cpp:72
+msgid "Discard all uncommitted splits"
+msgstr "Verwerfe alle nicht übernommenen Splits"
+
+#: ../src/audio_karaoke.cpp:76
+msgid "Commit splits"
+msgstr "Splits übernehmen"
+
+#: ../src/audio_karaoke.cpp:239
+msgid "Karaoke tag"
+msgstr "Karaoke-Tag"
+
+#: ../src/audio_karaoke.cpp:242
+msgid "Change karaoke tag to \\k"
+msgstr "Karaoke-Tag auf \\k ändern"
+
+#: ../src/audio_karaoke.cpp:243
+msgid "Change karaoke tag to \\kf"
+msgstr "Karaoke-Tag auf \\kf ändern"
+
+#: ../src/audio_karaoke.cpp:244
+msgid "Change karaoke tag to \\ko"
+msgstr "Karaoke-Tag auf \\ko ändern"
+
+#: ../src/audio_karaoke.cpp:418
+msgid "karaoke split"
+msgstr "Karaoke-Tag"
+
+#: ../src/timeedit_ctrl.cpp:208 ../src/dialog_style_manager.cpp:204
+#: ../src/subs_edit_ctrl.cpp:366
 msgid "&Copy"
 msgstr "&Kopieren"
 
-#: ../src/subs_edit_ctrl.cpp:340 ../src/timeedit_ctrl.cpp:213
+#: ../src/timeedit_ctrl.cpp:209 ../src/subs_edit_ctrl.cpp:367
 msgid "&Paste"
 msgstr "&Einfügen"
 
-#: ../src/subs_edit_ctrl.cpp:342 ../src/command/subtitle.cpp:393
-#: ../src/dialog_export.cpp:101 ../src/dialog_selected_choices.cpp:31
-msgid "Select &All"
-msgstr "Alles aus&wählen"
+#: ../src/auto4_base.cpp:460
+#, fuzzy, c-format
+msgid ""
+"Failed to load Automation script '%s':\n"
+"%s"
+msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
 
-#: ../src/subs_edit_ctrl.cpp:347 ../src/command/edit.cpp:983
-#: ../src/command/edit.cpp:984
-msgid "Split at cursor (preserve times)"
-msgstr "Bei Cursor auftrennen (Zeiten erhalten)"
-
-#: ../src/subs_edit_ctrl.cpp:348 ../src/command/edit.cpp:972
-#: ../src/command/edit.cpp:973
-msgid "Split at cursor (estimate times)"
-msgstr "Bei Cursor auftrennen (Zeiten annähern)"
-
-#: ../src/subs_edit_ctrl.cpp:358
+#: ../src/auto4_base.cpp:467
 #, c-format
-msgid "Remove \"%s\" from dictionary"
-msgstr "\"%s\" aus dem Wörterbuch entfernen"
-
-#: ../src/subs_edit_ctrl.cpp:363
-msgid "No spell checker suggestions"
-msgstr "Keine Rechtschreibprüfungsvorschläge"
-
-#: ../src/subs_edit_ctrl.cpp:369
-#, c-format
-msgid "Spell checker suggestions for \"%s\""
-msgstr "Rechtschreibprüfung: Vorschlag für \"%s\""
-
-#: ../src/subs_edit_ctrl.cpp:374
-msgid "No correction suggestions"
-msgstr "Kein Korrekturvorschlag"
-
-#: ../src/subs_edit_ctrl.cpp:380
-#, c-format
-msgid "Add \"%s\" to dictionary"
-msgstr "Füge \"%s\" zum Wörterbuch hinzu"
-
-#: ../src/subs_edit_ctrl.cpp:419
-#, c-format
-msgid "Thesaurus suggestions for \"%s\""
-msgstr "Thesaurus: Vorschlag für \"%s\""
-
-#: ../src/subs_edit_ctrl.cpp:422
-msgid "No thesaurus suggestions"
-msgstr "Keine Thesaurus-Vorschläge"
-
-#: ../src/subs_edit_ctrl.cpp:425
-msgid "Thesaurus language"
-msgstr "Thesaurus-Sprache"
-
-#: ../src/subs_edit_ctrl.cpp:434
-msgid "Disable"
-msgstr "Deaktivieren"
-
-#: ../src/subs_edit_box.cpp:108
-msgid "&Comment"
-msgstr "Kommentar"
-
-#: ../src/subs_edit_box.cpp:109
-msgid "Comment this line out. Commented lines don't show up on screen."
-msgstr ""
-"Diese Zeile auskommentieren. Auskommentierte Zeilen erscheinen nicht im "
-"Video."
-
-#: ../src/subs_edit_box.cpp:116
-msgid "Style for this line"
-msgstr "Stil für diese Zeile"
-
-#: ../src/subs_edit_box.cpp:118 ../src/dialog_paste_over.cpp:62
-#: ../src/base_grid.cpp:487 ../src/base_grid.cpp:769 ../src/base_grid.cpp:900
-#: ../src/dialog_search_replace.cpp:85
-msgid "Actor"
-msgstr "Sprecher"
-
-#: ../src/subs_edit_box.cpp:118
-msgid ""
-"Actor name for this speech. This is only for reference, and is mainly "
-"useless."
-msgstr ""
-"Sprechername für diese Zeile. Nur für Referenzzwecke, hat keinerlei "
-"sichtbare Auswirkungen."
-
-#: ../src/subs_edit_box.cpp:123 ../src/command/grid.cpp:147
-#: ../src/command/grid.cpp:160 ../src/dialog_paste_over.cpp:66
-#: ../src/base_grid.cpp:488 ../src/base_grid.cpp:770 ../src/base_grid.cpp:901
-#: ../src/dialog_search_replace.cpp:85
-msgid "Effect"
-msgstr "Effekt"
-
-#: ../src/subs_edit_box.cpp:123
-msgid ""
-"Effect for this line. This can be used to store extra information for "
-"karaoke scripts, or for the effects supported by the renderer."
-msgstr ""
-"Effekt für diese Zeile. Kann benutzt werden, um gesonderte Informationen für "
-"Karaokeskripte abzulegen, oder um vom Renderer unterstützte Effekte zu "
-"aktivieren."
-
-#: ../src/subs_edit_box.cpp:129
-msgid "Number of characters in the longest line of this subtitle."
-msgstr "Anzahl der Zeichen in der längsten Zeile dieses Untertitels."
-
-#: ../src/subs_edit_box.cpp:136
-msgid "Layer number"
-msgstr "Ebenennummer"
-
-#: ../src/subs_edit_box.cpp:140
-msgid "Start time"
-msgstr "Startzeit"
-
-#: ../src/subs_edit_box.cpp:141
-msgid "End time"
-msgstr "Endzeit"
-
-#: ../src/subs_edit_box.cpp:143
-msgid "Line duration"
-msgstr "Dauer der Zeile"
-
-#: ../src/subs_edit_box.cpp:146
-msgid "Left Margin (0 = default from style)"
-msgstr "Linker Rand (0 = Voreinstellung des Stils)"
-
-#: ../src/subs_edit_box.cpp:146
-msgid "left margin change"
-msgstr "Linken Rand ändern"
-
-#: ../src/subs_edit_box.cpp:147
-msgid "Right Margin (0 = default from style)"
-msgstr "Rechter Rand (0 = Voreinstellung des Stils)"
-
-#: ../src/subs_edit_box.cpp:147
-msgid "right margin change"
-msgstr "Rechten Rand ändern"
-
-#: ../src/subs_edit_box.cpp:148
-msgid "Vertical Margin (0 = default from style)"
-msgstr "Vertikaler Rand (0 = Voreinstellung des Stils)"
-
-#: ../src/subs_edit_box.cpp:148
-msgid "vertical margin change"
-msgstr "Vertikalen Rand ändern"
-
-#: ../src/subs_edit_box.cpp:167
-msgid "T&ime"
-msgstr "Zeit"
-
-#: ../src/subs_edit_box.cpp:167
-msgid "Time by h:mm:ss.cs"
-msgstr "Zeit als h:mm:ss.cs"
-
-#: ../src/subs_edit_box.cpp:168
-msgid "F&rame"
-msgstr "Frame"
-
-#: ../src/subs_edit_box.cpp:168
-msgid "Time by frame number"
-msgstr "Zeit als Framenummer"
-
-#: ../src/subs_edit_box.cpp:171
-msgid "Show Original"
-msgstr "Original anzeigen"
-
-#: ../src/subs_edit_box.cpp:172
-msgid ""
-"Show the contents of the subtitle line when it was first selected above the "
-"edit box. This is sometimes useful when editing subtitles or translating "
-"subtitles into another language."
-msgstr ""
-"Zeigt den Inhalt der Untertitel-Zeile an, als sie zuerst ausgewählt wurde. "
-"Dies kann hilfreich sein, wenn Untertitel bearbeitet werden oder in eine "
-"andere Sprache übersetzt werden."
-
-#: ../src/subs_edit_box.cpp:417
-msgid "modify text"
-msgstr "Text ändern"
-
-#: ../src/subs_edit_box.cpp:490
-msgid "modify times"
-msgstr "Zeiten ändern"
-
-#: ../src/subs_edit_box.cpp:551 ../src/dialog_style_editor.cpp:448
-msgid "style change"
-msgstr "Stil wechseln"
-
-#: ../src/subs_edit_box.cpp:556
-msgid "actor change"
-msgstr "Sprecher ändern"
-
-#: ../src/subs_edit_box.cpp:561
-msgid "layer change"
-msgstr "Ebene ändern"
-
-#: ../src/subs_edit_box.cpp:566
-msgid "effect change"
-msgstr "Effekt ändern"
-
-#: ../src/subs_edit_box.cpp:571
-msgid "comment change"
-msgstr "Kommentar ändern"
-
-#: ../src/dialog_text_import.cpp:49
-msgid "Text import options"
-msgstr "Textimportoptionen"
-
-#: ../src/dialog_text_import.cpp:59
-msgid "Actor separator:"
-msgstr "Sprecher-Trennzeichen:"
-
-#: ../src/dialog_text_import.cpp:61
-msgid "Comment starter:"
-msgstr "Kommentar-Starter:"
-
-#: ../src/dialog_text_import.cpp:66
-msgid "Include blank lines"
-msgstr "Einschließlich leerer Zeilen"
-
-#: ../src/preferences.cpp:93 ../src/preferences.cpp:94
-#: ../src/preferences.cpp:461 ../src/preferences.cpp:485
-msgid "General"
-msgstr "Allgemein"
-
-#: ../src/preferences.cpp:95
-msgid "Check for updates on startup"
-msgstr "Beim Start auf Updates prüfen"
-
-#: ../src/preferences.cpp:96
-msgid "Show main toolbar"
-msgstr "Zeige Werkzeugleiste"
-
-#: ../src/preferences.cpp:98
-msgid "Toolbar Icon Size"
-msgstr "Icongröße der Werkzeugleiste"
-
-#: ../src/preferences.cpp:99 ../src/preferences.cpp:179
-msgid "Never"
-msgstr "Nie"
-
-#: ../src/preferences.cpp:99 ../src/preferences.cpp:179
-msgid "Always"
-msgstr "Immer"
-
-#: ../src/preferences.cpp:99 ../src/preferences.cpp:179
-msgid "Ask"
-msgstr "Fragen"
-
-#: ../src/preferences.cpp:101
-msgid "Automatically load linked files"
-msgstr "Automatisch verknüpfte Dateien laden"
-
-#: ../src/preferences.cpp:102
-msgid "Undo Levels"
-msgstr "Maximale Rückgängig-Schritte"
-
-#: ../src/preferences.cpp:104
-msgid "Recently Used Lists"
-msgstr "Zuletzt verwendet"
-
-#: ../src/preferences.cpp:105 ../src/dialog_autosave.cpp:43
-msgid "Files"
-msgstr "Dateien"
-
-#: ../src/preferences.cpp:106
-msgid "Find/Replace"
-msgstr "Suchen/Ersetzen"
-
-#: ../src/preferences.cpp:112 ../src/preferences.cpp:497
-msgid "Audio"
-msgstr "Audio"
-
-#: ../src/preferences.cpp:113 ../src/preferences.cpp:151
-#: ../src/command/app.cpp:232 ../src/dialog_timing_processor.cpp:132
-#: ../src/dialog_properties.cpp:97
-msgid "Options"
-msgstr "Optionen"
-
-#: ../src/preferences.cpp:114
-msgid "Default mouse wheel to zoom"
-msgstr "Standard-Mausrad zum Zoomen"
-
-#: ../src/preferences.cpp:115
-msgid "Lock scroll on cursor"
-msgstr "Scrollen auf Cursor festsetzen"
-
-#: ../src/preferences.cpp:116
-msgid "Snap markers by default"
-msgstr "Standardmäßig bei Markierungen einrasten"
-
-#: ../src/preferences.cpp:117
-msgid "Auto-focus on mouse over"
-msgstr "Auto-Fokus, wenn der Mauszeiger darüber ist"
-
-#: ../src/preferences.cpp:118
-msgid "Play audio when stepping in video"
-msgstr "Audio abspielem im Video-Suchlauf"
-
-#: ../src/preferences.cpp:119
-msgid "Left-click-drag moves end marker"
-msgstr "Linke Maustaste halten und ziehen bewegt die Endmarkierung"
-
-#: ../src/preferences.cpp:120
-msgid "Default timing length (ms)"
-msgstr "Standard Timing-Länge (ms)"
-
-#: ../src/preferences.cpp:121
-msgid "Default lead-in length (ms)"
-msgstr "Standard Einlaufbereich-Länge (ms)"
-
-#: ../src/preferences.cpp:122
-msgid "Default lead-out length (ms)"
-msgstr "Standard Auslaufbereich-Länge (ms)"
-
-#: ../src/preferences.cpp:124
-msgid "Marker drag-start sensitivity (px)"
-msgstr "Markierung: Start-Bewegungsempfindlichkeit (px)"
-
-#: ../src/preferences.cpp:125
-msgid "Line boundary thickness (px)"
-msgstr "Liniendicke (px)"
-
-#: ../src/preferences.cpp:126
-msgid "Maximum snap distance (px)"
-msgstr "Max. Einrastdistanz (px)"
-
-#: ../src/preferences.cpp:128
-msgid "Don't show"
-msgstr "Nicht anzeigen"
-
-#: ../src/preferences.cpp:128
-msgid "Show previous"
-msgstr "Vorherige anzeigen"
-
-#: ../src/preferences.cpp:128
-msgid "Show previous and next"
-msgstr "Vorherige und nächste anzeigen"
-
-#: ../src/preferences.cpp:128
-msgid "Show all"
-msgstr "Alle anzeigen"
-
-#: ../src/preferences.cpp:130
-msgid "Show inactive lines"
-msgstr "Zeige inaktive Zeilen"
-
-#: ../src/preferences.cpp:132
-msgid "Include commented inactive lines"
-msgstr "Zeige inaktive Kommentar-Zeilen"
-
-#: ../src/preferences.cpp:134
-msgid "Display Visual Options"
-msgstr "Zeige visuelle Optionen"
-
-#: ../src/preferences.cpp:135
-msgid "Keyframes in dialogue mode"
-msgstr "Keyframes im Dialog-Modus"
-
-#: ../src/preferences.cpp:136
-msgid "Keyframes in karaoke mode"
-msgstr "Keyframes im Karaoke-Modus"
-
-#: ../src/preferences.cpp:137
-msgid "Cursor time"
-msgstr "Cursorzeit"
-
-#: ../src/preferences.cpp:138
-msgid "Video position"
-msgstr "Videoposition"
-
-#: ../src/preferences.cpp:139 ../src/preferences.cpp:220
-msgid "Seconds boundaries"
-msgstr "Sekundengrenze"
-
-#: ../src/preferences.cpp:141
-msgid "Waveform Style"
-msgstr "Wellenformansicht"
-
-#: ../src/preferences.cpp:143
-msgid "Audio labels"
-msgstr "Audio-Positionsmarke"
-
-#: ../src/preferences.cpp:150 ../src/preferences.cpp:560
-#: ../src/dialog_video_details.cpp:71
-msgid "Video"
-msgstr "Video"
-
-#: ../src/preferences.cpp:152
-msgid "Show keyframes in slider"
-msgstr "Zeige Keyframes in der Zeitleiste"
-
-#: ../src/preferences.cpp:154
-msgid "Only show visual tools when mouse is over video"
-msgstr ""
-"Nur visuelle Werkzeuge zeigen, wenn die Maus sich über dem Video befindet"
-
-#: ../src/preferences.cpp:156
-msgid "Seek video to line start on selection change"
-msgstr "Springe im Video zum Anfang der ausgewählten Zeile"
-
-#: ../src/preferences.cpp:158
-msgid "Automatically open audio when opening video"
-msgstr "Automatisch die Audiospur öffnen, wenn das Video geöffnet wird"
-
-#: ../src/preferences.cpp:163
-msgid "Default Zoom"
-msgstr "Standardzoom"
-
-#: ../src/preferences.cpp:165
-msgid "Fast jump step in frames"
-msgstr "Schnellsprung-Schritt in Frames"
-
-#: ../src/preferences.cpp:169
-msgid "Screenshot save path"
-msgstr "Screenshot-Ordner"
-
-#: ../src/preferences.cpp:171
-msgid "Script Resolution"
-msgstr "Skriptauflösung"
-
-#: ../src/preferences.cpp:172
-msgid "Use resolution of first video opened"
-msgstr "Nutze die Auflösung des zuerst geöffneten Videos"
-
-#: ../src/preferences.cpp:175
-msgid "Default width"
-msgstr "Standardbreite"
-
-#: ../src/preferences.cpp:177
-msgid "Default height"
-msgstr "Standardhöhe"
-
-#: ../src/preferences.cpp:181
-msgid "Match video resolution on open"
-msgstr "Videoauflösung beim Öffnen abgleichen"
-
-#: ../src/preferences.cpp:187
-msgid "Interface"
-msgstr "Oberfläche"
-
-#: ../src/preferences.cpp:188
-msgid "Edit Box"
-msgstr "Bearbeitungsbox"
-
-#: ../src/preferences.cpp:189
-msgid "Enable call tips"
-msgstr "Aktiviere Infotexte"
-
-#: ../src/preferences.cpp:190
-msgid "Overwrite in time boxes"
-msgstr "Überschreibendes Einfügen in der Zeit-Box"
-
-#: ../src/preferences.cpp:192
-msgid "Enable syntax highlighting"
-msgstr "Aktiviere Syntaxhervorhebung"
-
-#: ../src/preferences.cpp:193
-msgid "Dictionaries path"
-msgstr "Wörterbuch-Ordner"
-
-#: ../src/preferences.cpp:195
-msgid "Maximum characters per line"
-msgstr "Maximale Zeichen pro Zeile"
-
-#: ../src/preferences.cpp:197
-msgid "Grid"
-msgstr "Untertitel-Gitter"
-
-#: ../src/preferences.cpp:198
-msgid "Allow grid to take focus"
-msgstr "Gitter darf Fokus annehmen"
-
-#: ../src/preferences.cpp:199
-msgid "Highlight visible subtitles"
-msgstr "Hebe sichtbare Untertitel hervor"
-
-#: ../src/preferences.cpp:200
-msgid "Hide overrides symbol"
-msgstr "Symbol für nicht angezeigte Tags"
-
-#: ../src/preferences.cpp:207 ../src/dialog_style_editor.cpp:177
-msgid "Colors"
-msgstr "Farben"
-
-#: ../src/preferences.cpp:214
-msgid "Audio Display"
-msgstr "Audio-Anzeige"
-
-#: ../src/preferences.cpp:215
-msgid "Play cursor"
-msgstr "Wiedergabezeiger"
-
-#: ../src/preferences.cpp:216
-msgid "Line boundary start"
-msgstr "Zeilengrenze (Start)"
-
-#: ../src/preferences.cpp:217
-msgid "Line boundary end"
-msgstr "Zeilengrenze (Ende)"
-
-#: ../src/preferences.cpp:218
-msgid "Line boundary inactive line"
-msgstr "Zeilengrenze (inaktiv)"
-
-#: ../src/preferences.cpp:219
-msgid "Syllable boundaries"
-msgstr "Silbengrenze"
-
-#: ../src/preferences.cpp:222
-msgid "Syntax Highlighting"
-msgstr "Syntaxhervorhebung"
-
-#: ../src/preferences.cpp:223 ../src/preferences.cpp:471
-msgid "Normal"
-msgstr "Normal"
-
-#: ../src/preferences.cpp:224
-msgid "Brackets"
-msgstr "Geschweifte Klammern"
-
-#: ../src/preferences.cpp:225
-msgid "Slashes and Parentheses"
-msgstr "Schrägstriche und runde Klammern"
-
-#: ../src/preferences.cpp:226
-msgid "Tags"
-msgstr "Tags"
-
-#: ../src/preferences.cpp:227
-msgid "Parameters"
-msgstr "Parameter"
-
-#: ../src/preferences.cpp:228 ../src/dialog_kara_timing_copy.cpp:706
-#: ../src/dialog_kara_timing_copy.cpp:708
-#: ../src/dialog_kara_timing_copy.cpp:753
-#: ../src/dialog_fonts_collector.cpp:268 ../src/dialog_fonts_collector.cpp:273
-#: ../src/dialog_fonts_collector.cpp:278
-msgid "Error"
-msgstr "Fehler"
-
-#: ../src/preferences.cpp:229
-msgid "Error Background"
-msgstr "Fehlermarkierung"
-
-#: ../src/preferences.cpp:230
-msgid "Line Break"
-msgstr "Zeilenumbruch"
-
-#: ../src/preferences.cpp:231
-msgid "Karaoke templates"
-msgstr "Karaoke-Vorlage"
-
-#: ../src/preferences.cpp:237
-msgid "Audio Color Schemes"
-msgstr "Audio-Farbschema"
-
-#: ../src/preferences.cpp:239 ../src/preferences.cpp:514
-msgid "Spectrum"
-msgstr "Spektrum"
-
-#: ../src/preferences.cpp:240
-msgid "Waveform"
-msgstr "Wellenform"
-
-#: ../src/preferences.cpp:242
-msgid "Subtitle Grid"
-msgstr "Untertitel-Gitter"
-
-#: ../src/preferences.cpp:243
-msgid "Standard foreground"
-msgstr "Textfarbe"
-
-#: ../src/preferences.cpp:244
-msgid "Standard background"
-msgstr "Hintergrundfarbe"
-
-#: ../src/preferences.cpp:245
-msgid "Selection foreground"
-msgstr "Textfarbe (Auswahl)"
-
-#: ../src/preferences.cpp:246
-msgid "Selection background"
-msgstr "Hintergrundfarbe (Auswahl)"
-
-#: ../src/preferences.cpp:247
-msgid "Collision foreground"
-msgstr "Vordergrundkollision"
-
-#: ../src/preferences.cpp:248
-msgid "In frame background"
-msgstr "Frame-Hintergrund"
-
-#: ../src/preferences.cpp:249
-msgid "Comment background"
-msgstr "Kommentar-Hintergrundfarbe"
-
-#: ../src/preferences.cpp:250
-msgid "Selected comment background"
-msgstr "Kommentar-Hintergrundfarbe (Auswahl)"
-
-#: ../src/preferences.cpp:251
-msgid "Header background"
-msgstr "Kopfleiste-Hintergrundfarbe"
-
-#: ../src/preferences.cpp:252
-msgid "Left Column"
-msgstr "Linke Spalte"
-
-#: ../src/preferences.cpp:253
-msgid "Active Line Border"
-msgstr "Aktiver Zeilenrahmen"
-
-#: ../src/preferences.cpp:254
-msgid "Lines"
-msgstr "Zeilen"
-
-#: ../src/preferences.cpp:378
-msgid "Hotkeys"
-msgstr "Hotkeys"
-
-#: ../src/preferences.cpp:382 ../src/dialog_style_manager.cpp:102
-msgid "&New"
-msgstr "&Neu"
-
-#: ../src/preferences.cpp:383 ../src/dialog_style_manager.cpp:103
-msgid "&Edit"
-msgstr "&Bearbeiten"
-
-#: ../src/preferences.cpp:384 ../src/dialog_style_manager.cpp:105
-#: ../src/dialog_attachments.cpp:67
-msgid "&Delete"
-msgstr "&Löschen"
-
-#: ../src/preferences.cpp:442
-msgid "Backup"
-msgstr "Backup"
-
-#: ../src/preferences.cpp:443
-msgid "Automatic Save"
-msgstr "Automatisch speichern"
-
-#: ../src/preferences.cpp:444 ../src/preferences.cpp:452
-msgid "Enable"
-msgstr "Aktivieren"
-
-#: ../src/preferences.cpp:447
-msgid "Interval in seconds"
-msgstr "Intervall in Sekunden"
-
-#: ../src/preferences.cpp:448 ../src/preferences.cpp:454
-#: ../src/preferences.cpp:511
-msgid "Path"
-msgstr "Pfad"
-
-#: ../src/preferences.cpp:449
-msgid "Autosave after every change"
-msgstr "Automatisch bei jeder Änderung speichern"
-
-#: ../src/preferences.cpp:451
-msgid "Automatic Backup"
-msgstr "Automatisches Backup"
-
-#: ../src/preferences.cpp:460 ../src/command/automation.cpp:87
-#: ../src/command/automation.cpp:98
-msgid "Automation"
-msgstr "Automatisierung"
-
-#: ../src/preferences.cpp:463
-msgid "Base path"
-msgstr "Basisordner"
-
-#: ../src/preferences.cpp:464
-msgid "Include path"
-msgstr "Include-Ordner"
-
-#: ../src/preferences.cpp:465
-msgid "Auto-load path"
-msgstr "Auto-Load-Ordner"
-
-#: ../src/preferences.cpp:467
-msgid "0: Fatal"
-msgstr "0: Fatal"
-
-#: ../src/preferences.cpp:467
-msgid "1: Error"
-msgstr "1: Fehler"
-
-#: ../src/preferences.cpp:467
-msgid "2: Warning"
-msgstr "2: Warnung"
-
-#: ../src/preferences.cpp:467
-msgid "3: Hint"
-msgstr "3: Hinweis"
-
-#: ../src/preferences.cpp:467
-msgid "4: Debug"
-msgstr "4: Debug"
-
-#: ../src/preferences.cpp:467
-msgid "5: Trace"
-msgstr "5: Trace"
-
-#: ../src/preferences.cpp:469
-msgid "Trace level"
-msgstr "Trace-Level"
-
-#: ../src/preferences.cpp:471
-msgid "Below Normal (recommended)"
-msgstr "Unterhalb Normal (empfohlen)"
-
-#: ../src/preferences.cpp:471
-msgid "Lowest"
-msgstr "Niedrigste"
-
-#: ../src/preferences.cpp:473
-msgid "Thread priority"
-msgstr "Threadpriorität"
-
-#: ../src/preferences.cpp:475
-msgid "No scripts"
-msgstr "Keine Skripte"
-
-#: ../src/preferences.cpp:475
-msgid "Subtitle-local scripts"
-msgstr "Zu Untertiteln zugehörige Skripte"
-
-#: ../src/preferences.cpp:475
-msgid "Global autoload scripts"
-msgstr "Globale, automatisch geladene Skripte"
-
-#: ../src/preferences.cpp:475
-msgid "All scripts"
-msgstr "Alle Skripte"
-
-#: ../src/preferences.cpp:477
-msgid "Autoreload on Export"
-msgstr "Automatisch beim Export neu laden"
-
-#: ../src/preferences.cpp:484
-msgid "Advanced"
-msgstr "Erweitert"
-
-#: ../src/preferences.cpp:487
-msgid ""
-"Changing these settings might result in bugs and/or crashes.  Do not touch "
-"these unless you know what you're doing."
-msgstr ""
-"Wenn Sie diese Einstellungen ändern, könnte das zu Bugs und/oder Abstürzen "
-"führen. Ändern Sie nur etwas, wenn Sie wissen, was Sie tun."
-
-#: ../src/preferences.cpp:498 ../src/preferences.cpp:561
-msgid "Expert"
-msgstr "Experte"
-
-#: ../src/preferences.cpp:501
-msgid "Audio provider"
-msgstr "Audio-Provider"
-
-#: ../src/preferences.cpp:504
-msgid "Audio player"
-msgstr "Audio-Abspieler"
-
-#: ../src/preferences.cpp:506
-msgid "Cache"
-msgstr "Cache"
-
-#: ../src/preferences.cpp:507
-msgid "None (NOT RECOMMENDED)"
-msgstr "Keine (Nicht empfohlen)"
-
-#: ../src/preferences.cpp:507
-msgid "RAM"
-msgstr "Ram"
-
-#: ../src/preferences.cpp:507
-msgid "Hard Disk"
-msgstr "Festplatte"
-
-#: ../src/preferences.cpp:509
-msgid "Cache type"
-msgstr "Cache-Methode"
-
-#: ../src/preferences.cpp:512
-msgid "File name"
-msgstr "Dateiname"
-
-#: ../src/preferences.cpp:516
-msgid "Regular quality"
-msgstr "Normale Qualität"
-
-#: ../src/preferences.cpp:516
-msgid "Better quality"
-msgstr "Bessere Qualität"
-
-#: ../src/preferences.cpp:516
-msgid "High quality"
-msgstr "Hohe Qualität"
-
-#: ../src/preferences.cpp:516
-msgid "Insane quality"
-msgstr "Kranke Qualität"
-
-#: ../src/preferences.cpp:518
-msgid "Quality"
-msgstr "Qualität"
-
-#: ../src/preferences.cpp:520
-msgid "Cache memory max (MB)"
-msgstr "Maximale Cachegröße im Arbeitsspeicher (MB)"
-
-#: ../src/preferences.cpp:526
-msgid "Avisynth down-mixer"
-msgstr "Avisynth-Downmixer"
-
-#: ../src/preferences.cpp:527
-msgid "Force sample rate"
-msgstr "Erzwinge Samplerate"
-
-#: ../src/preferences.cpp:533
-msgid "Ignore"
-msgstr "Ignorieren"
-
-#: ../src/preferences.cpp:533 ../src/command/edit.cpp:1059
-#: ../src/command/edit.cpp:1060
-msgid "Clear"
-msgstr "Löschen"
-
-#: ../src/preferences.cpp:533 ../src/command/audio.cpp:294
-msgid "Stop"
-msgstr "Anhalten"
-
-#: ../src/preferences.cpp:533
-msgid "Abort"
-msgstr "Abbruch"
-
-#: ../src/preferences.cpp:535
-msgid "Audio indexing error handling mode"
-msgstr "Audio-Indexfehler-Handhabungsmodus"
-
-#: ../src/preferences.cpp:537
-msgid "Always index all audio tracks"
-msgstr "Immer alle Tonspuren indexieren"
-
-#: ../src/preferences.cpp:542
-msgid "Portaudio device"
-msgstr "Portaudio-Gerät"
-
-#: ../src/preferences.cpp:547
-msgid "OSS Device"
-msgstr "Oss-Gerät"
-
-#: ../src/preferences.cpp:552
-msgid "Buffer latency"
-msgstr "Pufferlatenz"
-
-#: ../src/preferences.cpp:553
-msgid "Buffer length"
-msgstr "Pufferlänge"
-
-#: ../src/preferences.cpp:564
-msgid "Video provider"
-msgstr "Video-Provider"
-
-#: ../src/preferences.cpp:567
-msgid "Subtitles provider"
-msgstr "Untertitel-Provider"
-
-#: ../src/preferences.cpp:570
-msgid "Force BT.601"
-msgstr "Erzwinge BT.601"
-
-#: ../src/preferences.cpp:574
-msgid "Allow pre-2.56a Avisynth"
-msgstr "Erlaube pre-2.56a-Avisynth"
-
-#: ../src/preferences.cpp:576
-msgid "Avisynth memory limit"
-msgstr "Avisynth-Arbeitsspeicherlimit"
-
-#: ../src/preferences.cpp:584
-msgid "Debug log verbosity"
-msgstr "Debuglog-Detailliertheit"
-
-#: ../src/preferences.cpp:586
-msgid "Decoding threads"
-msgstr "Decoder-Threads"
-
-#: ../src/preferences.cpp:587
-msgid "Enable unsafe seeking"
-msgstr "Aktiviere unsicheres Suchen"
-
-#: ../src/preferences.cpp:628
-msgid ""
-"Are you sure that you want to restore the defaults? All your settings will "
-"be overridden."
-msgstr ""
-"Wollen Sie wirklich die Standardeinstellungen wiederherstellen? Alle Ihre "
-"Einstellungen gehen verloren."
-
-#: ../src/preferences.cpp:628
-msgid "Restore defaults?"
-msgstr "Standardeinstellungen wiederherstellen?"
-
-#: ../src/preferences.cpp:650
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: ../src/preferences.cpp:675
-msgid "&Restore Defaults"
-msgstr "Standardeinstellungen wiederherstellen"
-
-#: ../src/search_replace_engine.cpp:249 ../src/search_replace_engine.cpp:338
+msgid "The file was not recognised as an Automation script: %s"
+msgstr "Die Datei wurde nicht als Automatisierungsskript erkannt: %s"
+
+#: ../src/auto4_base.cpp:496 ../src/command/timecode.cpp:74
+#: ../src/command/timecode.cpp:94 ../src/command/video.cpp:568
+#: ../src/command/audio.cpp:84 ../src/command/keyframe.cpp:74
+msgid "All Files"
+msgstr "Alle Dateien"
+
+#: ../src/auto4_base.cpp:502 ../src/command/timecode.cpp:74
+#: ../src/command/timecode.cpp:94 ../src/command/keyframe.cpp:74
+#: ../src/subtitle_format.cpp:312
+msgid "All Supported Formats"
+msgstr "Alle unterstützten Formate"
+
+#: ../src/auto4_base.cpp:508
+msgid "File was not recognized as a script"
+msgstr "Die Datei wurde nicht als Skript erkannt"
+
+#: ../src/search_replace_engine.cpp:247 ../src/search_replace_engine.cpp:331
 msgid "replace"
 msgstr "Ersetzen"
 
-#: ../src/search_replace_engine.cpp:339
-#, c-format
-msgid "%i matches were replaced."
-msgstr "%i Vorkommen ersetzt."
+#: ../src/search_replace_engine.cpp:332
+#, fuzzy, c-format
+msgid "One match was replaced."
+msgid_plural "%d matches were replaced."
+msgstr[0] "%i Vorkommen ersetzt."
+msgstr[1] "%i Vorkommen ersetzt."
 
-#: ../src/search_replace_engine.cpp:342
+#: ../src/search_replace_engine.cpp:335
 msgid "No matches found."
 msgstr "Keine Vorkommen gefunden."
 
-#: ../src/dialog_about.cpp:50 ../src/command/app.cpp:72
-msgid "About Aegisub"
-msgstr "Über Aegisub"
+#: ../src/visual_tool_drag.cpp:56
+msgid "Toggle between \\move and \\pos"
+msgstr "Wechsle zwischen \\move und \\pos"
 
-#: ../src/dialog_about.cpp:87
-msgid "Translated into LANGUAGE by PERSON\n"
-msgstr "Ins Deutsche übersetzt von Shimapan\n"
+#: ../src/visual_tool_drag.cpp:326 ../src/visual_tool_cross.cpp:62
+msgid "positioning"
+msgstr "Positionierung"
 
-#: ../src/dialog_about.cpp:128
-msgid ""
-"\n"
-"See the help file for full credits.\n"
-msgstr ""
-"\n"
-"Siehe Hilfedatei für vollständige Credits.\n"
+#: ../src/font_file_lister_fontconfig.cpp:80
+msgid "Updating font cache\n"
+msgstr "Aktualisiere Schriftartencache\n"
 
-#: ../src/dialog_about.cpp:129
+#: ../src/subtitle_format_ebu3264.cpp:408
 #, c-format
-msgid "Built by %s on %s."
-msgstr "Kompiliert von %s am %s."
+msgid "Line over maximum length: %s"
+msgstr "Zeile länger als die max. Länge: %s"
 
-#: ../src/command/app.cpp:70
-msgid "&About"
-msgstr "&Über..."
+#: ../src/dialog_video_details.cpp:44
+msgid "Video Details"
+msgstr "Videodetails:"
 
-#: ../src/command/app.cpp:71
-msgid "About"
-msgstr "Über..."
+#: ../src/dialog_video_details.cpp:58
+msgid "File name:"
+msgstr "Dateiname:"
 
-#: ../src/command/app.cpp:83
-msgid "&Audio+Subs View"
-msgstr "Audio+Untertitel anzeigen"
+#: ../src/dialog_video_details.cpp:59
+msgid "FPS:"
+msgstr "fps:"
 
-#: ../src/command/app.cpp:84
-msgid "Audio+Subs View"
-msgstr "Audio+Untertitel anzeigen"
+#: ../src/dialog_video_details.cpp:60
+msgid "Resolution:"
+msgstr "Auflösung:"
 
-#: ../src/command/app.cpp:85
-msgid "Display audio and subtitles only"
-msgstr "Zeigt Untertitel und Audiofenster an"
+#: ../src/dialog_video_details.cpp:61
+msgid "Length:"
+msgstr "Länge:"
 
-#: ../src/command/app.cpp:105
-msgid "&Full view"
-msgstr "Volle Ansicht"
+#: ../src/dialog_video_details.cpp:61
+#, fuzzy, c-format
+msgid "1 frame"
+msgid_plural "%d frames (%s)"
+msgstr[0] "%s Frames"
+msgstr[1] "%s Frames"
 
-#: ../src/command/app.cpp:106
-msgid "Full view"
-msgstr "Volle Ansicht"
+#: ../src/dialog_video_details.cpp:63
+msgid "Decoder:"
+msgstr "Dekodierer:"
 
-#: ../src/command/app.cpp:107
-msgid "Display audio, video and subtitles"
-msgstr "Zeigt Audio, Video und Untertitel an"
+#: ../src/dialog_video_details.cpp:65 ../src/preferences.cpp:165
+#: ../src/preferences.cpp:417
+msgid "Video"
+msgstr "Video"
 
-#: ../src/command/app.cpp:127
-msgid "S&ubs Only View"
-msgstr "Nur Untertitel anzeigen"
+#: ../src/dialog_timing_processor.cpp:139 ../src/command/tool.cpp:189
+msgid "Timing Post-Processor"
+msgstr "Timingnachbearbeitung"
 
-#: ../src/command/app.cpp:128
-msgid "Subs Only View"
-msgstr "Nur Untertitel anzeigen"
+#: ../src/dialog_timing_processor.cpp:157
+msgid "Apply to styles"
+msgstr "Auf alle Stile anwenden"
 
-#: ../src/command/app.cpp:129
-msgid "Display subtitles only"
-msgstr "Zeigt nur die Untertitel an"
+#: ../src/dialog_timing_processor.cpp:159
+msgid "Select styles to process. Unchecked ones will be ignored."
+msgstr ""
+"Die zu bearbeitenden Stile auswählen. Nicht ausgewählte Stile werden nicht "
+"angetastet."
 
-#: ../src/command/app.cpp:145
-msgid "&Video+Subs View"
-msgstr "Video+Untertitel anzeigen"
+#: ../src/dialog_timing_processor.cpp:161 ../src/dialog_paste_over.cpp:88
+msgid "&All"
+msgstr "Alle"
 
-#: ../src/command/app.cpp:146
-msgid "Video+Subs View"
-msgstr "Video+Untertitel"
+#: ../src/dialog_timing_processor.cpp:162
+msgid "Select all styles"
+msgstr "Wählt alle Stile aus"
 
-#: ../src/command/app.cpp:147
-msgid "Display video and subtitles only"
-msgstr "Zeigt nur Untertitel und Videofenster an"
+#: ../src/dialog_timing_processor.cpp:164 ../src/dialog_paste_over.cpp:90
+msgid "&None"
+msgstr "Keine"
 
-#: ../src/command/app.cpp:167
-msgid "E&xit"
-msgstr "&Beenden"
+#: ../src/dialog_timing_processor.cpp:165
+msgid "Deselect all styles"
+msgstr "Hebt die Stilauswahl auf"
 
-#: ../src/command/app.cpp:168
-msgid "Exit"
-msgstr "Beenden"
+#: ../src/dialog_timing_processor.cpp:168 ../src/command/app.cpp:207
+#: ../src/dialog_properties.cpp:138 ../src/preferences.cpp:127
+#: ../src/preferences.cpp:167
+msgid "Options"
+msgstr "Optionen"
 
-#: ../src/command/app.cpp:169
-msgid "Exit the application"
-msgstr "Beendet Aegisub"
+#: ../src/dialog_timing_processor.cpp:169
+msgid "Affect &selection only"
+msgstr "Auf Auswahl beschränken"
 
-#: ../src/command/app.cpp:180
-msgid "&Language..."
-msgstr "&Sprache... (Language)"
+#: ../src/dialog_timing_processor.cpp:174
+msgid "Lead-in/Lead-out"
+msgstr "Einlaufbereiche/Auslaufbereiche"
 
-#: ../src/command/app.cpp:181
-msgid "Language"
-msgstr "Sprache"
+#: ../src/dialog_timing_processor.cpp:176
+msgid "Add lead &in:"
+msgstr "Einlaufbereich hinzufügen:"
 
-#: ../src/command/app.cpp:182
-msgid "Select Aegisub interface language"
-msgstr "Sprache für Aegisub auswählen"
+#: ../src/dialog_timing_processor.cpp:178
+msgid "Enable adding of lead-ins to lines"
+msgstr "Den Zeilen Einlaufbereiche hinzufügen"
 
-#: ../src/command/app.cpp:205
-msgid "&Log window"
-msgstr "Logbuchfenster"
+#: ../src/dialog_timing_processor.cpp:179
+msgid "Lead in to be added, in milliseconds"
+msgstr "Hinzuzufügende Einlaufbereiche in ms"
 
-#: ../src/command/app.cpp:206 ../src/dialog_log.cpp:99
-msgid "Log window"
-msgstr "Logbuchfenster"
+#: ../src/dialog_timing_processor.cpp:181
+msgid "Add lead &out:"
+msgstr "Auslaufbereiche hinzufügen:"
 
-#: ../src/command/app.cpp:207
-msgid "View the event log"
-msgstr "Zeige das Ereignisprotokoll"
+#: ../src/dialog_timing_processor.cpp:183
+msgid "Enable adding of lead-outs to lines"
+msgstr "Den Zeilen Auslaufbereiche hinzufügen"
 
-#: ../src/command/app.cpp:218
-msgid "New &Window"
-msgstr "Neues Fenster"
+#: ../src/dialog_timing_processor.cpp:184
+msgid "Lead out to be added, in milliseconds"
+msgstr "Hinzuzufügende Auslaufbereich in ms"
 
-#: ../src/command/app.cpp:219
-msgid "New Window"
-msgstr "Neues Fenster"
+#: ../src/dialog_timing_processor.cpp:189
+msgid "Make adjacent subtitles continuous"
+msgstr "Die angrenzenden Untertitel kontinuierlich machen"
 
-#: ../src/command/app.cpp:220
-msgid "Open a new application window"
-msgstr "Öffne ein neues Programmfenster"
+#: ../src/dialog_timing_processor.cpp:190
+msgid "&Enable"
+msgstr "Aktivieren"
 
-#: ../src/command/app.cpp:231
-msgid "&Options..."
-msgstr "Einstellungen"
+#: ../src/dialog_timing_processor.cpp:192
+msgid ""
+"Enable snapping of subtitles together if they are within a certain distance "
+"of each other"
+msgstr ""
+"Untertitel, die weniger als einen bestimmten Abstand voneinander haben, "
+"durchgängig machen"
 
-#: ../src/command/app.cpp:233
-msgid "Configure Aegisub"
-msgstr "Aegisub einrichten"
+#: ../src/dialog_timing_processor.cpp:195
+msgid "Max gap:"
+msgstr "Max. Lücke:"
 
-#: ../src/command/app.cpp:247 ../src/command/app.cpp:248
-#: ../src/command/app.cpp:249
-msgid "Toggle global hotkey overrides"
-msgstr "Globale Hotkeys umschalten"
+#: ../src/dialog_timing_processor.cpp:196
+msgid ""
+"Maximum difference between start and end time for two subtitles to be made "
+"continuous, in milliseconds"
+msgstr ""
+"Maximaler Abstand zwischen Untertiteln, die zusammenhängend gemacht werden "
+"(in ms)"
 
-#: ../src/command/app.cpp:265
-msgid "Toggle the main toolbar"
-msgstr "Hauptwerkzeugleiste ein/aus"
+#: ../src/dialog_timing_processor.cpp:197
+msgid "Max overlap:"
+msgstr "Max. Überlappung:"
 
-#: ../src/command/app.cpp:270
-msgid "Hide Toolbar"
-msgstr "Werkzeugleiste ausblenden"
+#: ../src/dialog_timing_processor.cpp:198
+msgid ""
+"Maximum overlap between the end and start time for two subtitles to be made "
+"continuous, in milliseconds"
+msgstr ""
+"Maximale Überlappung zwischen Untertiteln, die zusammenhängend gemacht "
+"werden (in ms)"
 
-#: ../src/command/app.cpp:271
-msgid "Show Toolbar"
-msgstr "Werkzeugleiste einblenden"
+#: ../src/dialog_timing_processor.cpp:201
+msgid ""
+"Sets how to set the adjoining of lines. If set totally to left, it will "
+"extend or shrink start time of the second line; if totally to right, it will "
+"extend or shrink the end time of the first line."
+msgstr ""
+"Stellt ein, wie angrenzende Zeilen gesetzt werden. Ganz links gesetzt, wird "
+"die Startzeit der zweiten Zeile verlängert oder verkürzt, ganz rechts wird "
+"die Endzeit der ersten Zeile verlängert oder verkürzt."
 
-#: ../src/command/app.cpp:287
-msgid "&Check for Updates..."
-msgstr "Auf Updates überprüfen..."
+#: ../src/dialog_timing_processor.cpp:204
+msgid "Bias: Start <- "
+msgstr "Gewichtung: Anfang <- "
 
-#: ../src/command/app.cpp:288
-msgid "Check for Updates"
-msgstr "Auf Updates überprüfen"
+#: ../src/dialog_timing_processor.cpp:206
+msgid " -> End"
+msgstr " -> Ende"
 
-#: ../src/command/app.cpp:289
-msgid "Check to see if there is a new version of Aegisub available"
-msgstr "Überprüfen, ob eine neue Version von Aegisub verfügbar ist"
+#: ../src/dialog_timing_processor.cpp:214
+msgid "Keyframe snapping"
+msgstr "Einrasten auf Keyframes"
 
-#: ../src/command/recent.cpp:57 ../src/command/recent.cpp:58
-#: ../src/command/recent.cpp:59 ../src/command/recent.cpp:60
-#: ../src/command/recent.cpp:61 ../src/command/recent.cpp:65
-#: ../src/command/recent.cpp:66 ../src/command/recent.cpp:82
-#: ../src/command/recent.cpp:83 ../src/command/recent.cpp:93
-#: ../src/command/recent.cpp:94 ../src/command/recent.cpp:105
-#: ../src/command/recent.cpp:106 ../src/command/recent.cpp:116
-#: ../src/command/recent.cpp:117
-msgid "Recent"
-msgstr "Zuletzt geöffnet"
+#: ../src/dialog_timing_processor.cpp:217
+msgid "E&nable"
+msgstr "Aktivieren"
 
-#: ../src/command/recent.cpp:57 ../src/command/recent.cpp:67
-msgid "Open recent audio"
-msgstr "Letzte Audiodatei öffnen"
+#: ../src/dialog_timing_processor.cpp:218
+msgid ""
+"Enable snapping of subtitles to nearest keyframe, if distance is within "
+"threshold"
+msgstr ""
+"Aktiviert das Einrasten auf den nächstgelegenen Keyframe, falls dieser "
+"innerhalb des festgelegten Bereichs liegt"
 
-#: ../src/command/recent.cpp:58 ../src/command/recent.cpp:84
-msgid "Open recent keyframes"
-msgstr "Letzte Keyframes öffnen"
+#: ../src/dialog_timing_processor.cpp:229
+msgid "Starts before thres.:"
+msgstr "Fängt vor Bereich an:"
 
-#: ../src/command/recent.cpp:59 ../src/command/recent.cpp:95
-msgid "Open recent subtitles"
-msgstr "Letzte Untertitel öffnen"
+#: ../src/dialog_timing_processor.cpp:230
+msgid ""
+"Threshold for 'before start' distance, that is, how many milliseconds a "
+"subtitle must start before a keyframe to snap to it"
+msgstr ""
+"Bereich für 'vor Anfang', d.h. wieviele Millisekunden ein Untertitel vor "
+"einem Keyframe anfangen darf, um darauf einzurasten"
 
-#: ../src/command/recent.cpp:60 ../src/command/recent.cpp:107
-msgid "Open recent timecodes"
-msgstr "Zeitcode-Datei öffnen"
+#: ../src/dialog_timing_processor.cpp:232
+msgid "Starts after thres.:"
+msgstr "Fängt nach Bereich an:"
 
-#: ../src/command/recent.cpp:61
-msgid "Open recent video"
-msgstr "Letztes Video öffnen"
+#: ../src/dialog_timing_processor.cpp:233
+msgid ""
+"Threshold for 'after start' distance, that is, how many milliseconds a "
+"subtitle must start after a keyframe to snap to it"
+msgstr ""
+"Bereich für 'nach Anfang', d.h. wieviele Millisekunden ein Untertitel nach "
+"einem Keyframe anfangen darf, um darauf einzurasten"
 
-#: ../src/command/recent.cpp:118
-msgid "Open recent videos"
-msgstr "Letzte Videos öffnen"
+#: ../src/dialog_timing_processor.cpp:237
+msgid "Ends before thres.:"
+msgstr "Hört vor Bereich auf:"
 
-#: ../src/command/grid.cpp:60 ../src/command/grid.cpp:61
-#: ../src/command/grid.cpp:72 ../src/command/grid.cpp:73
-#: ../src/command/time.cpp:374 ../src/command/time.cpp:375
-#: ../src/command/tool.cpp:267
-msgid "Next Line"
-msgstr "Nächste Zeile"
+#: ../src/dialog_timing_processor.cpp:238
+msgid ""
+"Threshold for 'before end' distance, that is, how many milliseconds a "
+"subtitle must end before a keyframe to snap to it"
+msgstr ""
+"Bereich für 'vor Ende', d.h. wieviele Millisekunden ein Untertitel vor einem "
+"Keyframe enden darf, um darauf einzurasten"
 
-#: ../src/command/grid.cpp:62
-msgid "Move to the next subtitle line"
-msgstr "Gehe zur nächsten Untertitelzeile"
+#: ../src/dialog_timing_processor.cpp:240
+msgid "Ends after thres.:"
+msgstr "Hört nach Bereich auf:"
 
-#: ../src/command/grid.cpp:74
-msgid "Move to the next subtitle line, creating a new one if needed"
-msgstr "Gehe zur nächsten Untertitelzeile und erzeuge eine neue, falls nötig"
+#: ../src/dialog_timing_processor.cpp:241
+msgid ""
+"Threshold for 'after end' distance, that is, how many milliseconds a "
+"subtitle must end after a keyframe to snap to it"
+msgstr ""
+"Bereich für 'nach Ende', d.h. wieviele Millisekunden ein Untertitel nach "
+"einem Keyframe enden darf, um darauf einzurasten"
 
-#: ../src/command/grid.cpp:91 ../src/command/subtitle.cpp:137
-#: ../src/command/subtitle.cpp:174 ../src/command/subtitle.cpp:221
-msgid "line insertion"
-msgstr "Zeile einfügen"
+#: ../src/dialog_timing_processor.cpp:349
+#, c-format
+msgid "One of the lines in the file (%i) has negative duration. Aborting."
+msgstr "Eine der Zeilen in der Datei (%i) hat eine negative Dauer. Abbruch."
 
-#: ../src/command/grid.cpp:100 ../src/command/grid.cpp:101
-#: ../src/command/time.cpp:386 ../src/command/time.cpp:387
-#: ../src/command/tool.cpp:279
-msgid "Previous Line"
+#: ../src/dialog_timing_processor.cpp:350
+msgid "Invalid script"
+msgstr "Ungültiges Skript"
+
+#: ../src/dialog_timing_processor.cpp:445
+msgid "timing processor"
+msgstr "Timingverarbeitung"
+
+#: ../src/mkv_wrap.cpp:213
+msgid "Choose which track to read:"
+msgstr "Wählen Sie die Spur aus, den sie lesen wollen: "
+
+#: ../src/mkv_wrap.cpp:213
+msgid "Multiple subtitle tracks found"
+msgstr "Mehrere Untertitelspuren gefunden"
+
+#: ../src/mkv_wrap.cpp:251
+msgid "Parsing Matroska"
+msgstr "Analysiere Matroska"
+
+#: ../src/mkv_wrap.cpp:251
+msgid "Reading subtitles from Matroska file."
+msgstr "Lese Untertitel aus Matroska-Datei"
+
+#: ../src/dialog_styling_assistant.cpp:55 ../src/command/tool.cpp:123
+msgid "Styling Assistant"
+msgstr "Stil-Assistent"
+
+#: ../src/dialog_styling_assistant.cpp:65
+#: ../src/dialog_styling_assistant.cpp:66
+msgid "Current line"
+msgstr "Aktuelle Zeile"
+
+#: ../src/dialog_styling_assistant.cpp:72
+msgid "Styles available"
+msgstr "Verfügbare Stile"
+
+#: ../src/dialog_styling_assistant.cpp:80
+msgid "Set style"
+msgstr "Stil einstellen"
+
+#: ../src/dialog_styling_assistant.cpp:87 ../src/dialog_translation.cpp:108
+msgid "Keys"
+msgstr "Tasten"
+
+#: ../src/dialog_styling_assistant.cpp:90 ../src/command/tool.cpp:142
+#: ../src/command/tool.cpp:226 ../src/dialog_translation.cpp:111
+msgid "Accept changes"
+msgstr "Änderungen übernehmen"
+
+#: ../src/dialog_styling_assistant.cpp:91 ../src/command/tool.cpp:153
+#: ../src/command/tool.cpp:237 ../src/dialog_translation.cpp:112
+msgid "Preview changes"
+msgstr "Vorschau"
+
+#: ../src/dialog_styling_assistant.cpp:92 ../src/dialog_translation.cpp:113
+msgid "Previous line"
 msgstr "Vorherige Zeile"
 
-#: ../src/command/grid.cpp:102
-msgid "Move to the previous line"
-msgstr "Gehe zur vorherige Zeile"
+#: ../src/dialog_styling_assistant.cpp:93 ../src/dialog_translation.cpp:114
+msgid "Next line"
+msgstr "Nächste Zeile"
 
-#: ../src/command/grid.cpp:112 ../src/command/grid.cpp:133
-msgid "&Actor Name"
-msgstr "Sprecher"
+#: ../src/dialog_styling_assistant.cpp:94 ../src/dialog_translation.cpp:116
+msgid "Play video"
+msgstr "Video abspielen"
 
-#: ../src/command/grid.cpp:113 ../src/command/grid.cpp:134
-msgid "Actor Name"
-msgstr "Sprecher"
+#: ../src/dialog_styling_assistant.cpp:95 ../src/dialog_translation.cpp:117
+msgid "Play audio"
+msgstr "Audio abspielen"
 
-#: ../src/command/grid.cpp:114
-msgid "Sort all subtitles by their actor names"
-msgstr "Sortiert alle Untertitel nach ihren Sprechernamen"
+#: ../src/dialog_styling_assistant.cpp:96
+msgid "Click on list"
+msgstr "Auf Liste klicken"
 
-#: ../src/command/grid.cpp:118 ../src/command/grid.cpp:139
-#: ../src/command/grid.cpp:152 ../src/command/grid.cpp:165
-#: ../src/command/grid.cpp:178 ../src/command/grid.cpp:191
-#: ../src/command/grid.cpp:204 ../src/command/grid.cpp:217
-#: ../src/command/grid.cpp:230 ../src/command/grid.cpp:243
-#: ../src/command/grid.cpp:256 ../src/command/grid.cpp:269
-msgid "sort"
-msgstr "Sortieren"
+#: ../src/dialog_styling_assistant.cpp:97
+msgid "Select style"
+msgstr "Stil wählen"
 
-#: ../src/command/grid.cpp:135
-msgid "Sort selected subtitles by their actor names"
-msgstr "Sortiert markierte Untertitel nach ihren Sprechernamen"
+#: ../src/dialog_styling_assistant.cpp:101
+msgid "&Seek video to line start time"
+msgstr "Zur Anfangszeit der Zeile springen"
 
-#: ../src/command/grid.cpp:146 ../src/command/grid.cpp:159
-msgid "&Effect"
-msgstr "Effekt"
+#: ../src/dialog_styling_assistant.cpp:110 ../src/dialog_translation.cpp:129
+msgid "Actions"
+msgstr "Aktionen"
 
-#: ../src/command/grid.cpp:148
-msgid "Sort all subtitles by their effects"
-msgstr "Sortiert alle Untertitel nach ihren Effekten"
+#: ../src/dialog_styling_assistant.cpp:113 ../src/dialog_translation.cpp:131
+msgid "Play &Audio"
+msgstr "Audio abspielen"
 
-#: ../src/command/grid.cpp:161
-msgid "Sort selected subtitles by their effects"
-msgstr "Sortiert markierte Untertitel nach ihren Effekten"
+#: ../src/dialog_styling_assistant.cpp:117 ../src/dialog_translation.cpp:136
+msgid "Play &Video"
+msgstr "Video abspielen"
 
-#: ../src/command/grid.cpp:172 ../src/command/grid.cpp:185
-msgid "&End Time"
-msgstr "Endzeit"
+#: ../src/dialog_styling_assistant.cpp:175
+msgid "styling assistant"
+msgstr "Stil-Assistent"
 
-#: ../src/command/grid.cpp:173 ../src/command/grid.cpp:186
-#: ../src/dialog_paste_over.cpp:60
-msgid "End Time"
-msgstr "Endzeit"
+#: ../src/audio_timing_karaoke.cpp:241
+msgid "karaoke timing"
+msgstr "Karaoke-Timing"
 
-#: ../src/command/grid.cpp:174
-msgid "Sort all subtitles by their end times"
-msgstr "Sortiert alle Untertitel nach ihren Endzeiten"
+#: ../src/dialog_jumpto.cpp:66 ../src/command/video.cpp:523
+msgid "Jump to"
+msgstr "Springe zu"
 
-#: ../src/command/grid.cpp:187
-msgid "Sort selected subtitles by their end times"
-msgstr "Sortiert markierte Untertitel nach ihren Endzeiten"
+#: ../src/dialog_jumpto.cpp:72
+msgid "Frame: "
+msgstr "Frame: "
 
-#: ../src/command/grid.cpp:198 ../src/command/grid.cpp:211
-msgid "&Layer"
-msgstr "Ebene"
+#: ../src/dialog_jumpto.cpp:73
+msgid "Time: "
+msgstr "Zeit: "
 
-#: ../src/command/grid.cpp:199 ../src/command/grid.cpp:212
-#: ../src/dialog_paste_over.cpp:58 ../src/base_grid.cpp:765
-msgid "Layer"
-msgstr "Ebene"
+#: ../src/dialog_style_manager.cpp:188
+msgid "Move style up"
+msgstr "Verschiebe Stil nach oben"
 
-#: ../src/command/grid.cpp:200
-msgid "Sort all subtitles by their layer number"
-msgstr "Sortiert alle Untertitel nach ihren Ebenennummern"
+#: ../src/dialog_style_manager.cpp:189
+msgid "Move style down"
+msgstr "Verschiebe Stil nach unten"
 
-#: ../src/command/grid.cpp:213
-msgid "Sort selected subtitles by their layer number"
-msgstr "Sortiert markierte Untertitel nach ihren Ebenennummern"
+#: ../src/dialog_style_manager.cpp:190
+msgid "Move style to top"
+msgstr "Verschiebe Stil an die Spitze"
 
-#: ../src/command/grid.cpp:224 ../src/command/grid.cpp:237
-msgid "&Start Time"
-msgstr "Startzeit"
+#: ../src/dialog_style_manager.cpp:191
+msgid "Move style to bottom"
+msgstr "Verschiebe Stil ans Ende"
 
-#: ../src/command/grid.cpp:225 ../src/command/grid.cpp:238
-#: ../src/dialog_paste_over.cpp:59
-msgid "Start Time"
-msgstr "Startzeit"
+#: ../src/dialog_style_manager.cpp:192
+msgid "Sort styles alphabetically"
+msgstr "Sortiere Stile alphabetisch"
 
-#: ../src/command/grid.cpp:226
-msgid "Sort all subtitles by their start times"
-msgstr "Sortiert alle Untertitel nach ihren Startzeiten"
+#: ../src/dialog_style_manager.cpp:202 ../src/preferences.cpp:578
+msgid "&New"
+msgstr "&Neu"
 
-#: ../src/command/grid.cpp:239
-msgid "Sort selected subtitles by their start times"
-msgstr "Sortiert markierte Untertitel nach ihren Startzeiten"
+#: ../src/dialog_style_manager.cpp:203 ../src/preferences.cpp:579
+msgid "&Edit"
+msgstr "&Bearbeiten"
 
-#: ../src/command/grid.cpp:250 ../src/command/grid.cpp:263
-msgid "St&yle Name"
-msgstr "Stilname"
+#: ../src/dialog_style_manager.cpp:205 ../src/preferences.cpp:580
+#: ../src/dialog_attachments.cpp:79
+msgid "&Delete"
+msgstr "&Löschen"
 
-#: ../src/command/grid.cpp:251 ../src/command/grid.cpp:264
-#: ../src/dialog_style_editor.cpp:175
-msgid "Style Name"
-msgstr "Stilname"
+#: ../src/dialog_style_manager.cpp:218
+#, c-format
+msgid "%s - Copy"
+msgstr "%s - Kopieren"
 
-#: ../src/command/grid.cpp:252
-msgid "Sort all subtitles by their style names"
-msgstr "Sortiert alle Untertitel nach ihren Stilnamen"
+#: ../src/dialog_style_manager.cpp:220
+#, c-format
+msgid "%s - Copy (%d)"
+msgstr "%s - Kopieren (%d)"
 
-#: ../src/command/grid.cpp:265
-msgid "Sort selected subtitles by their style names"
-msgstr "Sortiert markierte Untertitel nach ihren Stilnamen"
+#: ../src/dialog_style_manager.cpp:243
+msgid "Could not parse style"
+msgstr "Kann den Stil nicht lesen"
 
-#: ../src/command/grid.cpp:276 ../src/command/grid.cpp:277
-msgid "Cycle Tag Hiding Mode"
-msgstr "Tag-Anzeigemodi durchlaufen"
+#: ../src/dialog_style_manager.cpp:248
+#, fuzzy, c-format
+msgid "Are you sure you want to delete this style?"
+msgid_plural "Are you sure you want to delete these %d styles?"
+msgstr[0] "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
+msgstr[1] "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
 
-#: ../src/command/grid.cpp:278
-msgid "Cycle through tag hiding modes"
-msgstr "Durchlaufe Modi der Tag-Anzeige"
+#: ../src/dialog_style_manager.cpp:259 ../src/command/tool.cpp:165
+msgid "Styles Manager"
+msgstr "Stil-Manager"
 
-#: ../src/command/grid.cpp:288
-msgid "ASS Override Tag mode set to show full tags."
-msgstr "ass-Tag-Modus auf 'alle Tags' setzen."
+#: ../src/dialog_style_manager.cpp:273
+msgid "Catalog of available storages"
+msgstr "Katalog der verfügbaren Speicher"
 
-#: ../src/command/grid.cpp:289
-msgid "ASS Override Tag mode set to simplify tags."
-msgstr "ass-Tag-Modus auf 'einfache Tags' setzen."
+#: ../src/dialog_style_manager.cpp:275
+msgid "New"
+msgstr "Neu"
 
-#: ../src/command/grid.cpp:290
-msgid "ASS Override Tag mode set to hide tags."
-msgstr "ass-Tag-Modus auf 'Tags verstecken' setzen."
+#: ../src/dialog_style_manager.cpp:276
+msgid "Delete"
+msgstr "Löschen"
 
-#: ../src/command/grid.cpp:302
-msgid "&Hide Tags"
-msgstr "Tags verstecken"
+#: ../src/dialog_style_manager.cpp:282
+msgid "Copy to &current script ->"
+msgstr "In aktuelles Skript kopieren ->"
 
-#: ../src/command/grid.cpp:303
-msgid "Hide Tags"
-msgstr "Tags verstecken"
+#: ../src/dialog_style_manager.cpp:289
+msgid "Storage"
+msgstr "Speicher"
 
-#: ../src/command/grid.cpp:304
-msgid "Hide override tags in the subtitle grid"
-msgstr "Verstecke Tags im Untertitelgitter"
+#: ../src/dialog_style_manager.cpp:295
+msgid "&Import from script..."
+msgstr "&Importiere aus Skript..."
 
-#: ../src/command/grid.cpp:320
-msgid "Sh&ow Tags"
-msgstr "Tags anzeigen"
+#: ../src/dialog_style_manager.cpp:296
+msgid "<- Copy to &storage"
+msgstr "<- In Speicher kopieren"
 
-#: ../src/command/grid.cpp:321
-msgid "Show Tags"
-msgstr "Tags anzeigen"
+#: ../src/dialog_style_manager.cpp:307
+msgid "Current script"
+msgstr "Aktuelles Skript"
 
-#: ../src/command/grid.cpp:322
-msgid "Show full override tags in the subtitle grid"
-msgstr "Zeige alle Tags im Untertitelgitter"
+#: ../src/dialog_style_manager.cpp:314 ../src/dialog_progress.cpp:179
+msgid "Close"
+msgstr "Schließen"
 
-#: ../src/command/grid.cpp:338
-msgid "S&implify Tags"
-msgstr "Einfache Tags"
+#: ../src/dialog_style_manager.cpp:454
+msgid "New storage name:"
+msgstr "Neuer Speichername:"
 
-#: ../src/command/grid.cpp:339
-msgid "Simplify Tags"
-msgstr "Einfache Tags"
+#: ../src/dialog_style_manager.cpp:454
+msgid "New catalog entry"
+msgstr "Neuer Katalogeintrag"
 
-#: ../src/command/grid.cpp:340
+#: ../src/dialog_style_manager.cpp:469
+msgid "A catalog with that name already exists."
+msgstr "Ein Katalog mit diesem Namen existiert schon."
+
+#: ../src/dialog_style_manager.cpp:469
+msgid "Catalog name conflict"
+msgstr "Katalog-Namenskonflikt"
+
+#: ../src/dialog_style_manager.cpp:476
+#, c-format
 msgid ""
-"Replace override tags in the subtitle grid with a simplified placeholder"
-msgstr "Ersetze die Tags im Untertitelgitter durch einen einfachen Platzhalter"
-
-#: ../src/command/grid.cpp:375 ../src/command/grid.cpp:376
-msgid "Move line up"
-msgstr "Verschiebe Zeile nach oben"
-
-#: ../src/command/grid.cpp:377
-msgid "Move the selected lines up one row"
-msgstr "Verschiebe die ausgewählten Zeilen um eine Zeile nach oben"
-
-#: ../src/command/grid.cpp:386 ../src/command/grid.cpp:404
-msgid "move lines"
-msgstr "Zeilen verschieben"
-
-#: ../src/command/grid.cpp:393 ../src/command/grid.cpp:394
-msgid "Move line down"
-msgstr "Verschiebe Zeile nach unten"
-
-#: ../src/command/grid.cpp:395
-msgid "Move the selected lines down one row"
-msgstr "Verschiebe die ausgewählten Zeilen um eine Zeile nach unten"
-
-#: ../src/command/grid.cpp:411 ../src/command/grid.cpp:412
-msgid "Swap Lines"
-msgstr "Zeilen vertauschen"
-
-#: ../src/command/grid.cpp:413
-msgid "Swaps the two selected lines"
-msgstr "Vertauscht die ausgewählten Zeilen miteinander"
-
-#: ../src/command/grid.cpp:424
-msgid "swap lines"
-msgstr "Zeilen vertauschen"
-
-#: ../src/command/automation.cpp:61
-msgid "&Reload Automation scripts"
-msgstr "Automatisierungs-Skripte neu laden"
-
-#: ../src/command/automation.cpp:62
-msgid "Reload Automation scripts"
-msgstr "Automatisierungs-Skripte neu laden"
-
-#: ../src/command/automation.cpp:63
-msgid "Reload all Automation scripts and rescan the autoload folder"
+"The specified catalog name contains one or more illegal characters. They "
+"have been replaced with underscores instead.\n"
+"The catalog has been renamed to \"%s\"."
 msgstr ""
-"Alle Automatisierungs-Skripte neu laden und den Autom.-Laden-Ordner neu "
-"prüfen"
+"Der von Ihnen gewählte Katalog enthält ein oder mehrere ungültige Zeichen. "
+"Diese wurden durch Unterstriche ersetzt.\n"
+"Der Katalog wurde umbenannt zu \"%s\"."
 
-#: ../src/command/automation.cpp:68
-msgid "Reloaded all Automation scripts"
-msgstr "Alle Automatisierungs-Skripte neu geladen"
+#: ../src/dialog_style_manager.cpp:477
+msgid "Invalid characters"
+msgstr "Ungültige Zeichen"
 
-#: ../src/command/automation.cpp:74
-msgid "R&eload autoload Automation scripts"
-msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+#: ../src/dialog_style_manager.cpp:490
+#, c-format
+msgid "Are you sure you want to delete the storage \"%s\" from the catalog?"
+msgstr ""
+"Sind Sie sicher, daß Sie den Speicher \"%s\" aus dem Katalog löschen wollen?"
 
-#: ../src/command/automation.cpp:75
-msgid "Reload autoload Automation scripts"
-msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+#: ../src/dialog_style_manager.cpp:491
+msgid "Confirm delete"
+msgstr "Löschen bestätigen"
 
-#: ../src/command/automation.cpp:76
-msgid "Rescan the Automation autoload folder"
-msgstr "Autom.-Laden-Ordner neu prüfen"
+#: ../src/dialog_style_manager.cpp:509
+#, c-format
+msgid ""
+"There is already a style with the name \"%s\" in the current storage. "
+"Overwrite?"
+msgstr ""
+"Es gibt bereits einen Stil mit dem Namen \"%s\" im aktuellen Speicher. "
+"Wollen Sie ihn überschreiben?"
 
-#: ../src/command/automation.cpp:80
-msgid "Reloaded autoload Automation scripts"
-msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
+#: ../src/dialog_style_manager.cpp:509 ../src/dialog_style_manager.cpp:536
+#: ../src/dialog_style_manager.cpp:714
+msgid "Style name collision"
+msgstr "Stilnamen-Kollision"
 
-#: ../src/command/automation.cpp:86 ../src/command/automation.cpp:97
-msgid "&Automation..."
-msgstr "&Automatisierung..."
+#: ../src/dialog_style_manager.cpp:536 ../src/dialog_style_manager.cpp:713
+#, c-format
+msgid ""
+"There is already a style with the name \"%s\" in the current script. "
+"Overwrite?"
+msgstr ""
+"Es gibt bereits einen Stil mit dem Namen \"%s\" im aktuellen Skript. Wollen "
+"Sie Ihn überschreiben?"
 
-#: ../src/command/automation.cpp:88 ../src/command/automation.cpp:99
-msgid "Open automation manager"
-msgstr "Öffnet den Automatisierungs-Manager"
+#: ../src/dialog_style_manager.cpp:547
+msgid "style copy"
+msgstr "Stil kopieren"
 
-#: ../src/command/subtitle.cpp:88
-msgid "A&ttachments..."
-msgstr "&Anhänge..."
+#: ../src/dialog_style_manager.cpp:576
+msgid "style paste"
+msgstr "Stil einfügen"
 
-#: ../src/command/subtitle.cpp:89
-msgid "Attachments"
-msgstr "Anhänge"
+#: ../src/dialog_style_manager.cpp:620
+msgid "Confirm delete from storage"
+msgstr "Löschen aus dem Speicher bestätigen"
 
-#: ../src/command/subtitle.cpp:90
-msgid "Open the attachment list"
-msgstr "Öffnet die Liste der Anhänge"
+#: ../src/dialog_style_manager.cpp:659
+msgid "Confirm delete from current"
+msgstr "Aktuelles Löschen bestätigen"
 
-#: ../src/command/subtitle.cpp:102
-msgid "&Find..."
-msgstr "&Suchen..."
+#: ../src/dialog_style_manager.cpp:663
+msgid "style delete"
+msgstr "Stil löschen"
 
-#: ../src/command/subtitle.cpp:103 ../src/dialog_search_replace.cpp:46
-msgid "Find"
-msgstr "Suchen"
-
-#: ../src/command/subtitle.cpp:104
-msgid "Find words in subtitles"
-msgstr "Suche nach Wörtern in den Untertiteln"
-
-#: ../src/command/subtitle.cpp:115
-msgid "Find &Next"
-msgstr "Nächstes Vorkommen"
-
-#: ../src/command/subtitle.cpp:116
-msgid "Find Next"
-msgstr "Nächstes Vorkommen"
-
-#: ../src/command/subtitle.cpp:117
-msgid "Find next match of last word"
-msgstr "Suche nächstes Vorkommen der letzten Suchanfrage"
-
-#: ../src/command/subtitle.cpp:147
-msgid "&After Current"
-msgstr "Nach aktueller"
-
-#: ../src/command/subtitle.cpp:148
-msgid "After Current"
-msgstr "Nach aktueller"
-
-#: ../src/command/subtitle.cpp:149
-msgid "Inserts a line after current"
-msgstr "Zeile nach der aktuellen einfügen"
-
-#: ../src/command/subtitle.cpp:184 ../src/command/subtitle.cpp:185
-msgid "After Current, at Video Time"
-msgstr "Nach aktueller, bei Videozeit"
-
-#: ../src/command/subtitle.cpp:186
-msgid "Inserts a line after current, starting at video time"
-msgstr "Fügt eine Zeile nach der aktuellen ein (ab aktueller Videozeit)"
-
-#: ../src/command/subtitle.cpp:197
-msgid "&Before Current"
-msgstr "Vor aktueller"
-
-#: ../src/command/subtitle.cpp:198
-msgid "Before Current"
-msgstr "Vor aktueller"
-
-#: ../src/command/subtitle.cpp:199
-msgid "Inserts a line before current"
-msgstr "Zeile vor aktueller einfügen"
-
-#: ../src/command/subtitle.cpp:232 ../src/command/subtitle.cpp:233
-msgid "Before Current, at Video Time"
-msgstr "Vor aktueller, bei Videozeit"
-
-#: ../src/command/subtitle.cpp:234
-msgid "Inserts a line before current, starting at video time"
-msgstr "Fügt eine Zeile vor der aktuellen ein (ab aktueller Videozeit)"
-
-#: ../src/command/subtitle.cpp:245
-msgid "&New Subtitles"
-msgstr "&Neue Untertitel"
-
-#: ../src/command/subtitle.cpp:246
-msgid "New Subtitles"
-msgstr "&Neue Untertitel"
-
-#: ../src/command/subtitle.cpp:247
-msgid "New subtitles"
-msgstr "Neue Untertitel"
-
-#: ../src/command/subtitle.cpp:259
-msgid "&Open Subtitles..."
-msgstr "Ö&ffne Untertitel..."
-
-#: ../src/command/subtitle.cpp:260
-msgid "Open Subtitles"
-msgstr "Öffne Untertitel"
-
-#: ../src/command/subtitle.cpp:261
-msgid "Opens a subtitles file"
-msgstr "Öffnet eine Untertitel-Datei"
-
-#: ../src/command/subtitle.cpp:265 ../src/command/subtitle.cpp:295
-#: ../src/dialog_style_manager.cpp:566
+#: ../src/dialog_style_manager.cpp:668 ../src/command/subtitle.cpp:240
+#: ../src/command/subtitle.cpp:270
 msgid "Open subtitles file"
 msgstr "Untertitel öffnen"
 
-#: ../src/command/subtitle.cpp:273
-msgid "Open A&utosaved Subtitles..."
-msgstr "Ö&ffne Autosave-Untertitel..."
+#: ../src/dialog_style_manager.cpp:698
+msgid "The selected file has no available styles."
+msgstr "Die ausgewählte Datei besitzt keine Stile."
 
-#: ../src/command/subtitle.cpp:274
-msgid "Open Autosaved Subtitles"
-msgstr "Öffne Autosave-Untertitel"
+#: ../src/dialog_style_manager.cpp:698
+msgid "Error Importing Styles"
+msgstr "Fehler beim Importieren der Stile"
 
-#: ../src/command/subtitle.cpp:275
-msgid "Open a previous version of a file which was autosaved by Aegisub"
-msgstr ""
-"Öffne eine vorherige Version einer Datei, die von Aegisub automatisch "
-"gespeichert wurde."
+#: ../src/dialog_style_manager.cpp:704
+msgid "Choose styles to import:"
+msgstr "Stile zum Importieren auswählen:"
 
-#: ../src/command/subtitle.cpp:288
-msgid "Open Subtitles with &Charset..."
-msgstr "Öffne Untertitel mit &Zeichensatz"
+#: ../src/dialog_style_manager.cpp:704
+msgid "Import Styles"
+msgstr "Importiere Stile"
 
-#: ../src/command/subtitle.cpp:289
-msgid "Open Subtitles with Charset"
-msgstr "Öffne Untertitel mit &Zeichensatz"
+#: ../src/dialog_style_manager.cpp:730
+msgid "style import"
+msgstr "Stilimport"
 
-#: ../src/command/subtitle.cpp:290
-msgid "Opens a subtitles file with a specific charset"
-msgstr "Öffnet eine Untertitel-Datei mit einem bestimmten Zeichensatz"
+#: ../src/dialog_style_manager.cpp:839
+msgid "Are you sure? This cannot be undone!"
+msgstr "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden!"
 
-#: ../src/command/subtitle.cpp:298
-msgid "Choose charset code:"
-msgstr "Zeichensatz auswählen:"
+#: ../src/dialog_style_manager.cpp:839
+msgid "Sort styles"
+msgstr "Stile sortieren"
 
-#: ../src/command/subtitle.cpp:298
-msgid "Charset"
-msgstr "Zeichensatz"
+#: ../src/dialog_style_manager.cpp:880
+msgid "style move"
+msgstr "Stil verschieben"
 
-#: ../src/command/subtitle.cpp:308
-msgid "Open Subtitles from &Video"
-msgstr "Öffne Untertitel vom &Video"
+#: ../src/command/timecode.cpp:52 ../src/command/timecode.cpp:53
+msgid "Close Timecodes File"
+msgstr "Zeitcode-Datei schließen"
 
-#: ../src/command/subtitle.cpp:309
-msgid "Open Subtitles from Video"
-msgstr "Öffne Untertitel vom Video"
+#: ../src/command/timecode.cpp:54
+#, fuzzy
+msgid "Close the currently open timecodes file"
+msgstr "Schließt die derzeit offene Datei mit Zeitcodes"
 
-#: ../src/command/subtitle.cpp:310
-msgid "Opens the subtitles from the current video file"
-msgstr "Öffnet die Untertitel der aktuellen Videodatei"
+#: ../src/command/timecode.cpp:69
+msgid "Open Timecodes File..."
+msgstr "Öffne Zeitcode-Datei..."
 
-#: ../src/command/subtitle.cpp:327
-msgid "&Properties..."
-msgstr "&Eigenschaften..."
+#: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
+msgid "Open Timecodes File"
+msgstr "Öffne Zeitcode-Datei..."
 
-#: ../src/command/subtitle.cpp:328
-msgid "Properties"
-msgstr "Eigenschaften"
+#: ../src/command/timecode.cpp:71
+#, fuzzy
+msgid "Open a VFR timecodes v1 or v2 file"
+msgstr "Öffnet eine Datei mit vfr-Zeitcodes, Typ v1 oder v2"
 
-#: ../src/command/subtitle.cpp:329
-msgid "Open script properties window"
-msgstr "Öffnet den Skripteigenschaften-Dialog"
+#: ../src/command/timecode.cpp:84
+msgid "Save Timecodes File..."
+msgstr "Speichere Zeitcode-Datei"
 
-#: ../src/command/subtitle.cpp:340
-msgid "Save subtitles file"
-msgstr "Untertiteldatei speichern"
+#: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
+msgid "Save Timecodes File"
+msgstr "Speichere Zeitcode-Datei"
 
-#: ../src/command/subtitle.cpp:363
-msgid "&Save Subtitles"
-msgstr "&Speichere Untertitel"
+#: ../src/command/timecode.cpp:86
+#, fuzzy
+msgid "Save a VFR timecodes v2 file"
+msgstr "Speichere eine Datei mit vfr-Timecodes, Typ v2"
 
-#: ../src/command/subtitle.cpp:364
-msgid "Save Subtitles"
-msgstr "&Speichere Untertitel"
+#: ../src/command/command.cpp:31
+#, c-format
+msgid "'%s' is not a valid command name"
+msgstr "'%s' ist kein gültiger Kommandoname"
 
-#: ../src/command/subtitle.cpp:365
-msgid "Saves subtitles"
-msgstr "Speichert die Untertitel-Datei"
-
-#: ../src/command/subtitle.cpp:381
-msgid "Save Subtitles &as..."
-msgstr "Speichere Untertitel unter..."
-
-#: ../src/command/subtitle.cpp:382
-msgid "Save Subtitles as"
-msgstr "Speichere Untertitel unter..."
-
-#: ../src/command/subtitle.cpp:383
-msgid "Saves subtitles with another name"
-msgstr "Speichert die Untertitel-Datei unter anderem Namen"
-
-#: ../src/command/subtitle.cpp:394
-msgid "Select All"
-msgstr "Alles aus&wählen"
-
-#: ../src/command/subtitle.cpp:395
-msgid "Selects all dialogue lines"
-msgstr "Wähle alle Dialogzeilen aus"
-
-#: ../src/command/subtitle.cpp:409 ../src/command/subtitle.cpp:410
-msgid "Select Visible"
-msgstr "Sichtbare auswählen"
-
-#: ../src/command/subtitle.cpp:411
-msgid "Selects all lines that are currently visible on video frame"
-msgstr "Wählt alle Zeilen aus, die im aktuellen Videoframe sichtbar sind"
-
-#: ../src/command/subtitle.cpp:445
-msgid "Spell &Checker..."
-msgstr "&Rechtschreibprüfung..."
-
-#: ../src/command/subtitle.cpp:446 ../src/dialog_spellchecker.cpp:54
-msgid "Spell Checker"
-msgstr "Rechtschreibprüfung"
-
-#: ../src/command/subtitle.cpp:447
-msgid "Open spell checker"
-msgstr "Öffnet die Rechtschreibprüfung"
-
-#: ../src/command/video.cpp:96
+#: ../src/command/video.cpp:84
 msgid "&Cinematic (2.35)"
 msgstr "Kinoformat (2.35)"
 
-#: ../src/command/video.cpp:97
+#: ../src/command/video.cpp:85
 msgid "Cinematic (2.35)"
 msgstr "Kinoformat (2.35)"
 
-#: ../src/command/video.cpp:98
-msgid "Forces video to 2.35 aspect ratio"
+#: ../src/command/video.cpp:86
+#, fuzzy
+msgid "Force video to 2.35 aspect ratio"
 msgstr "Erzwingt 2.35:1-Seitenverhältnis für das Video"
 
-#: ../src/command/video.cpp:115
+#: ../src/command/video.cpp:102
 msgid "C&ustom..."
 msgstr "Benutzerdefiniert..."
 
-#: ../src/command/video.cpp:116
+#: ../src/command/video.cpp:103
 msgid "Custom"
 msgstr "Benutzerdefiniert..."
 
-#: ../src/command/video.cpp:117
-msgid "Forces video to a custom aspect ratio"
+#: ../src/command/video.cpp:104
+#, fuzzy
+msgid "Force video to a custom aspect ratio"
 msgstr "Erzwingt ein benutzerdefiniertes Seitenverhältnis"
 
-#: ../src/command/video.cpp:128
+#: ../src/command/video.cpp:115
 msgid ""
 "Enter aspect ratio in either:\n"
 "  decimal (e.g. 2.35)\n"
@@ -1764,150 +903,175 @@ msgstr ""
 "  Verhältnis (z.B. 16:9)\n"
 "  bestimmte Auflösung (z.B. 853x480)"
 
-#: ../src/command/video.cpp:129
+#: ../src/command/video.cpp:116
 msgid "Enter aspect ratio"
 msgstr "Seitenverhältnis angeben"
 
-#: ../src/command/video.cpp:148
+#: ../src/command/video.cpp:135
 msgid "Invalid value! Aspect ratio must be between 0.5 and 5.0."
 msgstr "Ungültiger Wert! Seitenverhältnis muß zwischen 0.5 und 5.0 liegen."
 
-#: ../src/command/video.cpp:148
+#: ../src/command/video.cpp:135
 msgid "Invalid Aspect Ratio"
 msgstr "Ungültiges Seitenverhältnis"
 
-#: ../src/command/video.cpp:159
+#: ../src/command/video.cpp:145
 msgid "&Default"
 msgstr "Vorgabe"
 
-#: ../src/command/video.cpp:160 ../src/ass_style.cpp:233
+#: ../src/command/video.cpp:146 ../src/ass_style.cpp:194
 msgid "Default"
 msgstr "Vorgabe"
 
-#: ../src/command/video.cpp:161
-msgid "Leave video on original aspect ratio"
+#: ../src/command/video.cpp:147
+#, fuzzy
+msgid "Use video's original aspect ratio"
 msgstr "Beläßt das ursprüngliche Seitenverhältnis des Videos"
 
-#: ../src/command/video.cpp:178
+#: ../src/command/video.cpp:163
 msgid "&Fullscreen (4:3)"
 msgstr "&Vollbildformat (4:3)"
 
-#: ../src/command/video.cpp:179
+#: ../src/command/video.cpp:164
 msgid "Fullscreen (4:3)"
 msgstr "&Vollbildformat (4:3)"
 
-#: ../src/command/video.cpp:180
-msgid "Forces video to 4:3 aspect ratio"
+#: ../src/command/video.cpp:165
+#, fuzzy
+msgid "Force video to 4:3 aspect ratio"
 msgstr "Erzwingt 4:3-Seitenverhältnis für das Video"
 
-#: ../src/command/video.cpp:197
+#: ../src/command/video.cpp:181
 msgid "&Widescreen (16:9)"
 msgstr "&Breitbildformat (16:9)"
 
-#: ../src/command/video.cpp:198
+#: ../src/command/video.cpp:182
 msgid "Widescreen (16:9)"
 msgstr "&Breitbildformat (16:9)"
 
-#: ../src/command/video.cpp:199
-msgid "Forces video to 16:9 aspect ratio"
+#: ../src/command/video.cpp:183
+#, fuzzy
+msgid "Force video to 16:9 aspect ratio"
 msgstr "Erzwingt 19:9-Seitenverhältnis für das Video"
 
-#: ../src/command/video.cpp:216
+#: ../src/command/video.cpp:200
 msgid "&Close Video"
 msgstr "Video &schließen"
 
-#: ../src/command/video.cpp:217
+#: ../src/command/video.cpp:201
 msgid "Close Video"
 msgstr "Video &schließen"
 
-#: ../src/command/video.cpp:218
-msgid "Closes the currently open video file"
+#: ../src/command/video.cpp:202
+#, fuzzy
+msgid "Close the currently open video file"
 msgstr "Schließt die derzeit offene Videodatei"
 
-#: ../src/command/video.cpp:228 ../src/command/video.cpp:229
+#: ../src/command/video.cpp:211 ../src/command/video.cpp:212
 msgid "Copy coordinates to Clipboard"
 msgstr "Koordinaten in die Zwischenablage kopieren"
 
-#: ../src/command/video.cpp:230
+#: ../src/command/video.cpp:213
 msgid ""
 "Copy the current coordinates of the mouse over the video to the clipboard"
 msgstr ""
 "Kopiere die aktuellen Koordinaten der Mausposition auf dem Video in die "
 "Zwischenablage"
 
-#: ../src/command/video.cpp:240
+#: ../src/command/video.cpp:222 ../src/command/video.cpp:223
+#, fuzzy
+msgid "Cycle active subtitles provider"
+msgstr "Untertitel-Provider"
+
+#: ../src/command/video.cpp:224
+msgid "Cycle through the available subtitles providers"
+msgstr ""
+
+#: ../src/command/video.cpp:235
+#, fuzzy, c-format
+msgid "Subtitles provider set to %s"
+msgstr "Untertitel-Provider"
+
+#: ../src/command/video.cpp:242
 msgid "&Detach Video"
 msgstr "Video abkoppeln"
 
-#: ../src/command/video.cpp:241
+#: ../src/command/video.cpp:243
 msgid "Detach Video"
 msgstr "Video abkoppeln"
 
-#: ../src/command/video.cpp:242
-msgid "Detach video, displaying it in a separate Window"
+#: ../src/command/video.cpp:244
+#, fuzzy
+msgid ""
+"Detach the video display from the main window, displaying it in a separate "
+"Window"
 msgstr ""
 "Koppelt das Video vom Hauptfenster ab und zeigt es in einem separaten "
 "Fenster an"
 
-#: ../src/command/video.cpp:260
+#: ../src/command/video.cpp:262
 msgid "Show &Video Details"
 msgstr "Zeige Videodetails..."
 
-#: ../src/command/video.cpp:261
+#: ../src/command/video.cpp:263
 msgid "Show Video Details"
 msgstr "Zeige Videodetails..."
 
-#: ../src/command/video.cpp:262
-msgid "Shows video details"
+#: ../src/command/video.cpp:264
+#, fuzzy
+msgid "Show video details"
 msgstr "Zeigt die Videodetails an"
 
-#: ../src/command/video.cpp:273 ../src/command/video.cpp:274
+#: ../src/command/video.cpp:274 ../src/command/video.cpp:275
 msgid "Toggle video slider focus"
 msgstr "Wechsle Video-Schieberegeler"
 
-#: ../src/command/video.cpp:275
-msgid "Toggle focus between the video slider and other things"
+#: ../src/command/video.cpp:276
+#, fuzzy
+msgid ""
+"Toggle focus between the video slider and the previous thing to have focus"
 msgstr "Wechsle Fokus zwischen dem Videoschieberegler und anderen sachen"
 
-#: ../src/command/video.cpp:292 ../src/command/video.cpp:293
+#: ../src/command/video.cpp:297 ../src/command/video.cpp:298
 msgid "Copy image to Clipboard"
 msgstr "Bild in die Zwischenablage kopieren"
 
-#: ../src/command/video.cpp:294
+#: ../src/command/video.cpp:299
 msgid "Copy the currently displayed frame to the clipboard"
 msgstr "Kopiere den gerade angezeigten Frame in die Zwischenablage"
 
-#: ../src/command/video.cpp:304 ../src/command/video.cpp:305
+#: ../src/command/video.cpp:308 ../src/command/video.cpp:309
 msgid "Copy image to Clipboard (no subtitles)"
 msgstr "Bild in die Zwischenablage kopieren (ohne Untertitel)"
 
-#: ../src/command/video.cpp:306
+#: ../src/command/video.cpp:310
 msgid ""
 "Copy the currently displayed frame to the clipboard, without the subtitles"
 msgstr ""
 "Kopiere den gerade angezeigten Frame, ohne Untertitel, in die Zwischenablage"
 
-#: ../src/command/video.cpp:316 ../src/command/video.cpp:317
+#: ../src/command/video.cpp:319 ../src/command/video.cpp:320
 msgid "Next Frame"
 msgstr "Nächster Frame"
 
-#: ../src/command/video.cpp:318
+#: ../src/command/video.cpp:321
 msgid "Seek to the next frame"
 msgstr "Springe zum nächsten Frame"
 
-#: ../src/command/video.cpp:328 ../src/command/video.cpp:329
+#: ../src/command/video.cpp:330 ../src/command/video.cpp:331
 msgid "Next Boundary"
 msgstr "Nächste Grenze"
 
-#: ../src/command/video.cpp:330
-msgid "Seek to the next subtitle boundary"
+#: ../src/command/video.cpp:332
+#, fuzzy
+msgid "Seek to the next beginning or end of a subtitle"
 msgstr "Springe zur nächsten Untertitelgrenze"
 
-#: ../src/command/video.cpp:358 ../src/command/video.cpp:359
+#: ../src/command/video.cpp:359 ../src/command/video.cpp:360
 msgid "Next Keyframe"
 msgstr "Nächster Keyframe"
 
-#: ../src/command/video.cpp:360
+#: ../src/command/video.cpp:361
 msgid "Seek to the next keyframe"
 msgstr "Springe zum nächsten Keyframe"
 
@@ -1916,50 +1080,51 @@ msgstr "Springe zum nächsten Keyframe"
 msgid "Fast jump forward"
 msgstr "Schnell vorwärts springen"
 
-#: ../src/command/video.cpp:387 ../src/command/video.cpp:388
+#: ../src/command/video.cpp:386 ../src/command/video.cpp:387
 msgid "Previous Frame"
 msgstr "Vorheriger Frame"
 
-#: ../src/command/video.cpp:389
+#: ../src/command/video.cpp:388
 msgid "Seek to the previous frame"
 msgstr "Springe zum vorherigen Frame"
 
-#: ../src/command/video.cpp:399 ../src/command/video.cpp:400
+#: ../src/command/video.cpp:397 ../src/command/video.cpp:398
 msgid "Previous Boundary"
 msgstr "Vorherige Grenze"
 
-#: ../src/command/video.cpp:401
-msgid "Seek to the previous subtitle boundary"
+#: ../src/command/video.cpp:399
+#, fuzzy
+msgid "Seek to the previous beginning or end of a subtitle"
 msgstr "Springe zur vorherigen Untertitelgrenze"
 
-#: ../src/command/video.cpp:429 ../src/command/video.cpp:430
+#: ../src/command/video.cpp:426 ../src/command/video.cpp:427
 msgid "Previous Keyframe"
 msgstr "Vorheriger Keyframe"
 
-#: ../src/command/video.cpp:431
+#: ../src/command/video.cpp:428
 msgid "Seek to the previous keyframe"
 msgstr "Springe zum vorherigen Keyframe"
 
-#: ../src/command/video.cpp:453 ../src/command/video.cpp:454
-#: ../src/command/video.cpp:455
+#: ../src/command/video.cpp:448 ../src/command/video.cpp:449
+#: ../src/command/video.cpp:450
 msgid "Fast jump backwards"
 msgstr "Schneller Sprung zurück"
 
-#: ../src/command/video.cpp:502 ../src/command/video.cpp:503
+#: ../src/command/video.cpp:499 ../src/command/video.cpp:500
 msgid "Save PNG snapshot"
 msgstr "Bild als .png speichern"
 
-#: ../src/command/video.cpp:504
+#: ../src/command/video.cpp:501
 msgid ""
 "Save the currently displayed frame to a PNG file in the video's directory"
 msgstr ""
 "Speichere den gerade angezeigten Frame als .png-Bild im Ordner des Videos"
 
-#: ../src/command/video.cpp:514 ../src/command/video.cpp:515
+#: ../src/command/video.cpp:510 ../src/command/video.cpp:511
 msgid "Save PNG snapshot (no subtitles)"
 msgstr "Bild als .png speichern (ohne Untertitel)"
 
-#: ../src/command/video.cpp:516
+#: ../src/command/video.cpp:512
 msgid ""
 "Save the currently displayed frame without the subtitles to a PNG file in "
 "the video's directory"
@@ -1967,112 +1132,108 @@ msgstr ""
 "Speichere den gerade angezeigten Frame ohne Untertitel als .png-Datei im "
 "Ordner des Videos"
 
-#: ../src/command/video.cpp:526
+#: ../src/command/video.cpp:522
 msgid "&Jump to..."
 msgstr "&Springe zu..."
 
-#: ../src/command/video.cpp:527 ../src/dialog_jumpto.cpp:52
-msgid "Jump to"
-msgstr "Springe zu"
-
-#: ../src/command/video.cpp:528
+#: ../src/command/video.cpp:524
 msgid "Jump to frame or time"
 msgstr "Springt zu einem Frame oder zu einer Zeit"
 
-#: ../src/command/video.cpp:542
+#: ../src/command/video.cpp:536
 msgid "Jump Video to &End"
 msgstr "Video: ans Ende springen"
 
-#: ../src/command/video.cpp:543
+#: ../src/command/video.cpp:537
 msgid "Jump Video to End"
 msgstr "Video: ans Ende springen"
 
-#: ../src/command/video.cpp:544
-msgid "Jumps the video to the end frame of current subtitle"
+#: ../src/command/video.cpp:538
+#, fuzzy
+msgid "Jump the video to the end frame of current subtitle"
 msgstr "Springt mit dem Video zum Ende des aktuellen Untertitels"
 
-#: ../src/command/video.cpp:556
+#: ../src/command/video.cpp:549
 msgid "Jump Video to &Start"
 msgstr "Video: an den Anfang springen"
 
-#: ../src/command/video.cpp:557
+#: ../src/command/video.cpp:550
 msgid "Jump Video to Start"
 msgstr "Video: an den Anfang springen"
 
-#: ../src/command/video.cpp:558
-msgid "Jumps the video to the start frame of current subtitle"
+#: ../src/command/video.cpp:551
+#, fuzzy
+msgid "Jump the video to the start frame of current subtitle"
 msgstr "Springt mit dem Video zum Anfang des aktuellen Untertitels"
 
-#: ../src/command/video.cpp:569
+#: ../src/command/video.cpp:562
 msgid "&Open Video..."
 msgstr "Ö&ffne Video..."
 
-#: ../src/command/video.cpp:570
+#: ../src/command/video.cpp:563
 msgid "Open Video"
 msgstr "Öffne Video"
 
-#: ../src/command/video.cpp:571
-msgid "Opens a video file"
+#: ../src/command/video.cpp:564
+#, fuzzy
+msgid "Open a video file"
 msgstr "Öffnet eine Videodatei"
 
-#: ../src/command/video.cpp:574 ../src/command/audio.cpp:92
+#: ../src/command/video.cpp:567 ../src/command/audio.cpp:83
 msgid "Video Formats"
 msgstr "Videoformate"
 
-#: ../src/command/video.cpp:575 ../src/command/help.cpp:94
-#: ../src/command/keyframe.cpp:81 ../src/command/timecode.cpp:79
-#: ../src/command/timecode.cpp:99 ../src/command/audio.cpp:93
-#: ../src/auto4_base.cpp:506
-msgid "All Files"
-msgstr "Alle Dateien"
-
-#: ../src/command/video.cpp:576
+#: ../src/command/video.cpp:569
 msgid "Open video file"
 msgstr "Videodatei öffnen"
 
-#: ../src/command/video.cpp:585
+#: ../src/command/video.cpp:578
 msgid "&Use Dummy Video..."
 msgstr "Benutze Dummy-Video..."
 
-#: ../src/command/video.cpp:586
+#: ../src/command/video.cpp:579
 msgid "Use Dummy Video"
 msgstr "Benutze Dummy-Video"
 
-#: ../src/command/video.cpp:587
-msgid "Opens a video clip with solid color"
+#: ../src/command/video.cpp:580
+#, fuzzy
+msgid "Open a placeholder video clip with solid color"
 msgstr "Öffnet einen einfarbigen Videoclip"
 
-#: ../src/command/video.cpp:599 ../src/command/video.cpp:600
-#: ../src/command/video.cpp:601
+#: ../src/command/video.cpp:592 ../src/command/video.cpp:593
 msgid "Toggle autoscroll of video"
 msgstr "Automatisches Scrollen des Videos ein-/ausschalten"
 
-#: ../src/command/video.cpp:616 ../src/command/video.cpp:617
+#: ../src/command/video.cpp:594
+msgid "Toggle automatically seeking video to the start time of selected lines"
+msgstr ""
+
+#: ../src/command/video.cpp:609 ../src/command/video.cpp:610
 msgid "Play"
 msgstr "Wiedergabe"
 
-#: ../src/command/video.cpp:618
+#: ../src/command/video.cpp:611
 msgid "Play video starting on this position"
 msgstr "Video ab dieser Position abspielen"
 
-#: ../src/command/video.cpp:628 ../src/command/video.cpp:629
+#: ../src/command/video.cpp:621 ../src/command/video.cpp:622
 msgid "Play line"
 msgstr "Zeile abspielen"
 
-#: ../src/command/video.cpp:630 ../src/command/audio.cpp:247
-#: ../src/command/audio.cpp:248 ../src/command/audio.cpp:249
+#: ../src/command/video.cpp:623 ../src/command/audio.cpp:260
+#: ../src/command/audio.cpp:261
 msgid "Play current line"
 msgstr "Aktuelle Zeile abspielen"
 
-#: ../src/command/video.cpp:640
+#: ../src/command/video.cpp:632
 msgid "Show &Overscan Mask"
 msgstr "Zeige Overscan-Maske an"
 
-#: ../src/command/video.cpp:641
+#: ../src/command/video.cpp:633
 msgid "Show Overscan Mask"
 msgstr "Zeige Overscan-Maske an"
 
-#: ../src/command/video.cpp:642
+#: ../src/command/video.cpp:634
 msgid ""
 "Show a mask over the video, indicating areas that might get cropped off by "
 "overscan on televisions"
@@ -2080,395 +1241,405 @@ msgstr ""
 "Legt eine Maske übers Video, um die Bereiche, die beim Fernseher nicht "
 "sichtbar sind, anzuzeigen"
 
-#: ../src/command/video.cpp:659
+#: ../src/command/video.cpp:650
 msgid "&100%"
 msgstr "&100%"
 
-#: ../src/command/video.cpp:660
+#: ../src/command/video.cpp:651
 msgid "100%"
 msgstr "100%"
 
-#: ../src/command/video.cpp:661
+#: ../src/command/video.cpp:652
 msgid "Set zoom to 100%"
 msgstr "Setzt den Zoom auf 100%"
 
-#: ../src/command/video.cpp:678 ../src/command/video.cpp:679
+#: ../src/command/video.cpp:669 ../src/command/video.cpp:670
 msgid "Stop video"
 msgstr "Stoppe Video"
 
-#: ../src/command/video.cpp:680
+#: ../src/command/video.cpp:671
 msgid "Stop video playback"
 msgstr "Stoppe Abspielen"
 
-#: ../src/command/video.cpp:691
+#: ../src/command/video.cpp:681
 msgid "&200%"
 msgstr "&200%"
 
-#: ../src/command/video.cpp:692
+#: ../src/command/video.cpp:682
 msgid "200%"
 msgstr "200%"
 
-#: ../src/command/video.cpp:693
+#: ../src/command/video.cpp:683
 msgid "Set zoom to 200%"
 msgstr "Setzt den Zoom auf 200%"
 
-#: ../src/command/video.cpp:710
+#: ../src/command/video.cpp:699
 msgid "&50%"
 msgstr "&50%"
 
-#: ../src/command/video.cpp:711
+#: ../src/command/video.cpp:700
 msgid "50%"
 msgstr "50%"
 
-#: ../src/command/video.cpp:712
+#: ../src/command/video.cpp:701
 msgid "Set zoom to 50%"
 msgstr "Setzt den Zoom auf 50%"
 
-#: ../src/command/video.cpp:728 ../src/command/video.cpp:729
+#: ../src/command/video.cpp:717 ../src/command/video.cpp:718
 msgid "Zoom In"
 msgstr "Hereinzoomen"
 
-#: ../src/command/video.cpp:730
+#: ../src/command/video.cpp:719
 msgid "Zoom video in"
 msgstr "Video hereinzoomen"
 
-#: ../src/command/video.cpp:740 ../src/command/video.cpp:741
+#: ../src/command/video.cpp:729 ../src/command/video.cpp:730
 msgid "Zoom Out"
 msgstr "Herauszoomen"
 
-#: ../src/command/video.cpp:742
+#: ../src/command/video.cpp:731
 msgid "Zoom video out"
 msgstr "Video herauszoomen"
 
-#: ../src/command/edit.cpp:130
+#: ../src/command/edit.cpp:131 ../src/command/edit.cpp:831
 msgid "paste"
 msgstr "Einfügen"
 
-#: ../src/command/edit.cpp:306 ../src/command/edit.cpp:308
+#: ../src/command/edit.cpp:369
 msgid "set color"
 msgstr "Farbe wählen"
 
-#: ../src/command/edit.cpp:318
+#: ../src/command/edit.cpp:383
 msgid "Primary Color..."
 msgstr "Primäre Farbe..."
 
-#: ../src/command/edit.cpp:319
+#: ../src/command/edit.cpp:384
 msgid "Primary Color"
 msgstr "Primäre Farbe"
 
-#: ../src/command/edit.cpp:320
+#: ../src/command/edit.cpp:385
 msgid "Set the primary fill color (\\c) at the cursor position"
 msgstr "Primäre Füllfarbe (\\c) an der Cursorposition einstellen"
 
-#: ../src/command/edit.cpp:329
+#: ../src/command/edit.cpp:395
 msgid "Secondary Color..."
 msgstr "Sekundäre Farbe..."
 
-#: ../src/command/edit.cpp:330
+#: ../src/command/edit.cpp:396
 msgid "Secondary Color"
 msgstr "Sekundäre Farbe"
 
-#: ../src/command/edit.cpp:331
+#: ../src/command/edit.cpp:397
 msgid "Set the secondary (karaoke) fill color (\\2c) at the cursor position"
 msgstr "Sekundäre (Karaoke) Füllfarbe (\\2c) an der Cursorposition einstellen"
 
-#: ../src/command/edit.cpp:340
+#: ../src/command/edit.cpp:407
 msgid "Outline Color..."
 msgstr "Umrandungsfarbe..."
 
-#: ../src/command/edit.cpp:341
+#: ../src/command/edit.cpp:408
 msgid "Outline Color"
 msgstr "Umrandungsfarbe"
 
-#: ../src/command/edit.cpp:342
+#: ../src/command/edit.cpp:409
 msgid "Set the outline color (\\3c) at the cursor position"
 msgstr "Umrandungsfarbe (\\3c) an der Cursorposition einstellen"
 
-#: ../src/command/edit.cpp:351
+#: ../src/command/edit.cpp:419
 msgid "Shadow Color..."
 msgstr "Schattenfarbe..."
 
-#: ../src/command/edit.cpp:352
+#: ../src/command/edit.cpp:420
 msgid "Shadow Color"
 msgstr "Schattenfarbe"
 
-#: ../src/command/edit.cpp:353
+#: ../src/command/edit.cpp:421
 msgid "Set the shadow color (\\4c) at the cursor position"
 msgstr "Schattenfarbe (\\4c) an der Cursorposition einstellen"
 
-#: ../src/command/edit.cpp:362 ../src/command/edit.cpp:363
+#: ../src/command/edit.cpp:431 ../src/command/edit.cpp:432
 msgid "Toggle Bold"
 msgstr "Fett ein/aus"
 
-#: ../src/command/edit.cpp:364
+#: ../src/command/edit.cpp:433
 msgid ""
 "Toggle bold (\\b) for the current selection or at the current cursor position"
 msgstr "Fett (\\b) ein/aus für aktuelle Auswahl oder Cursorposition"
 
-#: ../src/command/edit.cpp:367
+#: ../src/command/edit.cpp:436
 msgid "toggle bold"
 msgstr "Fett ein/aus"
 
-#: ../src/command/edit.cpp:373 ../src/command/edit.cpp:374
+#: ../src/command/edit.cpp:443 ../src/command/edit.cpp:444
 msgid "Toggle Italics"
 msgstr "Kursiv ein/aus"
 
-#: ../src/command/edit.cpp:375
+#: ../src/command/edit.cpp:445
 msgid ""
 "Toggle italics (\\i) for the current selection or at the current cursor "
 "position"
 msgstr "Kursiv (\\i) ein/aus für aktuelle Auswahl oder Cursorposition"
 
-#: ../src/command/edit.cpp:378
+#: ../src/command/edit.cpp:448
 msgid "toggle italic"
 msgstr "Kursiv ein/aus"
 
-#: ../src/command/edit.cpp:384 ../src/command/edit.cpp:385
+#: ../src/command/edit.cpp:455 ../src/command/edit.cpp:456
 msgid "Toggle Underline"
 msgstr "Unterstrichen ein/aus"
 
-#: ../src/command/edit.cpp:386
+#: ../src/command/edit.cpp:457
 msgid ""
 "Toggle underline (\\u) for the current selection or at the current cursor "
 "position"
 msgstr "Unterstrichen (\\u) ein/aus für aktuelle Auswahl oder Cursorposition"
 
-#: ../src/command/edit.cpp:389
+#: ../src/command/edit.cpp:460
 msgid "toggle underline"
 msgstr "Unterstrichen ein/aus"
 
-#: ../src/command/edit.cpp:395 ../src/command/edit.cpp:396
+#: ../src/command/edit.cpp:467 ../src/command/edit.cpp:468
 msgid "Toggle Strikeout"
 msgstr "Durchgestrichen ein/aus"
 
-#: ../src/command/edit.cpp:397
+#: ../src/command/edit.cpp:469
 msgid ""
 "Toggle strikeout (\\s) for the current selection or at the current cursor "
 "position"
 msgstr "Durchgestrichen (\\s) ein/aus für aktuelle Auswahl oder Cursorposition"
 
-#: ../src/command/edit.cpp:400
+#: ../src/command/edit.cpp:472
 msgid "toggle strikeout"
 msgstr "Durchgestrichen ein/aus"
 
-#: ../src/command/edit.cpp:406
+#: ../src/command/edit.cpp:479
 msgid "Font Face..."
 msgstr "Schriftart"
 
-#: ../src/command/edit.cpp:408
+#: ../src/command/edit.cpp:480 ../src/preferences_base.cpp:251
+msgid "Font Face"
+msgstr "Schriftart"
+
+#: ../src/command/edit.cpp:481
 msgid "Select a font face and size"
 msgstr "Schriftart und Größe auswählen"
 
-#: ../src/command/edit.cpp:445
+#: ../src/command/edit.cpp:508
 msgid "set font"
 msgstr "Schriftart festlegen"
 
-#: ../src/command/edit.cpp:452
+#: ../src/command/edit.cpp:535
 msgid "Find and R&eplace..."
 msgstr "Suchen und &Ersetzen..."
 
-#: ../src/command/edit.cpp:453
+#: ../src/command/edit.cpp:536
 msgid "Find and Replace"
 msgstr "Suchen und &Ersetzen"
 
-#: ../src/command/edit.cpp:454
+#: ../src/command/edit.cpp:537
 msgid "Find and replace words in subtitles"
 msgstr "Suche und ersetze Wörter in den Untertiteln"
 
-#: ../src/command/edit.cpp:516
+#: ../src/command/edit.cpp:598
 msgid "&Copy Lines"
 msgstr "Kopiere Zeilen"
 
-#: ../src/command/edit.cpp:517
+#: ../src/command/edit.cpp:599
 msgid "Copy Lines"
 msgstr "Kopiere Zeilen"
 
-#: ../src/command/edit.cpp:518
-msgid "Copy subtitles"
-msgstr "Kopiere Untertitel"
+#: ../src/command/edit.cpp:600
+#, fuzzy
+msgid "Copy subtitles to the clipboard"
+msgstr "Bild in die Zwischenablage kopieren"
 
-#: ../src/command/edit.cpp:539
+#: ../src/command/edit.cpp:621
 msgid "Cu&t Lines"
 msgstr "Zeilen ausschneiden"
 
-#: ../src/command/edit.cpp:540
+#: ../src/command/edit.cpp:622
 msgid "Cut Lines"
 msgstr "Zeilen ausschneiden"
 
-#: ../src/command/edit.cpp:541
+#: ../src/command/edit.cpp:623
 msgid "Cut subtitles"
 msgstr "Untertitel ausschneiden"
 
-#: ../src/command/edit.cpp:548
+#: ../src/command/edit.cpp:630
 msgid "cut lines"
 msgstr "Zeilen ausschneiden"
 
-#: ../src/command/edit.cpp:556
+#: ../src/command/edit.cpp:638
 msgid "De&lete Lines"
 msgstr "Zeilen löschen"
 
-#: ../src/command/edit.cpp:557
+#: ../src/command/edit.cpp:639
 msgid "Delete Lines"
 msgstr "Zeilen löschen"
 
-#: ../src/command/edit.cpp:558
+#: ../src/command/edit.cpp:640
 msgid "Delete currently selected lines"
 msgstr "Lösche die ausgewählte(n) Zeile(n)"
 
-#: ../src/command/edit.cpp:561
+#: ../src/command/edit.cpp:643
 msgid "delete lines"
 msgstr "Zeilen löschen"
 
-#: ../src/command/edit.cpp:609
+#: ../src/command/edit.cpp:708 ../src/command/edit.cpp:1093
+msgid "split"
+msgstr "Splitten"
+
+#: ../src/command/edit.cpp:708
 msgid "duplicate lines"
 msgstr "Zeilen &Duplizieren"
 
-#: ../src/command/edit.cpp:617
+#: ../src/command/edit.cpp:715
 msgid "&Duplicate Lines"
 msgstr "Zeilen &Duplizieren"
 
-#: ../src/command/edit.cpp:618
+#: ../src/command/edit.cpp:716
 msgid "Duplicate Lines"
 msgstr "Zeilen &Duplizieren"
 
-#: ../src/command/edit.cpp:619
+#: ../src/command/edit.cpp:717
 msgid "Duplicate the selected lines"
 msgstr "Markierte Zeilen duplizieren"
 
-#: ../src/command/edit.cpp:629
-msgid "D&uplicate and Shift by 1 Frame"
-msgstr "&Duplizieren und um 1 Frame verschieben"
+#: ../src/command/edit.cpp:726 ../src/command/edit.cpp:727
+#, fuzzy
+msgid "Split lines after current frame"
+msgstr "Zeile nach der aktuellen einfügen"
 
-#: ../src/command/edit.cpp:630
-msgid "Duplicate and Shift by 1 Frame"
-msgstr "&Duplizieren und um 1 Frame verschieben"
-
-#: ../src/command/edit.cpp:631
+#: ../src/command/edit.cpp:728
 msgid ""
-"Duplicate lines and shift them to the frame after the original end frame"
+"Split the current line into a line which ends on the current frame and a "
+"line which starts on the next frame"
 msgstr ""
-"Zeilen duplizieren und zum Frame nach dem ursprünglichen End-Frame "
-"verschieben"
 
-#: ../src/command/edit.cpp:649
-msgid "Du&plicate and Shift by 1 Frame Backwards"
-msgstr "Du&plizieren und um 1 Frame rückwärts verschieben"
+#: ../src/command/edit.cpp:738 ../src/command/edit.cpp:739
+#, fuzzy
+msgid "Split lines before current frame"
+msgstr "Zeile vor aktueller einfügen"
 
-#: ../src/command/edit.cpp:650
-msgid "Duplicate and Shift by 1 Frame Backwards"
-msgstr "Duplizieren und um 1 Frame rückwärts verschieben"
-
-#: ../src/command/edit.cpp:651
+#: ../src/command/edit.cpp:740
 msgid ""
-"Duplicate selected lines and shift them to the frame before the original "
-"start frame"
+"Split the current line into a line which ends on the previous frame and a "
+"line which starts on the current frame"
 msgstr ""
-"Ausgewählte Zeilen duplizieren und auf den Frame vor dem ursprünglichen "
-"Anfangs-Frame verschieben"
 
-#: ../src/command/edit.cpp:704
+#: ../src/command/edit.cpp:775
 msgid "As &Karaoke"
 msgstr "Als Karaoke"
 
-#: ../src/command/edit.cpp:705
+#: ../src/command/edit.cpp:776
 msgid "As Karaoke"
 msgstr "Als Karaoke"
 
-#: ../src/command/edit.cpp:706
-msgid "Joins selected lines in a single one, as karaoke"
+#: ../src/command/edit.cpp:777
+#, fuzzy
+msgid "Join selected lines in a single one, as karaoke"
 msgstr "Fügt die markierten Zeilen zu einer zusammen (als Karaoke)"
 
-#: ../src/command/edit.cpp:709
+#: ../src/command/edit.cpp:780
 msgid "join as karaoke"
 msgstr "Zusammenfügen (als Karaoke)"
 
-#: ../src/command/edit.cpp:717
+#: ../src/command/edit.cpp:786
 msgid "&Concatenate"
 msgstr "&Zusammenfügen (verbinden)"
 
-#: ../src/command/edit.cpp:718
+#: ../src/command/edit.cpp:787
 msgid "Concatenate"
 msgstr "&Zusammenfügen (verbinden)"
 
-#: ../src/command/edit.cpp:719
-msgid "Joins selected lines in a single one, concatenating text together"
+#: ../src/command/edit.cpp:788
+#, fuzzy
+msgid "Join selected lines in a single one, concatenating text together"
 msgstr ""
 "Fügt die ausgewählten Zeilen zu einer einzigen zusammen, der Text wird "
 "aneinandergehängt"
 
-#: ../src/command/edit.cpp:722 ../src/command/edit.cpp:735
+#: ../src/command/edit.cpp:791 ../src/command/edit.cpp:802
 msgid "join lines"
 msgstr "Zeilen zusammenfügen"
 
-#: ../src/command/edit.cpp:730
+#: ../src/command/edit.cpp:797
 msgid "Keep &First"
 msgstr "Erhalte erste"
 
-#: ../src/command/edit.cpp:731
+#: ../src/command/edit.cpp:798
 msgid "Keep First"
 msgstr "Erhalte erste"
 
-#: ../src/command/edit.cpp:732
+#: ../src/command/edit.cpp:799
+#, fuzzy
 msgid ""
-"Joins selected lines in a single one, keeping text of first and discarding "
+"Join selected lines in a single one, keeping text of first and discarding "
 "remaining"
 msgstr ""
 "Fügt die ausgewählten Zeilen zu einer, erhält den ersten Text und verwirft "
 "den restlichen"
 
-#: ../src/command/edit.cpp:742
+#: ../src/command/edit.cpp:840
 msgid "&Paste Lines"
 msgstr "Zeilen einfügen"
 
-#: ../src/command/edit.cpp:743
+#: ../src/command/edit.cpp:841
 msgid "Paste Lines"
 msgstr "Zeilen einfügen"
 
-#: ../src/command/edit.cpp:744
+#: ../src/command/edit.cpp:842
 msgid "Paste subtitles"
 msgstr "Fügt Untertitel ein"
 
-#: ../src/command/edit.cpp:772
+#: ../src/command/edit.cpp:871
 msgid "Paste Lines &Over..."
 msgstr "Zeilen überschreiben..."
 
-#: ../src/command/edit.cpp:773
+#: ../src/command/edit.cpp:872
 msgid "Paste Lines Over"
 msgstr "Zeilen überschreiben..."
 
-#: ../src/command/edit.cpp:774
+#: ../src/command/edit.cpp:873
 msgid "Paste subtitles over others"
 msgstr "Fügt Untertitel über den anderen ein"
 
-#: ../src/command/edit.cpp:865
+#: ../src/command/edit.cpp:956
 msgid "Recom&bine Lines"
 msgstr "Zeilen kombinieren"
 
-#: ../src/command/edit.cpp:866
+#: ../src/command/edit.cpp:957
 msgid "Recombine Lines"
 msgstr "Zeilen kombinieren"
 
-#: ../src/command/edit.cpp:867
-msgid "Recombine subtitles when they have been split and merged"
+#: ../src/command/edit.cpp:958
+#, fuzzy
+msgid "Recombine subtitles which have been split and merged"
 msgstr "Untertitel kombinieren, wenn sie aufgeteilt und zusammengeführt wurden"
 
-#: ../src/command/edit.cpp:934
+#: ../src/command/edit.cpp:1028
 msgid "combining"
 msgstr "kombinieren"
 
-#: ../src/command/edit.cpp:942 ../src/command/edit.cpp:943
+#: ../src/command/edit.cpp:1034 ../src/command/edit.cpp:1035
 msgid "Split Lines (by karaoke)"
 msgstr "Auftrennen (entlang Karaoke)"
 
-#: ../src/command/edit.cpp:944
-msgid "Uses karaoke timing to split line into multiple smaller lines"
+#: ../src/command/edit.cpp:1036
+#, fuzzy
+msgid "Use karaoke timing to split line into multiple smaller lines"
 msgstr "Nutzt Karaoketiming, um die Zeilen in viele kürzere Zeilen zu splitten"
 
-#: ../src/command/edit.cpp:967
-msgid "split"
+#: ../src/command/edit.cpp:1070
+msgid "splitting"
 msgstr "Splitten"
 
-#: ../src/command/edit.cpp:974
+#: ../src/command/edit.cpp:1098 ../src/command/edit.cpp:1099
+#: ../src/subs_edit_ctrl.cpp:375
+msgid "Split at cursor (estimate times)"
+msgstr "Bei Cursor auftrennen (Zeiten annähern)"
+
+#: ../src/command/edit.cpp:1100
 msgid ""
 "Split the current line at the cursor, dividing the original line's duration "
 "between the new ones"
@@ -2476,7 +1647,12 @@ msgstr ""
 "Aktuelle Zeile am Cursor aufteilen und die ursprüngliche Zeitdauer zwischen "
 "den neuen Zeilen auteilen"
 
-#: ../src/command/edit.cpp:985
+#: ../src/command/edit.cpp:1114 ../src/command/edit.cpp:1115
+#: ../src/subs_edit_ctrl.cpp:374
+msgid "Split at cursor (preserve times)"
+msgstr "Bei Cursor auftrennen (Zeiten erhalten)"
+
+#: ../src/command/edit.cpp:1116
 msgid ""
 "Split the current line at the cursor, setting both lines to the original "
 "line's times"
@@ -2484,833 +1660,1417 @@ msgstr ""
 "Aktuelle Zeile am Cursor aufteilen und beide Zeilen auf die ursprüngliche "
 "Zeitdauer setzen"
 
-#: ../src/command/edit.cpp:995
-msgid "Redoes last action"
+#: ../src/command/edit.cpp:1125 ../src/command/edit.cpp:1126
+#, fuzzy
+msgid "Split at cursor (at video frame)"
+msgstr "Bei Cursor auftrennen (Zeiten annähern)"
+
+#: ../src/command/edit.cpp:1127
+#, fuzzy
+msgid ""
+"Split the current line at the cursor, dividing the line's duration at the "
+"current video frame"
+msgstr ""
+"Aktuelle Zeile am Cursor aufteilen und die ursprüngliche Zeitdauer zwischen "
+"den neuen Zeilen auteilen"
+
+#: ../src/command/edit.cpp:1143
+#, fuzzy
+msgid "Redo last undone action"
 msgstr "Wiederholt die letzte rückgängig gemachte Aktion"
 
-#: ../src/command/edit.cpp:1000
+#: ../src/command/edit.cpp:1148
 msgid "Nothing to &redo"
 msgstr "Nichts zum Wiederholen"
 
-#: ../src/command/edit.cpp:1001
+#: ../src/command/edit.cpp:1149
 #, c-format
 msgid "&Redo %s"
 msgstr "Wiederholen %s"
 
-#: ../src/command/edit.cpp:1005
+#: ../src/command/edit.cpp:1153
 msgid "Nothing to redo"
 msgstr "Nichts zum Wiederholen"
 
-#: ../src/command/edit.cpp:1006
+#: ../src/command/edit.cpp:1154
 #, c-format
 msgid "Redo %s"
 msgstr "Wiederholen %s"
 
-#: ../src/command/edit.cpp:1021
-msgid "Undoes last action"
+#: ../src/command/edit.cpp:1169
+#, fuzzy
+msgid "Undo last action"
 msgstr "Macht die letzte Aktion rückgängig"
 
-#: ../src/command/edit.cpp:1026
+#: ../src/command/edit.cpp:1174
 msgid "Nothing to &undo"
 msgstr "Nichts zum Rückgängig machen"
 
-#: ../src/command/edit.cpp:1027
+#: ../src/command/edit.cpp:1175
 #, c-format
 msgid "&Undo %s"
 msgstr "&Rückgängig %s"
 
-#: ../src/command/edit.cpp:1031
+#: ../src/command/edit.cpp:1179
 msgid "Nothing to undo"
 msgstr "Nichts zum Rückgängig machen"
 
-#: ../src/command/edit.cpp:1032
+#: ../src/command/edit.cpp:1180
 #, c-format
 msgid "Undo %s"
 msgstr "Rückgängig: %s"
 
-#: ../src/command/edit.cpp:1046 ../src/command/edit.cpp:1047
+#: ../src/command/edit.cpp:1194 ../src/command/edit.cpp:1195
 msgid "Revert"
 msgstr "Wiederherstellen"
 
-#: ../src/command/edit.cpp:1048
+#: ../src/command/edit.cpp:1196
 msgid "Revert the active line to its initial state (shown in the upper editor)"
 msgstr ""
 "Ursprungszustand der aktiven Zeile wiederherstellen (im oberen Fenster "
 "angezeigt)"
 
-#: ../src/command/edit.cpp:1053
+#: ../src/command/edit.cpp:1201
 msgid "revert line"
 msgstr "Zeile wiederherstellen"
 
-#: ../src/command/edit.cpp:1061
+#: ../src/command/edit.cpp:1207 ../src/command/edit.cpp:1208
+#: ../src/preferences.cpp:389
+msgid "Clear"
+msgstr "Löschen"
+
+#: ../src/command/edit.cpp:1209
 msgid "Clear the current line's text"
 msgstr "Text der aktuellen Zeile löschen"
 
-#: ../src/command/edit.cpp:1066 ../src/command/edit.cpp:1084
+#: ../src/command/edit.cpp:1214 ../src/command/edit.cpp:1233
 msgid "clear line"
 msgstr "Zeile löschen"
 
-#: ../src/command/edit.cpp:1073 ../src/command/edit.cpp:1074
+#: ../src/command/edit.cpp:1221 ../src/command/edit.cpp:1222
 msgid "Clear Text"
 msgstr "Text löschen"
 
-#: ../src/command/edit.cpp:1075
+#: ../src/command/edit.cpp:1223
 msgid "Clear the current line's text, leaving override tags"
 msgstr "Text der aktuellen Zeile löschen, Tags dabei stehen lassen"
 
-#: ../src/command/edit.cpp:1090 ../src/command/edit.cpp:1091
-#: ../src/command/tool.cpp:292
+#: ../src/command/edit.cpp:1239 ../src/command/edit.cpp:1240
+#: ../src/command/tool.cpp:271
 msgid "Insert Original"
 msgstr "Original einfügen"
 
-#: ../src/command/edit.cpp:1092
+#: ../src/command/edit.cpp:1241
 msgid "Insert the original line text at the cursor"
 msgstr "Text der ursprünglichen Zeile beim Cursor einfügen"
 
-#: ../src/command/edit.cpp:1100
+#: ../src/command/edit.cpp:1249
 msgid "insert original"
 msgstr "Original einfügen"
 
-#: ../src/command/vis_tool.cpp:64 ../src/command/vis_tool.cpp:65
-msgid "Standard"
-msgstr "Standard"
+#: ../src/command/recent.cpp:43 ../src/command/recent.cpp:44
+#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:46
+#: ../src/command/recent.cpp:47 ../src/command/recent.cpp:51
+#: ../src/command/recent.cpp:52 ../src/command/recent.cpp:62
+#: ../src/command/recent.cpp:63 ../src/command/recent.cpp:73
+#: ../src/command/recent.cpp:74 ../src/command/recent.cpp:85
+#: ../src/command/recent.cpp:86 ../src/command/recent.cpp:96
+#: ../src/command/recent.cpp:97
+msgid "Recent"
+msgstr "Zuletzt geöffnet"
 
-#: ../src/command/vis_tool.cpp:66
-msgid "Standard mode, double click sets position"
-msgstr "Standardmodus, Doppelklick setzt Position"
+#: ../src/command/recent.cpp:43 ../src/command/recent.cpp:53
+msgid "Open recent audio"
+msgstr "Letzte Audiodatei öffnen"
 
-#: ../src/command/vis_tool.cpp:73
-msgid "Drag subtitles"
-msgstr "Untertitel ziehen (mit der Maus)"
+#: ../src/command/recent.cpp:44 ../src/command/recent.cpp:64
+msgid "Open recent keyframes"
+msgstr "Letzte Keyframes öffnen"
 
-#: ../src/command/vis_tool.cpp:78 ../src/command/vis_tool.cpp:79
-msgid "Rotate Z"
-msgstr "Rotiere Z"
+#: ../src/command/recent.cpp:45 ../src/command/recent.cpp:75
+msgid "Open recent subtitles"
+msgstr "Letzte Untertitel öffnen"
 
-#: ../src/command/vis_tool.cpp:80
-msgid "Rotate subtitles on their Z axis"
-msgstr "Rotiert Untertitel um die Z-Achse"
+#: ../src/command/recent.cpp:46 ../src/command/recent.cpp:87
+msgid "Open recent timecodes"
+msgstr "Zeitcode-Datei öffnen"
 
-#: ../src/command/vis_tool.cpp:85 ../src/command/vis_tool.cpp:86
-msgid "Rotate XY"
-msgstr "Rotiere XY"
+#: ../src/command/recent.cpp:47
+msgid "Open recent video"
+msgstr "Letztes Video öffnen"
 
-#: ../src/command/vis_tool.cpp:87
-msgid "Rotate subtitles on their X and Y axes"
-msgstr "Rotiert Untertitel um die X- und Y-Achse"
+#: ../src/command/recent.cpp:98
+msgid "Open recent videos"
+msgstr "Letzte Videos öffnen"
 
-#: ../src/command/vis_tool.cpp:92 ../src/command/vis_tool.cpp:93
-msgid "Scale"
-msgstr "Skalieren"
+#: ../src/command/subtitle.cpp:78
+msgid "A&ttachments..."
+msgstr "&Anhänge..."
 
-#: ../src/command/vis_tool.cpp:94
-msgid "Scale subtitles on X and Y axes"
-msgstr "Skaliere Untertitel auf der X- und Y-Achse"
+#: ../src/command/subtitle.cpp:79
+msgid "Attachments"
+msgstr "Anhänge"
 
-#: ../src/command/vis_tool.cpp:99 ../src/command/vis_tool.cpp:100
-msgid "Clip"
-msgstr "Beschneiden"
+#: ../src/command/subtitle.cpp:80
+#, fuzzy
+msgid "Open the attachment manager dialog"
+msgstr "Öffnet die Liste der Anhänge"
 
-#: ../src/command/vis_tool.cpp:101
-msgid "Clip subtitles to a rectangle"
-msgstr "Untertitel mit Rechteck beschneiden"
+#: ../src/command/subtitle.cpp:91
+msgid "&Find..."
+msgstr "&Suchen..."
 
-#: ../src/command/vis_tool.cpp:106 ../src/command/vis_tool.cpp:107
-msgid "Vector Clip"
-msgstr "Vektor-Beschneiden"
+#: ../src/command/subtitle.cpp:92 ../src/dialog_search_replace.cpp:46
+msgid "Find"
+msgstr "Suchen"
 
-#: ../src/command/vis_tool.cpp:108
-msgid "Clip subtitles to a vectorial area"
-msgstr "Untertitel mit Vektorgrafik beschneiden"
+#: ../src/command/subtitle.cpp:93
+#, fuzzy
+msgid "Search for text in the subtitles"
+msgstr "Zeige alle Tags im Untertitelgitter"
 
-#: ../src/command/help.cpp:58
-msgid "&Bug Tracker..."
-msgstr "&Bugtracker..."
+#: ../src/command/subtitle.cpp:104
+msgid "Find &Next"
+msgstr "Nächstes Vorkommen"
 
-#: ../src/command/help.cpp:59
-msgid "Bug Tracker"
-msgstr "Bugtracker"
+#: ../src/command/subtitle.cpp:105
+msgid "Find Next"
+msgstr "Nächstes Vorkommen"
 
-#: ../src/command/help.cpp:60
-msgid "Visit Aegisub's bug tracker to report bugs and request new features"
+#: ../src/command/subtitle.cpp:106
+#, fuzzy
+msgid "Find next match of last search"
+msgstr "Suche nächstes Vorkommen der letzten Suchanfrage"
+
+#: ../src/command/subtitle.cpp:126 ../src/command/subtitle.cpp:160
+#: ../src/command/subtitle.cpp:202 ../src/command/grid.cpp:82
+msgid "line insertion"
+msgstr "Zeile einfügen"
+
+#: ../src/command/subtitle.cpp:133
+msgid "&After Current"
+msgstr "Nach aktueller"
+
+#: ../src/command/subtitle.cpp:134
+msgid "After Current"
+msgstr "Nach aktueller"
+
+#: ../src/command/subtitle.cpp:135
+#, fuzzy
+msgid "Insert a new line after the current one"
+msgstr "Zeile nach der aktuellen einfügen"
+
+#: ../src/command/subtitle.cpp:167 ../src/command/subtitle.cpp:168
+msgid "After Current, at Video Time"
+msgstr "Nach aktueller, bei Videozeit"
+
+#: ../src/command/subtitle.cpp:169
+#, fuzzy
+msgid "Insert a new line after the current one, starting at video time"
+msgstr "Fügt eine Zeile nach der aktuellen ein (ab aktueller Videozeit)"
+
+#: ../src/command/subtitle.cpp:178
+msgid "&Before Current"
+msgstr "Vor aktueller"
+
+#: ../src/command/subtitle.cpp:179
+msgid "Before Current"
+msgstr "Vor aktueller"
+
+#: ../src/command/subtitle.cpp:180
+#, fuzzy
+msgid "Insert a new line before the current one"
+msgstr "Zeile vor aktueller einfügen"
+
+#: ../src/command/subtitle.cpp:209 ../src/command/subtitle.cpp:210
+msgid "Before Current, at Video Time"
+msgstr "Vor aktueller, bei Videozeit"
+
+#: ../src/command/subtitle.cpp:211
+#, fuzzy
+msgid "Insert a new line before the current one, starting at video time"
+msgstr "Fügt eine Zeile vor der aktuellen ein (ab aktueller Videozeit)"
+
+#: ../src/command/subtitle.cpp:221
+msgid "&New Subtitles"
+msgstr "&Neue Untertitel"
+
+#: ../src/command/subtitle.cpp:222
+msgid "New Subtitles"
+msgstr "&Neue Untertitel"
+
+#: ../src/command/subtitle.cpp:223
+msgid "New subtitles"
+msgstr "Neue Untertitel"
+
+#: ../src/command/subtitle.cpp:234
+msgid "&Open Subtitles..."
+msgstr "Ö&ffne Untertitel..."
+
+#: ../src/command/subtitle.cpp:235
+msgid "Open Subtitles"
+msgstr "Öffne Untertitel"
+
+#: ../src/command/subtitle.cpp:236
+#, fuzzy
+msgid "Open a subtitles file"
+msgstr "Öffnet eine Untertitel-Datei"
+
+#: ../src/command/subtitle.cpp:248
+msgid "Open A&utosaved Subtitles..."
+msgstr "Ö&ffne Autosave-Untertitel..."
+
+#: ../src/command/subtitle.cpp:249
+msgid "Open Autosaved Subtitles"
+msgstr "Öffne Autosave-Untertitel"
+
+#: ../src/command/subtitle.cpp:250
+msgid "Open a previous version of a file which was autosaved by Aegisub"
 msgstr ""
-"Besuchen Sie Aegisubs Bugtracker, um einen Bug oder gewünschte Features zu "
-"melden"
+"Öffne eine vorherige Version einer Datei, die von Aegisub automatisch "
+"gespeichert wurde."
 
-#: ../src/command/help.cpp:80
-msgid "&Contents"
-msgstr "&Inhalt"
+#: ../src/command/subtitle.cpp:263
+msgid "Open Subtitles with &Charset..."
+msgstr "Öffne Untertitel mit &Zeichensatz"
 
-#: ../src/command/help.cpp:81
-msgid "Contents"
-msgstr "Inhalt"
+#: ../src/command/subtitle.cpp:264
+msgid "Open Subtitles with Charset"
+msgstr "Öffne Untertitel mit &Zeichensatz"
 
-#: ../src/command/help.cpp:82
-msgid "Help topics"
-msgstr "Hilfethemen"
+#: ../src/command/subtitle.cpp:265
+#, fuzzy
+msgid "Open a subtitles file with a specific file encoding"
+msgstr "Öffnet eine Untertitel-Datei mit einem bestimmten Zeichensatz"
 
-#: ../src/command/help.cpp:93
-msgid "All Fil&es"
-msgstr "Alle Dateien"
+#: ../src/command/subtitle.cpp:273
+msgid "Choose charset code:"
+msgstr "Zeichensatz auswählen:"
 
-#: ../src/command/help.cpp:95
-msgid "Resource files"
-msgstr "Ressourcen-Dateien"
+#: ../src/command/subtitle.cpp:273
+msgid "Charset"
+msgstr "Zeichensatz"
 
-#: ../src/command/help.cpp:106
-msgid "&Forums"
-msgstr "&Forum"
+#: ../src/command/subtitle.cpp:282
+msgid "Open Subtitles from &Video"
+msgstr "Öffne Untertitel vom &Video"
 
-#: ../src/command/help.cpp:107
-msgid "Forums"
-msgstr "Forum"
+#: ../src/command/subtitle.cpp:283
+msgid "Open Subtitles from Video"
+msgstr "Öffne Untertitel vom Video"
 
-#: ../src/command/help.cpp:108
-msgid "Visit Aegisub's forums"
-msgstr "Aegisubs Forum öffnen"
+#: ../src/command/subtitle.cpp:284
+#, fuzzy
+msgid "Open the subtitles from the current video file"
+msgstr "Öffnet die Untertitel der aktuellen Videodatei"
 
-#: ../src/command/help.cpp:119
-msgid "&IRC Channel"
-msgstr "&Irc-Kanal"
+#: ../src/command/subtitle.cpp:300
+msgid "&Properties..."
+msgstr "&Eigenschaften..."
 
-#: ../src/command/help.cpp:120
-msgid "IRC Channel"
-msgstr "Irc-Kanal"
+#: ../src/command/subtitle.cpp:301
+msgid "Properties"
+msgstr "Eigenschaften"
 
-#: ../src/command/help.cpp:121
-msgid "Visit Aegisub's official IRC channel"
-msgstr "Aegisubs offiziellen Irc-Channel öffnen"
+#: ../src/command/subtitle.cpp:302
+msgid "Open script properties window"
+msgstr "Öffnet den Skripteigenschaften-Dialog"
 
-#: ../src/command/help.cpp:131
-msgid "&Visual Typesetting"
-msgstr "Visuelles Typesetting"
+#: ../src/command/subtitle.cpp:313
+msgid "Save subtitles file"
+msgstr "Untertiteldatei speichern"
 
-#: ../src/command/help.cpp:132
-msgid "Visual Typesetting"
-msgstr "Visuelles Typesetting"
+#: ../src/command/subtitle.cpp:333
+msgid "&Save Subtitles"
+msgstr "&Speichere Untertitel"
 
-#: ../src/command/help.cpp:133
-msgid "Open the manual page for Visual Typesetting"
-msgstr "Öffne die Handbuchseite für Visuelles Typesetting"
+#: ../src/command/subtitle.cpp:334
+msgid "Save Subtitles"
+msgstr "&Speichere Untertitel"
 
-#: ../src/command/help.cpp:143
-msgid "&Website"
-msgstr "&Webseite"
+#: ../src/command/subtitle.cpp:335
+#, fuzzy
+msgid "Save the current subtitles"
+msgstr "Letzte Untertitel öffnen"
 
-#: ../src/command/help.cpp:144
-msgid "Website"
-msgstr "Webseite"
+#: ../src/command/subtitle.cpp:350
+msgid "Save Subtitles &as..."
+msgstr "Speichere Untertitel unter..."
 
-#: ../src/command/help.cpp:145
-msgid "Visit Aegisub's official website"
-msgstr "Aegisubs offizielle Webseite öffnen"
+#: ../src/command/subtitle.cpp:351
+msgid "Save Subtitles as"
+msgstr "Speichere Untertitel unter..."
 
-#: ../src/command/time.cpp:114
+#: ../src/command/subtitle.cpp:352
+#, fuzzy
+msgid "Save subtitles with another name"
+msgstr "Speichert die Untertitel-Datei unter anderem Namen"
+
+#: ../src/command/subtitle.cpp:361 ../src/dialog_selected_choices.cpp:26
+#: ../src/subs_edit_ctrl.cpp:369 ../src/dialog_export.cpp:125
+msgid "Select &All"
+msgstr "Alles aus&wählen"
+
+#: ../src/command/subtitle.cpp:362
+msgid "Select All"
+msgstr "Alles aus&wählen"
+
+#: ../src/command/subtitle.cpp:363
+#, fuzzy
+msgid "Select all dialogue lines"
+msgstr "Wähle alle Dialogzeilen aus"
+
+#: ../src/command/subtitle.cpp:375 ../src/command/subtitle.cpp:376
+msgid "Select Visible"
+msgstr "Sichtbare auswählen"
+
+#: ../src/command/subtitle.cpp:377
+#, fuzzy
+msgid "Select all dialogue lines that are visible on the current video frame"
+msgstr "Wählt alle Zeilen aus, die im aktuellen Videoframe sichtbar sind"
+
+#: ../src/command/subtitle.cpp:407
+msgid "Spell &Checker..."
+msgstr "&Rechtschreibprüfung..."
+
+#: ../src/command/subtitle.cpp:408 ../src/dialog_spellchecker.cpp:103
+msgid "Spell Checker"
+msgstr "Rechtschreibprüfung"
+
+#: ../src/command/subtitle.cpp:409
+msgid "Open spell checker"
+msgstr "Öffnet die Rechtschreibprüfung"
+
+#: ../src/command/tool.cpp:58
+msgid "ASSDraw3..."
+msgstr "AssDraw3..."
+
+#: ../src/command/tool.cpp:59
+msgid "ASSDraw3"
+msgstr "AssDraw3"
+
+#: ../src/command/tool.cpp:60
+#, fuzzy
+msgid "Launch the ASSDraw3 tool for vector drawing"
+msgstr "Startet das AssDraw3-Werkzeug für Vektorgrafik"
+
+#: ../src/command/tool.cpp:70
+msgid "&Export Subtitles..."
+msgstr "Exportiere Untertitel..."
+
+#: ../src/command/tool.cpp:71
+msgid "Export Subtitles"
+msgstr "Exportiere Untertitel..."
+
+#: ../src/command/tool.cpp:72
+#, fuzzy
+msgid ""
+"Save a copy of subtitles in a different format or with processing applied to "
+"it"
+msgstr "Speichert eine nachbearbeitete Kopie der Untertitel"
+
+#: ../src/command/tool.cpp:83
+msgid "&Fonts Collector..."
+msgstr "&Schriftartensammlung..."
+
+#: ../src/command/tool.cpp:84 ../src/dialog_fonts_collector.cpp:218
+msgid "Fonts Collector"
+msgstr "Schriftartensammlung"
+
+#: ../src/command/tool.cpp:85
+msgid "Open fonts collector"
+msgstr "Öffnet die Schriftartensammlung"
+
+#: ../src/command/tool.cpp:95
+msgid "S&elect Lines..."
+msgstr "Zeilen auswählen..."
+
+#: ../src/command/tool.cpp:96
+msgid "Select Lines"
+msgstr "Zeilen auswählen"
+
+#: ../src/command/tool.cpp:97
+#, fuzzy
+msgid "Select lines based on defined criteria"
+msgstr "Wählt Zeilen nach bestimmten Kriterien aus"
+
+#: ../src/command/tool.cpp:107
+msgid "&Resample Resolution..."
+msgstr "Auflösung anpassen..."
+
+#: ../src/command/tool.cpp:108 ../src/dialog_resample.cpp:90
+msgid "Resample Resolution"
+msgstr "Auflösung anpassen"
+
+#: ../src/command/tool.cpp:109
+msgid ""
+"Resample subtitles to maintain their current appearance at a different "
+"script resolution"
+msgstr ""
+
+#: ../src/command/tool.cpp:122
+msgid "St&yling Assistant..."
+msgstr "Stil-Assistent..."
+
+#: ../src/command/tool.cpp:124
+msgid "Open styling assistant"
+msgstr "Öffnet den Stil-Assistenten"
+
+#: ../src/command/tool.cpp:141 ../src/command/tool.cpp:225
+msgid "&Accept changes"
+msgstr "Änderungen übernehmen"
+
+#: ../src/command/tool.cpp:143 ../src/command/tool.cpp:227
+msgid "Commit changes and move to the next line"
+msgstr "Änderungen anwenden und zur nächsten Zeile gehen"
+
+#: ../src/command/tool.cpp:152 ../src/command/tool.cpp:236
+msgid "&Preview changes"
+msgstr "Vorschau"
+
+#: ../src/command/tool.cpp:154 ../src/command/tool.cpp:238
+msgid "Commit changes and stay on the current line"
+msgstr "Änderungen anwenden und in der aktuellen Zeile bleiben"
+
+#: ../src/command/tool.cpp:164
+msgid "&Styles Manager..."
+msgstr "&Stil-Manager..."
+
+#: ../src/command/tool.cpp:166
+#, fuzzy
+msgid "Open the styles manager"
+msgstr "Öffnet den Stil-Manager"
+
+#: ../src/command/tool.cpp:176
+msgid "&Kanji Timer..."
+msgstr "Kanji-Timer..."
+
+#: ../src/command/tool.cpp:177
+msgid "Kanji Timer"
+msgstr "Kanji-Timer"
+
+#: ../src/command/tool.cpp:178
+#, fuzzy
+msgid "Open the Kanji timer copier"
+msgstr "Öffne Kanji-Timer"
+
+#: ../src/command/tool.cpp:188
+msgid "&Timing Post-Processor..."
+msgstr "Timingnachbearbeitung..."
+
+#: ../src/command/tool.cpp:190
+#, fuzzy
+msgid ""
+"Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
+"to scene changes, etc."
+msgstr ""
+"Startet eine Timingnachbearbeitung, die Einlaufbereiche, Auslaufbereiche, "
+"Szenen-Timing usw. übernimmt."
+
+#: ../src/command/tool.cpp:200
+msgid "&Translation Assistant..."
+msgstr "&Übersetzungsassistent..."
+
+#: ../src/command/tool.cpp:201 ../src/dialog_translation.cpp:64
+msgid "Translation Assistant"
+msgstr "Übersetzungsassistent"
+
+#: ../src/command/tool.cpp:202
+msgid "Open translation assistant"
+msgstr "Öffnet den Übersetzungsassistenten"
+
+#: ../src/command/tool.cpp:210
+msgid "There is nothing to translate in the file."
+msgstr "In der Datei ist nichts zu übersetzen."
+
+#: ../src/command/tool.cpp:247
+msgid "&Next Line"
+msgstr "Nächste Zeile"
+
+#: ../src/command/tool.cpp:248 ../src/command/grid.cpp:51
+#: ../src/command/grid.cpp:52 ../src/command/grid.cpp:63
+#: ../src/command/grid.cpp:64 ../src/command/time.cpp:354
+#: ../src/command/time.cpp:355
+msgid "Next Line"
+msgstr "Nächste Zeile"
+
+#: ../src/command/tool.cpp:249
+msgid "Move to the next line without committing changes"
+msgstr "Zur nächsten Zeile gehen, Änderungen verwerfen"
+
+#: ../src/command/tool.cpp:258
+msgid "&Previous Line"
+msgstr "Vorherige Zeile"
+
+#: ../src/command/tool.cpp:259 ../src/command/grid.cpp:90
+#: ../src/command/grid.cpp:91 ../src/command/time.cpp:366
+#: ../src/command/time.cpp:367
+msgid "Previous Line"
+msgstr "Vorherige Zeile"
+
+#: ../src/command/tool.cpp:260
+msgid "Move to the previous line without committing changes"
+msgstr "Zur vorherigen Zeile gehen, Änderungen verwerfen"
+
+#: ../src/command/tool.cpp:270
+msgid "&Insert Original"
+msgstr "Original einfügen"
+
+#: ../src/command/tool.cpp:272
+msgid "Insert the untranslated text"
+msgstr "Einfügen des unübersetzten Textes"
+
+#: ../src/command/app.cpp:58
+msgid "&About"
+msgstr "&Über..."
+
+#: ../src/command/app.cpp:59
+msgid "About"
+msgstr "Über..."
+
+#: ../src/command/app.cpp:60 ../src/dialog_about.cpp:44
+msgid "About Aegisub"
+msgstr "Über Aegisub"
+
+#: ../src/command/app.cpp:69
+msgid "&Audio+Subs View"
+msgstr "Audio+Untertitel anzeigen"
+
+#: ../src/command/app.cpp:70
+msgid "Audio+Subs View"
+msgstr "Audio+Untertitel anzeigen"
+
+#: ../src/command/app.cpp:71
+#, fuzzy
+msgid "Display audio and the subtitles grid only"
+msgstr "Zeigt Untertitel und Audiofenster an"
+
+#: ../src/command/app.cpp:89
+msgid "&Full view"
+msgstr "Volle Ansicht"
+
+#: ../src/command/app.cpp:90
+msgid "Full view"
+msgstr "Volle Ansicht"
+
+#: ../src/command/app.cpp:91
+#, fuzzy
+msgid "Display audio, video and then subtitles grid"
+msgstr "Zeigt Audio, Video und Untertitel an"
+
+#: ../src/command/app.cpp:109
+msgid "S&ubs Only View"
+msgstr "Nur Untertitel anzeigen"
+
+#: ../src/command/app.cpp:110
+msgid "Subs Only View"
+msgstr "Nur Untertitel anzeigen"
+
+#: ../src/command/app.cpp:111
+#, fuzzy
+msgid "Display the subtitles grid only"
+msgstr "Zeigt nur die Untertitel an"
+
+#: ../src/command/app.cpp:125
+msgid "&Video+Subs View"
+msgstr "Video+Untertitel anzeigen"
+
+#: ../src/command/app.cpp:126
+msgid "Video+Subs View"
+msgstr "Video+Untertitel"
+
+#: ../src/command/app.cpp:127
+#, fuzzy
+msgid "Display video and the subtitles grid only"
+msgstr "Zeigt nur Untertitel und Videofenster an"
+
+#: ../src/command/app.cpp:145
+msgid "E&xit"
+msgstr "&Beenden"
+
+#: ../src/command/app.cpp:146
+msgid "Exit"
+msgstr "Beenden"
+
+#: ../src/command/app.cpp:147
+msgid "Exit the application"
+msgstr "Beendet Aegisub"
+
+#: ../src/command/app.cpp:157
+msgid "&Language..."
+msgstr "&Sprache... (Language)"
+
+#: ../src/command/app.cpp:158
+msgid "Language"
+msgstr "Sprache"
+
+#: ../src/command/app.cpp:159
+msgid "Select Aegisub interface language"
+msgstr "Sprache für Aegisub auswählen"
+
+#: ../src/command/app.cpp:182
+msgid "&Log window"
+msgstr "Logbuchfenster"
+
+#: ../src/command/app.cpp:183 ../src/dialog_log.cpp:99
+msgid "Log window"
+msgstr "Logbuchfenster"
+
+#: ../src/command/app.cpp:184
+msgid "View the event log"
+msgstr "Zeige das Ereignisprotokoll"
+
+#: ../src/command/app.cpp:194
+msgid "New &Window"
+msgstr "Neues Fenster"
+
+#: ../src/command/app.cpp:195
+msgid "New Window"
+msgstr "Neues Fenster"
+
+#: ../src/command/app.cpp:196
+msgid "Open a new application window"
+msgstr "Öffne ein neues Programmfenster"
+
+#: ../src/command/app.cpp:206
+msgid "&Options..."
+msgstr "Einstellungen"
+
+#: ../src/command/app.cpp:208
+msgid "Configure Aegisub"
+msgstr "Aegisub einrichten"
+
+#: ../src/command/app.cpp:222 ../src/command/app.cpp:223
+msgid "Toggle global hotkey overrides"
+msgstr "Globale Hotkeys umschalten"
+
+#: ../src/command/app.cpp:224
+#, fuzzy
+msgid "Toggle global hotkey overrides (Medusa Mode)"
+msgstr "Globale Hotkeys umschalten"
+
+#: ../src/command/app.cpp:239
+msgid "Toggle the main toolbar"
+msgstr "Hauptwerkzeugleiste ein/aus"
+
+#: ../src/command/app.cpp:244
+msgid "Hide Toolbar"
+msgstr "Werkzeugleiste ausblenden"
+
+#: ../src/command/app.cpp:245
+msgid "Show Toolbar"
+msgstr "Werkzeugleiste einblenden"
+
+#: ../src/command/app.cpp:260
+msgid "&Check for Updates..."
+msgstr "Auf Updates überprüfen..."
+
+#: ../src/command/app.cpp:261
+msgid "Check for Updates"
+msgstr "Auf Updates überprüfen"
+
+#: ../src/command/app.cpp:262
+msgid "Check to see if there is a new version of Aegisub available"
+msgstr "Überprüfen, ob eine neue Version von Aegisub verfügbar ist"
+
+#: ../src/command/grid.cpp:53
+msgid "Move to the next subtitle line"
+msgstr "Gehe zur nächsten Untertitelzeile"
+
+#: ../src/command/grid.cpp:65
+msgid "Move to the next subtitle line, creating a new one if needed"
+msgstr "Gehe zur nächsten Untertitelzeile und erzeuge eine neue, falls nötig"
+
+#: ../src/command/grid.cpp:92
+msgid "Move to the previous line"
+msgstr "Gehe zur vorherige Zeile"
+
+#: ../src/command/grid.cpp:101 ../src/command/grid.cpp:121
+msgid "&Actor Name"
+msgstr "Sprecher"
+
+#: ../src/command/grid.cpp:102 ../src/command/grid.cpp:122
+msgid "Actor Name"
+msgstr "Sprecher"
+
+#: ../src/command/grid.cpp:103
+msgid "Sort all subtitles by their actor names"
+msgstr "Sortiert alle Untertitel nach ihren Sprechernamen"
+
+#: ../src/command/grid.cpp:107 ../src/command/grid.cpp:127
+#: ../src/command/grid.cpp:139 ../src/command/grid.cpp:151
+#: ../src/command/grid.cpp:163 ../src/command/grid.cpp:175
+#: ../src/command/grid.cpp:187 ../src/command/grid.cpp:199
+#: ../src/command/grid.cpp:211 ../src/command/grid.cpp:223
+#: ../src/command/grid.cpp:235 ../src/command/grid.cpp:247
+msgid "sort"
+msgstr "Sortieren"
+
+#: ../src/command/grid.cpp:123
+msgid "Sort selected subtitles by their actor names"
+msgstr "Sortiert markierte Untertitel nach ihren Sprechernamen"
+
+#: ../src/command/grid.cpp:133 ../src/command/grid.cpp:145
+#: ../src/dialog_search_replace.cpp:87
+msgid "&Effect"
+msgstr "Effekt"
+
+#: ../src/command/grid.cpp:134 ../src/command/grid.cpp:146
+#: ../src/dialog_paste_over.cpp:72 ../src/subs_edit_box.cpp:145
+#: ../src/grid_column.cpp:191 ../src/grid_column.cpp:192
+msgid "Effect"
+msgstr "Effekt"
+
+#: ../src/command/grid.cpp:135
+msgid "Sort all subtitles by their effects"
+msgstr "Sortiert alle Untertitel nach ihren Effekten"
+
+#: ../src/command/grid.cpp:147
+msgid "Sort selected subtitles by their effects"
+msgstr "Sortiert markierte Untertitel nach ihren Effekten"
+
+#: ../src/command/grid.cpp:157 ../src/command/grid.cpp:169
+msgid "&End Time"
+msgstr "Endzeit"
+
+#: ../src/command/grid.cpp:158 ../src/command/grid.cpp:170
+#: ../src/dialog_paste_over.cpp:66 ../src/grid_column.cpp:147
+msgid "End Time"
+msgstr "Endzeit"
+
+#: ../src/command/grid.cpp:159
+msgid "Sort all subtitles by their end times"
+msgstr "Sortiert alle Untertitel nach ihren Endzeiten"
+
+#: ../src/command/grid.cpp:171
+msgid "Sort selected subtitles by their end times"
+msgstr "Sortiert markierte Untertitel nach ihren Endzeiten"
+
+#: ../src/command/grid.cpp:181 ../src/command/grid.cpp:193
+msgid "&Layer"
+msgstr "Ebene"
+
+#: ../src/command/grid.cpp:182 ../src/command/grid.cpp:194
+#: ../src/dialog_paste_over.cpp:64 ../src/grid_column.cpp:107
+msgid "Layer"
+msgstr "Ebene"
+
+#: ../src/command/grid.cpp:183
+msgid "Sort all subtitles by their layer number"
+msgstr "Sortiert alle Untertitel nach ihren Ebenennummern"
+
+#: ../src/command/grid.cpp:195
+msgid "Sort selected subtitles by their layer number"
+msgstr "Sortiert markierte Untertitel nach ihren Ebenennummern"
+
+#: ../src/command/grid.cpp:205 ../src/command/grid.cpp:217
+msgid "&Start Time"
+msgstr "Startzeit"
+
+#: ../src/command/grid.cpp:206 ../src/command/grid.cpp:218
+#: ../src/dialog_paste_over.cpp:65 ../src/grid_column.cpp:129
+msgid "Start Time"
+msgstr "Startzeit"
+
+#: ../src/command/grid.cpp:207
+msgid "Sort all subtitles by their start times"
+msgstr "Sortiert alle Untertitel nach ihren Startzeiten"
+
+#: ../src/command/grid.cpp:219
+msgid "Sort selected subtitles by their start times"
+msgstr "Sortiert markierte Untertitel nach ihren Startzeiten"
+
+#: ../src/command/grid.cpp:229 ../src/command/grid.cpp:241
+msgid "St&yle Name"
+msgstr "Stilname"
+
+#: ../src/command/grid.cpp:230 ../src/command/grid.cpp:242
+#: ../src/dialog_style_editor.cpp:177
+msgid "Style Name"
+msgstr "Stilname"
+
+#: ../src/command/grid.cpp:231
+msgid "Sort all subtitles by their style names"
+msgstr "Sortiert alle Untertitel nach ihren Stilnamen"
+
+#: ../src/command/grid.cpp:243
+msgid "Sort selected subtitles by their style names"
+msgstr "Sortiert markierte Untertitel nach ihren Stilnamen"
+
+#: ../src/command/grid.cpp:254 ../src/command/grid.cpp:255
+msgid "Cycle Tag Hiding Mode"
+msgstr "Tag-Anzeigemodi durchlaufen"
+
+#: ../src/command/grid.cpp:256
+msgid "Cycle through tag hiding modes"
+msgstr "Durchlaufe Modi der Tag-Anzeige"
+
+#: ../src/command/grid.cpp:266
+msgid "ASS Override Tag mode set to show full tags."
+msgstr "ass-Tag-Modus auf 'alle Tags' setzen."
+
+#: ../src/command/grid.cpp:267
+msgid "ASS Override Tag mode set to simplify tags."
+msgstr "ass-Tag-Modus auf 'einfache Tags' setzen."
+
+#: ../src/command/grid.cpp:268
+msgid "ASS Override Tag mode set to hide tags."
+msgstr "ass-Tag-Modus auf 'Tags verstecken' setzen."
+
+#: ../src/command/grid.cpp:278
+msgid "&Hide Tags"
+msgstr "Tags verstecken"
+
+#: ../src/command/grid.cpp:279
+msgid "Hide Tags"
+msgstr "Tags verstecken"
+
+#: ../src/command/grid.cpp:280
+msgid "Hide override tags in the subtitle grid"
+msgstr "Verstecke Tags im Untertitelgitter"
+
+#: ../src/command/grid.cpp:294
+msgid "Sh&ow Tags"
+msgstr "Tags anzeigen"
+
+#: ../src/command/grid.cpp:295
+msgid "Show Tags"
+msgstr "Tags anzeigen"
+
+#: ../src/command/grid.cpp:296
+msgid "Show full override tags in the subtitle grid"
+msgstr "Zeige alle Tags im Untertitelgitter"
+
+#: ../src/command/grid.cpp:310
+msgid "S&implify Tags"
+msgstr "Einfache Tags"
+
+#: ../src/command/grid.cpp:311
+msgid "Simplify Tags"
+msgstr "Einfache Tags"
+
+#: ../src/command/grid.cpp:312
+msgid ""
+"Replace override tags in the subtitle grid with a simplified placeholder"
+msgstr "Ersetze die Tags im Untertitelgitter durch einen einfachen Platzhalter"
+
+#: ../src/command/grid.cpp:348 ../src/command/grid.cpp:349
+msgid "Move line up"
+msgstr "Verschiebe Zeile nach oben"
+
+#: ../src/command/grid.cpp:350
+msgid "Move the selected lines up one row"
+msgstr "Verschiebe die ausgewählten Zeilen um eine Zeile nach oben"
+
+#: ../src/command/grid.cpp:359 ../src/command/grid.cpp:376
+msgid "move lines"
+msgstr "Zeilen verschieben"
+
+#: ../src/command/grid.cpp:365 ../src/command/grid.cpp:366
+msgid "Move line down"
+msgstr "Verschiebe Zeile nach unten"
+
+#: ../src/command/grid.cpp:367
+msgid "Move the selected lines down one row"
+msgstr "Verschiebe die ausgewählten Zeilen um eine Zeile nach unten"
+
+#: ../src/command/grid.cpp:383 ../src/command/grid.cpp:384
+msgid "Swap Lines"
+msgstr "Zeilen vertauschen"
+
+#: ../src/command/grid.cpp:385
+#, fuzzy
+msgid "Swap the two selected lines"
+msgstr "Vertauscht die ausgewählten Zeilen miteinander"
+
+#: ../src/command/grid.cpp:396
+msgid "swap lines"
+msgstr "Zeilen vertauschen"
+
+#: ../src/command/automation.cpp:48
+msgid "&Reload Automation scripts"
+msgstr "Automatisierungs-Skripte neu laden"
+
+#: ../src/command/automation.cpp:49
+msgid "Reload Automation scripts"
+msgstr "Automatisierungs-Skripte neu laden"
+
+#: ../src/command/automation.cpp:50
+msgid "Reload all Automation scripts and rescan the autoload folder"
+msgstr ""
+"Alle Automatisierungs-Skripte neu laden und den Autom.-Laden-Ordner neu "
+"prüfen"
+
+#: ../src/command/automation.cpp:55
+msgid "Reloaded all Automation scripts"
+msgstr "Alle Automatisierungs-Skripte neu geladen"
+
+#: ../src/command/automation.cpp:61
+msgid "R&eload autoload Automation scripts"
+msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+
+#: ../src/command/automation.cpp:62
+msgid "Reload autoload Automation scripts"
+msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+
+#: ../src/command/automation.cpp:63
+msgid "Rescan the Automation autoload folder"
+msgstr "Autom.-Laden-Ordner neu prüfen"
+
+#: ../src/command/automation.cpp:67
+msgid "Reloaded autoload Automation scripts"
+msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
+
+#: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
+msgid "&Automation..."
+msgstr "&Automatisierung..."
+
+#: ../src/command/automation.cpp:75 ../src/command/automation.cpp:87
+#: ../src/preferences.cpp:314
+msgid "Automation"
+msgstr "Automatisierung"
+
+#: ../src/command/automation.cpp:76
+msgid "Open automation manager"
+msgstr "Öffnet den Automatisierungs-Manager"
+
+#: ../src/command/automation.cpp:88
+msgid ""
+"Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
+"autoload folder and reload all automation scripts"
+msgstr ""
+
+#: ../src/command/time.cpp:99
 msgid "adjoin"
 msgstr "grenzt an"
 
-#: ../src/command/time.cpp:120
+#: ../src/command/time.cpp:104
 msgid "Change &End"
 msgstr "Ändere Ende"
 
-#: ../src/command/time.cpp:121
+#: ../src/command/time.cpp:105
 msgid "Change End"
 msgstr "Ändere Ende"
 
-#: ../src/command/time.cpp:122
-msgid "Changes times of subs so end times begin on next's start time"
+#: ../src/command/time.cpp:106
+#, fuzzy
+msgid "Change end times of lines to the next line's start time"
 msgstr ""
 "Ändert die Untertitelzeit so, daß die Endzeit auf die Anfangszeit des "
 "nächsten gesetzt wird"
 
-#: ../src/command/time.cpp:132
+#: ../src/command/time.cpp:115
 msgid "Change &Start"
 msgstr "Ändere Anfang"
 
-#: ../src/command/time.cpp:133
+#: ../src/command/time.cpp:116
 msgid "Change Start"
 msgstr "Ändere Anfang"
 
-#: ../src/command/time.cpp:134
-msgid "Changes times of subs so start times begin on previous's end time"
+#: ../src/command/time.cpp:117
+#, fuzzy
+msgid "Change start times of lines to the previous line's end time"
 msgstr ""
 "Ändert die Untertitelzeit so, daß die Anfangszeit auf die Endzeit des "
 "vorigen gesetzt wird"
 
-#: ../src/command/time.cpp:145
+#: ../src/command/time.cpp:127
 msgid "Shift to &Current Frame"
 msgstr "Verschiebe auf aktuellen Frame"
 
-#: ../src/command/time.cpp:146
+#: ../src/command/time.cpp:128
 msgid "Shift to Current Frame"
 msgstr "Verschiebe auf aktuellen Frame"
 
-#: ../src/command/time.cpp:147
+#: ../src/command/time.cpp:129
 msgid "Shift selection so that the active line starts at current frame"
 msgstr ""
 "Verschiebt die ausgewählten Zeilen, so daß die erste ausgewählte Zeile beim "
 "aktuellen Frame anfängt"
 
-#: ../src/command/time.cpp:165
+#: ../src/command/time.cpp:145
 msgid "shift to frame"
 msgstr "Um Frames verschieben"
 
-#: ../src/command/time.cpp:173
+#: ../src/command/time.cpp:152
 msgid "S&hift Times..."
 msgstr "Timings &verschieben..."
 
-#: ../src/command/time.cpp:174 ../src/dialog_shift_times.cpp:100
-msgid "Shift Times"
-msgstr "Timings verschieben"
-
-#: ../src/command/time.cpp:175
+#: ../src/command/time.cpp:154
 msgid "Shift subtitles by time or frames"
 msgstr "Verschiebt die Untertitel um eine Zeitdauer oder Frameanzahl"
 
-#: ../src/command/time.cpp:197 ../src/audio_timing_dialogue.cpp:553
-#: ../src/audio_timing_dialogue.cpp:559
+#: ../src/command/time.cpp:175 ../src/audio_timing_dialogue.cpp:512
+#: ../src/audio_timing_dialogue.cpp:518
 msgid "timing"
 msgstr "Timing"
 
-#: ../src/command/time.cpp:203
+#: ../src/command/time.cpp:181
 msgid "Snap &End to Video"
 msgstr "Ende auf Video setzen"
 
-#: ../src/command/time.cpp:204
+#: ../src/command/time.cpp:182
 msgid "Snap End to Video"
 msgstr "Ende auf Video setzen"
 
-#: ../src/command/time.cpp:205
+#: ../src/command/time.cpp:183
 msgid "Set end of selected subtitles to current video frame"
 msgstr "Setzt das Ende der ausgewählten Zeile auf den aktuellen Videoframe"
 
-#: ../src/command/time.cpp:215
+#: ../src/command/time.cpp:193
 msgid "Snap to S&cene"
 msgstr "Auf Szene einrasten"
 
-#: ../src/command/time.cpp:216
+#: ../src/command/time.cpp:194
 msgid "Snap to Scene"
 msgstr "Auf Szene einrasten"
 
-#: ../src/command/time.cpp:217
+#: ../src/command/time.cpp:195
 msgid ""
 "Set start and end of subtitles to the keyframes around current video frame"
 msgstr ""
 "Setzt Start- und Endzeit der Untertitel auf die Keyframes vor und nach dem "
 "aktuellen Frame"
 
-#: ../src/command/time.cpp:254
+#: ../src/command/time.cpp:232
 msgid "snap to scene"
 msgstr "Auf Szene einrasten"
 
-#: ../src/command/time.cpp:260 ../src/command/time.cpp:261
-#: ../src/command/time.cpp:262
+#: ../src/command/time.cpp:238 ../src/command/time.cpp:239
 msgid "Add lead in and out"
 msgstr "Ein- und Auslaufbereiche hinzufügen"
 
-#: ../src/command/time.cpp:273 ../src/command/time.cpp:274
-#: ../src/command/time.cpp:275
+#: ../src/command/time.cpp:240
+#, fuzzy
+msgid "Add both lead in and out to the selected lines"
+msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+
+#: ../src/command/time.cpp:252 ../src/command/time.cpp:253
 msgid "Add lead in"
 msgstr "Einlaufbereiche hinzufügen"
 
-#: ../src/command/time.cpp:284 ../src/command/time.cpp:285
-#: ../src/command/time.cpp:286
+#: ../src/command/time.cpp:254
+#, fuzzy
+msgid "Add the lead in time to the selected lines"
+msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+
+#: ../src/command/time.cpp:264 ../src/command/time.cpp:265
 msgid "Add lead out"
 msgstr "Auslaufbereiche hinzufügen"
 
-#: ../src/command/time.cpp:295 ../src/command/time.cpp:296
+#: ../src/command/time.cpp:266
+#, fuzzy
+msgid "Add the lead out time to the selected lines"
+msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+
+#: ../src/command/time.cpp:275 ../src/command/time.cpp:276
 msgid "Increase length"
 msgstr "Länge vergrößern"
 
-#: ../src/command/time.cpp:297
+#: ../src/command/time.cpp:277
 msgid "Increase the length of the current timing unit"
 msgstr "Vergrößere die Länge der aktuellen Zeiteinheit"
 
-#: ../src/command/time.cpp:306 ../src/command/time.cpp:307
+#: ../src/command/time.cpp:286 ../src/command/time.cpp:287
 msgid "Increase length and shift"
 msgstr "Vergrößere Länge und verschiebe"
 
-#: ../src/command/time.cpp:308
+#: ../src/command/time.cpp:288
 msgid ""
 "Increase the length of the current timing unit and shift the following items"
 msgstr ""
 "Vergrößere die Länge der aktuellen Zeiteinheit und verschiebe die folgenden "
 "Elemente"
 
-#: ../src/command/time.cpp:317 ../src/command/time.cpp:318
+#: ../src/command/time.cpp:297 ../src/command/time.cpp:298
 msgid "Decrease length"
 msgstr "Länge reduzieren"
 
-#: ../src/command/time.cpp:319
+#: ../src/command/time.cpp:299
 msgid "Decrease the length of the current timing unit"
 msgstr "Reduziere die Länge der aktuellen Zeiteinheit"
 
-#: ../src/command/time.cpp:328 ../src/command/time.cpp:329
+#: ../src/command/time.cpp:308 ../src/command/time.cpp:309
 msgid "Decrease length and shift"
 msgstr "Reduziere Länge und verschiebe"
 
-#: ../src/command/time.cpp:330
+#: ../src/command/time.cpp:310
 msgid ""
 "Decrease the length of the current timing unit and shift the following items"
 msgstr ""
 "Reduziere die Länge der aktuellen Zeiteinheit und verschiebe die folgenden "
 "Elemente"
 
-#: ../src/command/time.cpp:339 ../src/command/time.cpp:340
+#: ../src/command/time.cpp:319 ../src/command/time.cpp:320
 msgid "Shift start time forward"
 msgstr "Verschiebe die Startzeit nach vorne"
 
-#: ../src/command/time.cpp:341
+#: ../src/command/time.cpp:321
 msgid "Shift the start time of the current timing unit forward"
 msgstr "Verschiebe die Startzeit der aktuellen Zeiteinheit nach vorne"
 
-#: ../src/command/time.cpp:350 ../src/command/time.cpp:351
+#: ../src/command/time.cpp:330 ../src/command/time.cpp:331
 msgid "Shift start time backward"
 msgstr "Startzeit nach hinten verschieben"
 
-#: ../src/command/time.cpp:352
+#: ../src/command/time.cpp:332
 msgid "Shift the start time of the current timing unit backward"
 msgstr "Verschiebe die Startzeit der aktuellen Zeiteinheit nach hinten"
 
-#: ../src/command/time.cpp:362
+#: ../src/command/time.cpp:342
 msgid "Snap &Start to Video"
 msgstr "Anfang auf Video setzen"
 
-#: ../src/command/time.cpp:363
+#: ../src/command/time.cpp:343
 msgid "Snap Start to Video"
 msgstr "Anfang auf Video setzen"
 
-#: ../src/command/time.cpp:364
+#: ../src/command/time.cpp:344
 msgid "Set start of selected subtitles to current video frame"
 msgstr ""
 "Setze den Anfang der ausgewählten Untertitel auf den aktuellen Videoframe"
 
-#: ../src/command/time.cpp:376
+#: ../src/command/time.cpp:356
 msgid "Next line or syllable"
 msgstr "Nächste Zeile oder Silbe"
 
-#: ../src/command/time.cpp:388
+#: ../src/command/time.cpp:368
 msgid "Previous line or syllable"
 msgstr "Vorherige Zeile oder Silbe"
 
-#: ../src/command/keyframe.cpp:56 ../src/command/keyframe.cpp:57
-msgid "Close Keyframes"
-msgstr "Schließe Keyframe-Datei"
+#: ../src/command/vis_tool.cpp:56 ../src/command/vis_tool.cpp:57
+msgid "Standard"
+msgstr "Standard"
 
-#: ../src/command/keyframe.cpp:58
-msgid "Closes the currently open keyframes list"
-msgstr "Schließt die aktuelle Keyframe-Datei"
+#: ../src/command/vis_tool.cpp:58
+msgid "Standard mode, double click sets position"
+msgstr "Standardmodus, Doppelklick setzt Position"
 
-#: ../src/command/keyframe.cpp:73
-msgid "Open Keyframes..."
-msgstr "Öffne Keyframe-Datei..."
+#: ../src/command/vis_tool.cpp:64 ../src/command/vis_tool.cpp:65
+#: ../src/visual_tool_vector_clip.cpp:57
+msgid "Drag"
+msgstr "Ziehen"
 
-#: ../src/command/keyframe.cpp:74
-msgid "Open Keyframes"
-msgstr "Öffne Keyframe-Datei..."
+#: ../src/command/vis_tool.cpp:66
+msgid "Drag subtitles"
+msgstr "Untertitel ziehen (mit der Maus)"
 
-#: ../src/command/keyframe.cpp:75
-msgid "Opens a keyframe list file"
-msgstr "Öffnet eine Keyframe-Datei"
+#: ../src/command/vis_tool.cpp:72 ../src/command/vis_tool.cpp:73
+msgid "Rotate Z"
+msgstr "Rotiere Z"
 
-#: ../src/command/keyframe.cpp:79
-msgid "Open keyframes file"
-msgstr "Öffne Keyframe-Datei"
+#: ../src/command/vis_tool.cpp:74
+msgid "Rotate subtitles on their Z axis"
+msgstr "Rotiert Untertitel um die Z-Achse"
 
-#: ../src/command/keyframe.cpp:81 ../src/command/timecode.cpp:79
-#: ../src/command/timecode.cpp:99 ../src/auto4_base.cpp:512
-#: ../src/subtitle_format.cpp:363
-msgid "All Supported Formats"
-msgstr "Alle unterstützten Formate"
+#: ../src/command/vis_tool.cpp:80 ../src/command/vis_tool.cpp:81
+msgid "Rotate XY"
+msgstr "Rotiere XY"
 
-#: ../src/command/keyframe.cpp:92
-msgid "Save Keyframes..."
-msgstr "Speichere Keyframe-Datei..."
+#: ../src/command/vis_tool.cpp:82
+msgid "Rotate subtitles on their X and Y axes"
+msgstr "Rotiert Untertitel um die X- und Y-Achse"
 
-#: ../src/command/keyframe.cpp:93
-msgid "Save Keyframes"
-msgstr "Speichere Keyframe-Datei..."
+#: ../src/command/vis_tool.cpp:88 ../src/command/vis_tool.cpp:89
+msgid "Scale"
+msgstr "Skalieren"
 
-#: ../src/command/keyframe.cpp:94
-msgid "Saves the current keyframe list"
-msgstr "Speichert die aktuelle Keyframeliste"
+#: ../src/command/vis_tool.cpp:90
+msgid "Scale subtitles on X and Y axes"
+msgstr "Skaliere Untertitel auf der X- und Y-Achse"
 
-#: ../src/command/keyframe.cpp:102
-msgid "Save keyframes file"
-msgstr "Speichere Keyframe-Datei"
+#: ../src/command/vis_tool.cpp:96 ../src/command/vis_tool.cpp:97
+msgid "Clip"
+msgstr "Beschneiden"
 
-#: ../src/command/tool.cpp:72
-msgid "ASSDraw3..."
-msgstr "AssDraw3..."
+#: ../src/command/vis_tool.cpp:98
+msgid "Clip subtitles to a rectangle"
+msgstr "Untertitel mit Rechteck beschneiden"
 
-#: ../src/command/tool.cpp:73
-msgid "ASSDraw3"
-msgstr "AssDraw3"
+#: ../src/command/vis_tool.cpp:104 ../src/command/vis_tool.cpp:105
+msgid "Vector Clip"
+msgstr "Vektor-Beschneiden"
 
-#: ../src/command/tool.cpp:74
-msgid "Launch ASSDraw3 tool for vector drawing"
-msgstr "Startet das AssDraw3-Werkzeug für Vektorgrafik"
+#: ../src/command/vis_tool.cpp:106
+msgid "Clip subtitles to a vectorial area"
+msgstr "Untertitel mit Vektorgrafik beschneiden"
 
-#: ../src/command/tool.cpp:84
-msgid "&Export Subtitles..."
-msgstr "Exportiere Untertitel..."
-
-#: ../src/command/tool.cpp:85
-msgid "Export Subtitles"
-msgstr "Exportiere Untertitel..."
-
-#: ../src/command/tool.cpp:86
-msgid "Saves a copy of subtitles with processing applied to it"
-msgstr "Speichert eine nachbearbeitete Kopie der Untertitel"
-
-#: ../src/command/tool.cpp:97
-msgid "&Fonts Collector..."
-msgstr "&Schriftartensammlung..."
-
-#: ../src/command/tool.cpp:98 ../src/dialog_fonts_collector.cpp:185
-msgid "Fonts Collector"
-msgstr "Schriftartensammlung"
-
-#: ../src/command/tool.cpp:99
-msgid "Open fonts collector"
-msgstr "Öffnet die Schriftartensammlung"
-
-#: ../src/command/tool.cpp:109
-msgid "S&elect Lines..."
-msgstr "Zeilen auswählen..."
-
-#: ../src/command/tool.cpp:110
-msgid "Select Lines"
-msgstr "Zeilen auswählen"
-
-#: ../src/command/tool.cpp:111
-msgid "Selects lines based on defined criteria"
-msgstr "Wählt Zeilen nach bestimmten Kriterien aus"
-
-#: ../src/command/tool.cpp:121
-msgid "&Resample Resolution..."
-msgstr "Auflösung anpassen..."
-
-#: ../src/command/tool.cpp:122 ../src/dialog_resample.cpp:53
-msgid "Resample Resolution"
-msgstr "Auflösung anpassen"
-
-#: ../src/command/tool.cpp:123
-msgid "Changes resolution and modifies subtitles to conform to change"
-msgstr "Verändert die Auflösung und paßt die Untertitel entsprechend an"
-
-#: ../src/command/tool.cpp:136
-msgid "St&yling Assistant..."
-msgstr "Stil-Assistent..."
-
-#: ../src/command/tool.cpp:137 ../src/dialog_styling_assistant.cpp:56
-msgid "Styling Assistant"
-msgstr "Stil-Assistent"
-
-#: ../src/command/tool.cpp:138
-msgid "Open styling assistant"
-msgstr "Öffnet den Stil-Assistenten"
-
-#: ../src/command/tool.cpp:156 ../src/command/tool.cpp:242
-msgid "&Accept changes"
-msgstr "Änderungen übernehmen"
-
-#: ../src/command/tool.cpp:157 ../src/command/tool.cpp:243
-#: ../src/dialog_translation.cpp:113 ../src/dialog_styling_assistant.cpp:92
-msgid "Accept changes"
-msgstr "Änderungen übernehmen"
-
-#: ../src/command/tool.cpp:158 ../src/command/tool.cpp:244
-msgid "Commit changes and move to the next line"
-msgstr "Änderungen anwenden und zur nächsten Zeile gehen"
-
-#: ../src/command/tool.cpp:168 ../src/command/tool.cpp:254
-msgid "&Preview changes"
-msgstr "Vorschau"
-
-#: ../src/command/tool.cpp:169 ../src/command/tool.cpp:255
-#: ../src/dialog_translation.cpp:114 ../src/dialog_styling_assistant.cpp:93
-msgid "Preview changes"
-msgstr "Vorschau"
-
-#: ../src/command/tool.cpp:170 ../src/command/tool.cpp:256
-msgid "Commit changes and stay on the current line"
-msgstr "Änderungen anwenden und in der aktuellen Zeile bleiben"
-
-#: ../src/command/tool.cpp:180
-msgid "&Styles Manager..."
-msgstr "&Stil-Manager..."
-
-#: ../src/command/tool.cpp:181 ../src/dialog_style_manager.cpp:158
-msgid "Styles Manager"
-msgstr "Stil-Manager"
-
-#: ../src/command/tool.cpp:182
-msgid "Open styles manager"
-msgstr "Öffnet den Stil-Manager"
-
-#: ../src/command/tool.cpp:192
-msgid "&Kanji Timer..."
-msgstr "Kanji-Timer..."
-
-#: ../src/command/tool.cpp:193
-msgid "Kanji Timer"
-msgstr "Kanji-Timer"
-
-#: ../src/command/tool.cpp:194
-msgid "Open Kanji timer"
-msgstr "Öffne Kanji-Timer"
-
-#: ../src/command/tool.cpp:204
-msgid "&Timing Post-Processor..."
-msgstr "Timingnachbearbeitung..."
-
-#: ../src/command/tool.cpp:205 ../src/dialog_timing_processor.cpp:103
-msgid "Timing Post-Processor"
-msgstr "Timingnachbearbeitung"
-
-#: ../src/command/tool.cpp:206
-msgid ""
-"Runs a post-processor for timing to deal with lead-ins, lead-outs, scene "
-"timing and etc"
-msgstr ""
-"Startet eine Timingnachbearbeitung, die Einlaufbereiche, Auslaufbereiche, "
-"Szenen-Timing usw. übernimmt."
-
-#: ../src/command/tool.cpp:216
-msgid "&Translation Assistant..."
-msgstr "&Übersetzungsassistent..."
-
-#: ../src/command/tool.cpp:217 ../src/dialog_translation.cpp:64
-msgid "Translation Assistant"
-msgstr "Übersetzungsassistent"
-
-#: ../src/command/tool.cpp:218
-msgid "Open translation assistant"
-msgstr "Öffnet den Übersetzungsassistenten"
-
-#: ../src/command/tool.cpp:266
-msgid "&Next Line"
-msgstr "Nächste Zeile"
-
-#: ../src/command/tool.cpp:268
-msgid "Move to the next line without committing changes"
-msgstr "Zur nächsten Zeile gehen, Änderungen verwerfen"
-
-#: ../src/command/tool.cpp:278
-msgid "&Previous Line"
-msgstr "Vorherige Zeile"
-
-#: ../src/command/tool.cpp:280
-msgid "Move to the previous line without committing changes"
-msgstr "Zur vorherigen Zeile gehen, Änderungen verwerfen"
-
-#: ../src/command/tool.cpp:291
-msgid "&Insert Original"
-msgstr "Original einfügen"
-
-#: ../src/command/tool.cpp:293
-msgid "Insert the untranslated text"
-msgstr "Einfügen des unübersetzten Textes"
-
-#: ../src/command/command.cpp:35
-#, c-format
-msgid "'%s' is not a valid command name"
-msgstr "'%s' ist kein gültiger Kommandoname"
-
-#: ../src/command/timecode.cpp:56 ../src/command/timecode.cpp:57
-msgid "Close Timecodes File"
-msgstr "Zeitcode-Datei schließen"
-
-#: ../src/command/timecode.cpp:58
-msgid "Closes the currently open timecodes file"
-msgstr "Schließt die derzeit offene Datei mit Zeitcodes"
-
-#: ../src/command/timecode.cpp:74
-msgid "Open Timecodes File..."
-msgstr "Öffne Zeitcode-Datei..."
-
-#: ../src/command/timecode.cpp:75 ../src/command/timecode.cpp:80
-msgid "Open Timecodes File"
-msgstr "Öffne Zeitcode-Datei..."
-
-#: ../src/command/timecode.cpp:76
-msgid "Opens a VFR timecodes v1 or v2 file"
-msgstr "Öffnet eine Datei mit vfr-Zeitcodes, Typ v1 oder v2"
-
-#: ../src/command/timecode.cpp:89
-msgid "Save Timecodes File..."
-msgstr "Speichere Zeitcode-Datei"
-
-#: ../src/command/timecode.cpp:90 ../src/command/timecode.cpp:100
-msgid "Save Timecodes File"
-msgstr "Speichere Zeitcode-Datei"
-
-#: ../src/command/timecode.cpp:91
-msgid "Saves a VFR timecodes v2 file"
-msgstr "Speichere eine Datei mit vfr-Timecodes, Typ v2"
-
-#: ../src/command/audio.cpp:73
+#: ../src/command/audio.cpp:65
 msgid "&Close Audio"
 msgstr "Audio &schließen"
 
-#: ../src/command/audio.cpp:74
+#: ../src/command/audio.cpp:66
 msgid "Close Audio"
 msgstr "Audio schließen"
 
-#: ../src/command/audio.cpp:75
-msgid "Closes the currently open audio file"
+#: ../src/command/audio.cpp:67
+#, fuzzy
+msgid "Close the currently open audio file"
 msgstr "Schließt die geöffnete Audiodatei"
 
-#: ../src/command/audio.cpp:86
+#: ../src/command/audio.cpp:77
 msgid "&Open Audio File..."
 msgstr "Ö&ffne Audiodatei..."
 
-#: ../src/command/audio.cpp:87 ../src/command/audio.cpp:94
+#: ../src/command/audio.cpp:78 ../src/command/audio.cpp:85
 msgid "Open Audio File"
 msgstr "Öffne Audiodatei..."
 
-#: ../src/command/audio.cpp:88
-msgid "Opens an audio file"
+#: ../src/command/audio.cpp:79
+#, fuzzy
+msgid "Open an audio file"
 msgstr "Öffnet eine Audiodatei"
 
-#: ../src/command/audio.cpp:91
+#: ../src/command/audio.cpp:82
 msgid "Audio Formats"
 msgstr "Audioformate"
 
-#: ../src/command/audio.cpp:111 ../src/command/audio.cpp:112
+#: ../src/command/audio.cpp:93 ../src/command/audio.cpp:94
 msgid "Open 2h30 Blank Audio"
 msgstr "Öffne eine 2h30m lange, leere Tonspur"
 
-#: ../src/command/audio.cpp:113
+#: ../src/command/audio.cpp:95
 msgid "Open a 150 minutes blank audio clip, for debugging"
 msgstr "Öffne einen leeren Audio-Clip von 150 Minuten (zum Debuggen)"
 
-#: ../src/command/audio.cpp:129 ../src/command/audio.cpp:130
+#: ../src/command/audio.cpp:104 ../src/command/audio.cpp:105
 msgid "Open 2h30 Noise Audio"
 msgstr "Öffne 2h30m Rauschen (Audio)"
 
-#: ../src/command/audio.cpp:131
+#: ../src/command/audio.cpp:106
 msgid "Open a 150 minutes noise-filled audio clip, for debugging"
 msgstr ""
 "Öffnet einen 150 Minuten langen Audio-Clip, der mit Rauschen gefüllt ist "
 "(zum Debuggen)"
 
-#: ../src/command/audio.cpp:147
+#: ../src/command/audio.cpp:116
 msgid "Open Audio from &Video"
 msgstr "Öffne Audio von &Video"
 
-#: ../src/command/audio.cpp:148
+#: ../src/command/audio.cpp:117
 msgid "Open Audio from Video"
 msgstr "Öffne Tonspur von &Video"
 
-#: ../src/command/audio.cpp:149
-msgid "Opens the audio from the current video file"
+#: ../src/command/audio.cpp:118
+#, fuzzy
+msgid "Open the audio from the current video file"
 msgstr "Öffnet eine Tonspur der aktuellen Videodatei"
 
-#: ../src/command/audio.cpp:171
+#: ../src/command/audio.cpp:132
 msgid "&Spectrum Display"
 msgstr "Spektrum anzeigen"
 
-#: ../src/command/audio.cpp:172
+#: ../src/command/audio.cpp:133
 msgid "Spectrum Display"
 msgstr "Spektrum anzeigen"
 
-#: ../src/command/audio.cpp:173
+#: ../src/command/audio.cpp:134
 msgid "Display audio as a frequency-power spectrograph"
 msgstr "Zeige Audio als Frequenzstärke-Spektrum an"
 
-#: ../src/command/audio.cpp:189
+#: ../src/command/audio.cpp:148
 msgid "&Waveform Display"
 msgstr "Wellenform anzeigen"
 
-#: ../src/command/audio.cpp:190
+#: ../src/command/audio.cpp:149
 msgid "Waveform Display"
 msgstr "Wellenform anzeigen"
 
-#: ../src/command/audio.cpp:191
+#: ../src/command/audio.cpp:150
 msgid "Display audio as a linear amplitude graph"
 msgstr "Zeige Audio als linearen Amplitudengrafen an"
 
-#: ../src/command/audio.cpp:206 ../src/command/audio.cpp:207
+#: ../src/command/audio.cpp:187 ../src/command/audio.cpp:188
 msgid "Create audio clip"
 msgstr "Erzeuge einen Audioclip"
 
-#: ../src/command/audio.cpp:208
-msgid "Create an audio clip of the selected line"
+#: ../src/command/audio.cpp:189
+#, fuzzy
+msgid "Save an audio clip of the selected line"
 msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
 
-#: ../src/command/audio.cpp:226
+#: ../src/command/audio.cpp:200
 msgid "Save audio clip"
 msgstr "Speichere Audioclip"
 
-#: ../src/command/audio.cpp:234 ../src/command/audio.cpp:235
+#: ../src/command/audio.cpp:247 ../src/command/audio.cpp:248
 msgid "Play current audio selection"
 msgstr "Aktuelle Audio-Auswahl wiedergeben"
 
-#: ../src/command/audio.cpp:236
+#: ../src/command/audio.cpp:249
 msgid "Play the current audio selection, ignoring changes made while playing"
 msgstr ""
 "Aktuelle Audio-Auswahl wiedergeben, ignoriere Änderungen bei Wiedergabe"
 
-#: ../src/command/audio.cpp:262 ../src/command/audio.cpp:263
+#: ../src/command/audio.cpp:262
+#, fuzzy
+msgid "Play the audio for the current line"
+msgstr "Öffnet eine Tonspur der aktuellen Videodatei"
+
+#: ../src/command/audio.cpp:275 ../src/command/audio.cpp:276
 msgid "Play audio selection"
 msgstr "Audio-Auswahl wiedergeben"
 
-#: ../src/command/audio.cpp:264
+#: ../src/command/audio.cpp:277
 msgid "Play audio until the end of the selection is reached"
 msgstr "Audio wiedergeben, bis das Ende der Auswahl erreicht ist"
 
-#: ../src/command/audio.cpp:275 ../src/command/audio.cpp:276
+#: ../src/command/audio.cpp:287 ../src/command/audio.cpp:288
 msgid "Play audio selection or stop"
 msgstr "Audio-Auswahl wiedergeben oder anhalten"
 
-#: ../src/command/audio.cpp:277
-msgid "Play selection or stop playback if it's already playing"
+#: ../src/command/audio.cpp:289
+#, fuzzy
+msgid "Play selection, or stop playback if it's already playing"
 msgstr "Auswahl wiedergeben oder bei Wiedergabe anhalten"
 
-#: ../src/command/audio.cpp:292 ../src/command/audio.cpp:293
+#: ../src/command/audio.cpp:304 ../src/command/audio.cpp:305
 msgid "Stop playing"
 msgstr "Wiedergabe anhalten"
 
-#: ../src/command/audio.cpp:310 ../src/command/audio.cpp:311
-#: ../src/command/audio.cpp:312
+#: ../src/command/audio.cpp:306
+#, fuzzy
+msgid "Stop audio and video playback"
+msgstr "Stoppe Abspielen"
+
+#: ../src/command/audio.cpp:322 ../src/command/audio.cpp:323
+#: ../src/command/audio.cpp:324
 msgid "Play 500 ms before selection"
 msgstr "500 ms vor Auswahl abspielen"
 
-#: ../src/command/audio.cpp:324 ../src/command/audio.cpp:325
-#: ../src/command/audio.cpp:326
+#: ../src/command/audio.cpp:336 ../src/command/audio.cpp:337
+#: ../src/command/audio.cpp:338
 msgid "Play 500 ms after selection"
 msgstr "500 ms nach Auswahl abspielen"
 
-#: ../src/command/audio.cpp:338 ../src/command/audio.cpp:339
-#: ../src/command/audio.cpp:340
+#: ../src/command/audio.cpp:350 ../src/command/audio.cpp:351
+#: ../src/command/audio.cpp:352
 msgid "Play last 500 ms of selection"
 msgstr "Letzte 500ms der Auswahl abspielen"
 
-#: ../src/command/audio.cpp:352 ../src/command/audio.cpp:353
-#: ../src/command/audio.cpp:354
+#: ../src/command/audio.cpp:364 ../src/command/audio.cpp:365
+#: ../src/command/audio.cpp:366
 msgid "Play first 500 ms of selection"
 msgstr "Erste 500ms der Auswahl abspielen"
 
-#: ../src/command/audio.cpp:368 ../src/command/audio.cpp:369
-#: ../src/command/audio.cpp:370
+#: ../src/command/audio.cpp:380 ../src/command/audio.cpp:381
+#: ../src/command/audio.cpp:382
 msgid "Play from selection start to end of file"
 msgstr "Von Auswahlbeginn bis Dateiende abspielen"
 
-#: ../src/command/audio.cpp:382 ../src/command/audio.cpp:383
+#: ../src/command/audio.cpp:393 ../src/command/audio.cpp:394
 msgid "Commit"
 msgstr "Übernehmen"
 
-#: ../src/command/audio.cpp:384
+#: ../src/command/audio.cpp:395
 msgid "Commit any pending audio timing changes"
 msgstr "Übernehme alle Änderungen im Audio-Timing"
 
-#: ../src/command/audio.cpp:400 ../src/command/audio.cpp:401
+#: ../src/command/audio.cpp:409 ../src/command/audio.cpp:410
 msgid "Commit and use default timing for next line"
 msgstr "Übernehme Änderungen und nutze Standard-Timing für die nächste Zeile"
 
-#: ../src/command/audio.cpp:402
+#: ../src/command/audio.cpp:411
 msgid ""
 "Commit any pending audio timing changes and reset the next line's times to "
 "the default"
@@ -3318,632 +3078,1417 @@ msgstr ""
 "Übernehme alle Änderungen im Audio-Timing und setze die Zeiten in der "
 "nächsten Zeile auf den Standardwert zurück"
 
-#: ../src/command/audio.cpp:417 ../src/command/audio.cpp:418
+#: ../src/command/audio.cpp:424 ../src/command/audio.cpp:425
 msgid "Commit and move to next line"
 msgstr "Übernehmen und zur nächsten Zeile gehen"
 
-#: ../src/command/audio.cpp:419
+#: ../src/command/audio.cpp:426
 msgid "Commit any pending audio timing changes and move to the next line"
 msgstr "Übernehme alle Änderungen im Audio-Timing und gehe zur nächsten Zeile"
 
-#: ../src/command/audio.cpp:434 ../src/command/audio.cpp:435
+#: ../src/command/audio.cpp:439 ../src/command/audio.cpp:440
 msgid "Commit and stay on current line"
 msgstr "Übernehmen und in der aktuellen Zeile bleiben"
 
-#: ../src/command/audio.cpp:436
+#: ../src/command/audio.cpp:441
 msgid "Commit any pending audio timing changes and stay on the current line"
 msgstr ""
 "Übernehme alle Änderungen im Audio-Timing und bleibe in der aktuellen Zeile"
 
-#: ../src/command/audio.cpp:447 ../src/command/audio.cpp:448
-#: ../src/command/audio.cpp:449
+#: ../src/command/audio.cpp:452 ../src/command/audio.cpp:453
 msgid "Go to selection"
 msgstr "Gehe zur Auswahl"
 
-#: ../src/command/audio.cpp:459 ../src/command/audio.cpp:460
+#: ../src/command/audio.cpp:454
+msgid "Scroll the audio display to center on the current audio selection"
+msgstr ""
+
+#: ../src/command/audio.cpp:463 ../src/command/audio.cpp:464
 msgid "Scroll left"
 msgstr "Nach links scrollen"
 
-#: ../src/command/audio.cpp:461
+#: ../src/command/audio.cpp:465
 msgid "Scroll the audio display left"
 msgstr "Audioanzeige nach links scrollen"
 
-#: ../src/command/audio.cpp:472 ../src/command/audio.cpp:473
+#: ../src/command/audio.cpp:474 ../src/command/audio.cpp:475
 msgid "Scroll right"
 msgstr "Nach rechts scrollen"
 
-#: ../src/command/audio.cpp:474
+#: ../src/command/audio.cpp:476
 msgid "Scroll the audio display right"
 msgstr "Audioanzeige nach rechts scrollen"
 
-#: ../src/command/audio.cpp:488 ../src/command/audio.cpp:489
-#: ../src/command/audio.cpp:490
-msgid "Auto scrolls audio display to selected line"
+#: ../src/command/audio.cpp:490 ../src/command/audio.cpp:491
+#: ../src/command/audio.cpp:492
+#, fuzzy
+msgid "Auto scroll audio display to selected line"
 msgstr "Audioanzeige automatisch auf ausgewählte Zeile setzen"
 
-#: ../src/command/audio.cpp:505 ../src/command/audio.cpp:506
-#: ../src/command/audio.cpp:507
+#: ../src/command/audio.cpp:507 ../src/command/audio.cpp:508
+#: ../src/command/audio.cpp:509
 msgid "Automatically commit all changes"
 msgstr "Änderungen automatisch anwenden"
 
-#: ../src/command/audio.cpp:522 ../src/command/audio.cpp:523
-#: ../src/command/audio.cpp:524
-msgid "Auto goes to next line on commit"
+#: ../src/command/audio.cpp:524 ../src/command/audio.cpp:525
+#, fuzzy
+msgid "Auto go to next line on commit"
 msgstr "Automatisch nach dem Anwenden zur nächsten Zeile gehen"
 
-#: ../src/command/audio.cpp:539 ../src/command/audio.cpp:540
-#: ../src/command/audio.cpp:541
+#: ../src/command/audio.cpp:526
+#, fuzzy
+msgid "Automatically go to next line on commit"
+msgstr "Automatisch nach dem Anwenden zur nächsten Zeile gehen"
+
+#: ../src/command/audio.cpp:541 ../src/command/audio.cpp:542
+#: ../src/command/audio.cpp:543
 msgid "Spectrum analyzer mode"
 msgstr "Spektrumsanalyse-Modus"
 
-#: ../src/command/audio.cpp:556 ../src/command/audio.cpp:557
-#: ../src/command/audio.cpp:558
+#: ../src/command/audio.cpp:558 ../src/command/audio.cpp:559
+#: ../src/command/audio.cpp:560
 msgid "Link vertical zoom and volume sliders"
 msgstr "Vertikalen Zoom- und Lautstärke-Regler verbinden"
 
-#: ../src/command/audio.cpp:573 ../src/command/audio.cpp:574
-#: ../src/command/audio.cpp:575
+#: ../src/command/audio.cpp:575 ../src/command/audio.cpp:576
+#: ../src/command/audio.cpp:577
 msgid "Toggle karaoke mode"
 msgstr "Karaokemodus ein-/ausschalten"
+
+#: ../src/command/help.cpp:48
+msgid "&Bug Tracker..."
+msgstr "&Bugtracker..."
+
+#: ../src/command/help.cpp:49
+msgid "Bug Tracker"
+msgstr "Bugtracker"
+
+#: ../src/command/help.cpp:50
+msgid "Visit Aegisub's bug tracker to report bugs and request new features"
+msgstr ""
+"Besuchen Sie Aegisubs Bugtracker, um einen Bug oder gewünschte Features zu "
+"melden"
+
+#: ../src/command/help.cpp:69
+msgid "&Contents"
+msgstr "&Inhalt"
+
+#: ../src/command/help.cpp:70
+msgid "Contents"
+msgstr "Inhalt"
+
+#: ../src/command/help.cpp:71
+msgid "Help topics"
+msgstr "Hilfethemen"
+
+#: ../src/command/help.cpp:81
+msgid "&Forums"
+msgstr "&Forum"
+
+#: ../src/command/help.cpp:82
+msgid "Forums"
+msgstr "Forum"
+
+#: ../src/command/help.cpp:83
+msgid "Visit Aegisub's forums"
+msgstr "Aegisubs Forum öffnen"
+
+#: ../src/command/help.cpp:93
+msgid "&IRC Channel"
+msgstr "&Irc-Kanal"
+
+#: ../src/command/help.cpp:94
+msgid "IRC Channel"
+msgstr "Irc-Kanal"
+
+#: ../src/command/help.cpp:95
+msgid "Visit Aegisub's official IRC channel"
+msgstr "Aegisubs offiziellen Irc-Channel öffnen"
+
+#: ../src/command/help.cpp:105
+msgid "&Visual Typesetting"
+msgstr "Visuelles Typesetting"
+
+#: ../src/command/help.cpp:106
+msgid "Visual Typesetting"
+msgstr "Visuelles Typesetting"
+
+#: ../src/command/help.cpp:107
+msgid "Open the manual page for Visual Typesetting"
+msgstr "Öffne die Handbuchseite für Visuelles Typesetting"
+
+#: ../src/command/help.cpp:117
+msgid "&Website"
+msgstr "&Webseite"
+
+#: ../src/command/help.cpp:118
+msgid "Website"
+msgstr "Webseite"
+
+#: ../src/command/help.cpp:119
+msgid "Visit Aegisub's official website"
+msgstr "Aegisubs offizielle Webseite öffnen"
+
+#: ../src/command/keyframe.cpp:49 ../src/command/keyframe.cpp:50
+msgid "Close Keyframes"
+msgstr "Schließe Keyframe-Datei"
+
+#: ../src/command/keyframe.cpp:51
+#, fuzzy
+msgid ""
+"Discard the currently loaded keyframes and use those from the video, if any"
+msgstr ""
+"Speichere den gerade angezeigten Frame als .png-Bild im Ordner des Videos"
+
+#: ../src/command/keyframe.cpp:66
+msgid "Open Keyframes..."
+msgstr "Öffne Keyframe-Datei..."
+
+#: ../src/command/keyframe.cpp:67
+msgid "Open Keyframes"
+msgstr "Öffne Keyframe-Datei..."
+
+#: ../src/command/keyframe.cpp:68
+#, fuzzy
+msgid "Open a keyframe list file"
+msgstr "Öffnet eine Keyframe-Datei"
+
+#: ../src/command/keyframe.cpp:72
+msgid "Open keyframes file"
+msgstr "Öffne Keyframe-Datei"
+
+#: ../src/command/keyframe.cpp:85
+msgid "Save Keyframes..."
+msgstr "Speichere Keyframe-Datei..."
+
+#: ../src/command/keyframe.cpp:86
+msgid "Save Keyframes"
+msgstr "Speichere Keyframe-Datei..."
+
+#: ../src/command/keyframe.cpp:87
+#, fuzzy
+msgid "Save the current list of keyframes to a file"
+msgstr "Speichert die aktuelle Keyframeliste"
+
+#: ../src/command/keyframe.cpp:95
+msgid "Save keyframes file"
+msgstr "Speichere Keyframe-Datei"
+
+#: ../src/dialog_selected_choices.cpp:33 ../src/dialog_export.cpp:126
+msgid "Select &None"
+msgstr "Auswahl aufheben"
+
+#: ../src/subtitles_provider_libass.cpp:112
+msgid "Updating font index"
+msgstr "Aktualisiere Schriftarten-Index"
+
+#: ../src/subtitles_provider_libass.cpp:113
+msgid "This may take several minutes"
+msgstr "Dies könnte ein paar Minuten dauern"
+
+#: ../src/dialog_spellchecker.cpp:125
+msgid "Misspelled word:"
+msgstr "Falsch geschriebenes Wort:"
+
+#: ../src/dialog_spellchecker.cpp:127 ../src/dialog_search_replace.cpp:73
+msgid "Replace with:"
+msgstr "Ersetzen durch:"
+
+#: ../src/dialog_spellchecker.cpp:182 ../src/dialog_search_replace.cpp:80
+msgid "&Skip Comments"
+msgstr "Überspringe Kommentare"
+
+#: ../src/dialog_spellchecker.cpp:183
+msgid "Ignore &UPPERCASE words"
+msgstr "Worte in Großbuchstaben ignorieren"
+
+#: ../src/dialog_spellchecker.cpp:187
+msgid "&Replace"
+msgstr "Ersetzen"
+
+#: ../src/dialog_spellchecker.cpp:190 ../src/dialog_search_replace.cpp:95
+msgid "Replace &all"
+msgstr "Alle ersetzen"
+
+#: ../src/dialog_spellchecker.cpp:197
+msgid "&Ignore"
+msgstr "Ignorieren"
+
+#: ../src/dialog_spellchecker.cpp:200
+msgid "Ignore a&ll"
+msgstr "Alle ignorieren"
+
+#: ../src/dialog_spellchecker.cpp:206
+msgid "Add to &dictionary"
+msgstr "Zum Wörterbuch hinzufügen"
+
+#: ../src/dialog_spellchecker.cpp:212
+msgid "Remove fro&m dictionary"
+msgstr "Aus dem Wörterbuch entfernen"
+
+#: ../src/dialog_spellchecker.cpp:279
+msgid "Aegisub has finished checking spelling of this script."
+msgstr "Aegisub hat die Rechtschreibprüfung für dieses Skript abgeschlossen."
+
+#: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
+msgid "Spell checking complete."
+msgstr "&Rechtschreibprüfung abgeschlossen"
+
+#: ../src/dialog_spellchecker.cpp:283
+msgid "Aegisub has found no spelling mistakes in this script."
+msgstr "Aegisub hat keine Rechtschreibfehler in diesem Skript gefunden."
+
+#: ../src/dialog_spellchecker.cpp:329 ../src/dialog_spellchecker.cpp:343
+msgid "spell check replace"
+msgstr "Rechtschreibprüfung ersetzen"
+
+#: ../src/preferences_base.cpp:63
+msgid "Please choose the folder:"
+msgstr "Bitte wählen Sie den Ordner:"
+
+#: ../src/preferences_base.cpp:209
+msgid "Browse..."
+msgstr "Durchsuchen..."
+
+#: ../src/preferences_base.cpp:244
+msgid "Choose..."
+msgstr "Auswählen"
+
+#: ../src/preferences_base.cpp:252
+msgid "Font Size"
+msgstr "Schriftgröße"
+
+#: ../src/dialog_properties.cpp:89
+msgid "Script Properties"
+msgstr "Skripteigenschaften"
+
+#: ../src/dialog_properties.cpp:95
+msgid "Script"
+msgstr "Skript"
+
+#: ../src/dialog_properties.cpp:98
+msgid "Title:"
+msgstr "Titel:"
+
+#: ../src/dialog_properties.cpp:99
+msgid "Original script:"
+msgstr "Ursprüngliches Skript:"
+
+#: ../src/dialog_properties.cpp:100
+msgid "Translation:"
+msgstr "Übersetzung:"
+
+#: ../src/dialog_properties.cpp:101
+msgid "Editing:"
+msgstr "Bearbeitung:"
+
+#: ../src/dialog_properties.cpp:102
+msgid "Timing:"
+msgstr "Timing:"
+
+#: ../src/dialog_properties.cpp:103
+msgid "Synch point:"
+msgstr "Sync-Punkt:"
+
+#: ../src/dialog_properties.cpp:104
+msgid "Updated by:"
+msgstr "Aktualisiert von:"
+
+#: ../src/dialog_properties.cpp:105
+msgid "Update details:"
+msgstr "Aktualisierungsdetails:"
+
+#: ../src/dialog_properties.cpp:114 ../src/export_framerate.cpp:70
+#: ../src/dialog_resample.cpp:141
+msgid "From &video"
+msgstr "Vom Video"
+
+#: ../src/dialog_properties.cpp:133
+msgid "Resolution"
+msgstr "Auflösung"
+
+#: ../src/dialog_properties.cpp:141
+msgid "0: Smart wrapping, top line is wider"
+msgstr "0: Intelligent umbrechen, obere Zeile ist breiter"
+
+#: ../src/dialog_properties.cpp:142
+msgid "1: End-of-line word wrapping, only \\N breaks"
+msgstr "1: Am Ende der Zeile oder bei \\N umbrechen"
+
+#: ../src/dialog_properties.cpp:143
+msgid "2: No word wrapping, both \\n and \\N break"
+msgstr "2: Kein Umbruch, nur manuell mit \\n und \\N"
+
+#: ../src/dialog_properties.cpp:144
+msgid "3: Smart wrapping, bottom line is wider"
+msgstr "3: Intelligent umbrechen, untere Zeile ist breiter"
+
+#: ../src/dialog_properties.cpp:148
+msgid "Wrap Style: "
+msgstr "Umbruch-Stil:"
+
+#: ../src/dialog_properties.cpp:151
+msgid "Scale Border and Shadow"
+msgstr "Skaliert Umrahmung und Schatten"
+
+#: ../src/dialog_properties.cpp:152
+msgid ""
+"Scale border and shadow together with script/render resolution. If this is "
+"unchecked, relative border and shadow size will depend on renderer."
+msgstr ""
+"Skaliert Ränder und Schatten mit der Skript-/Render-Auflösung. Wenn dies "
+"deaktiviert ist, wird die relative Rand- und Schattengröße beim Rendern "
+"verwendet."
+
+#: ../src/dialog_properties.cpp:193
+msgid "property changes"
+msgstr "Änderungen der Eigenschaften"
+
+#: ../src/dialog_fonts_collector.cpp:107
+msgid "Symlinking fonts to folder...\n"
+msgstr "Verknüpfe Schriftarten in Ordner...\n"
+
+#: ../src/dialog_fonts_collector.cpp:111
+msgid "Copying fonts to folder...\n"
+msgstr "Kopiere Schriftarten in Ordner...\n"
+
+#: ../src/dialog_fonts_collector.cpp:114
+msgid "Copying fonts to archive...\n"
+msgstr "Kopiere Schriftarten in Archiv...\n"
+
+#: ../src/dialog_fonts_collector.cpp:126
+#, fuzzy, c-format
+msgid "* Failed to create directory '%s': %s.\n"
+msgstr "* Kopieren fehlgeschlagen: %s\n"
+
+#: ../src/dialog_fonts_collector.cpp:137
+#, fuzzy, c-format
+msgid "* Failed to open %s.\n"
+msgstr "* Kopieren fehlgeschlagen: %s\n"
+
+#: ../src/dialog_fonts_collector.cpp:192
+#, c-format
+msgid "* Copied %s.\n"
+msgstr "* Kopiert: %s\n"
+
+#: ../src/dialog_fonts_collector.cpp:194
+#, c-format
+msgid "* %s already exists on destination.\n"
+msgstr "* %s existiert bereits am Zielort.\n"
+
+#: ../src/dialog_fonts_collector.cpp:196
+#, c-format
+msgid "* Symlinked %s.\n"
+msgstr "* Verknüpft: %s\n"
+
+#: ../src/dialog_fonts_collector.cpp:198
+#, c-format
+msgid "* Failed to copy %s.\n"
+msgstr "* Kopieren fehlgeschlagen: %s\n"
+
+#: ../src/dialog_fonts_collector.cpp:204
+msgid "Done. All fonts copied."
+msgstr "Fertig. Alle Schriftarten kopiert."
+
+#: ../src/dialog_fonts_collector.cpp:206
+msgid "Done. Some fonts could not be copied."
+msgstr "Fertig. Einige Schriftarten konnten nicht kopiert werden."
+
+#: ../src/dialog_fonts_collector.cpp:209
+msgid ""
+"\n"
+"Over 32 MB of fonts were copied. Some of the fonts may not be loaded by the "
+"player if they are all attached to a Matroska file."
+msgstr ""
+"\n"
+"Mehr als 32 MB an Schriftarten wurden kopiert. Einige der Schriftarten "
+"können vielleicht nicht vom Video-Abspieler geladen werden, wenn alle davon "
+"an eine Matroska-Datei angehängt werden."
+
+#: ../src/dialog_fonts_collector.cpp:224
+msgid "Check fonts for availability"
+msgstr "Teste, ob alle Schriftarten verfügbar sind"
+
+#: ../src/dialog_fonts_collector.cpp:225
+msgid "Copy fonts to folder"
+msgstr "Kopiere Schriftarten in Ordner"
+
+#: ../src/dialog_fonts_collector.cpp:226
+msgid "Copy fonts to subtitle file's folder"
+msgstr "Kopiere Schriftarten in den Ordner der Untertitel-Datei"
+
+#: ../src/dialog_fonts_collector.cpp:227
+msgid "Copy fonts to zipped archive"
+msgstr "Kopiere Schriftarten in Archiv"
+
+#: ../src/dialog_fonts_collector.cpp:229
+msgid "Symlink fonts to folder"
+msgstr "Verknüpfe Schriftarten in Ordner"
+
+#: ../src/dialog_fonts_collector.cpp:232 ../src/dialog_selection.cpp:150
+msgid "Action"
+msgstr "Aktion"
+
+#: ../src/dialog_fonts_collector.cpp:238
+msgid "Destination"
+msgstr "Ziel"
+
+#: ../src/dialog_fonts_collector.cpp:242
+msgid "&Browse..."
+msgstr "&Durchsuchen..."
+
+#: ../src/dialog_fonts_collector.cpp:251
+msgid "Log"
+msgstr "Log"
+
+#: ../src/dialog_fonts_collector.cpp:264
+msgid "&Start!"
+msgstr "&Los!"
+
+#: ../src/dialog_fonts_collector.cpp:301
+msgid "Invalid destination."
+msgstr "Ungültiges Ziel."
+
+#: ../src/dialog_fonts_collector.cpp:301 ../src/dialog_fonts_collector.cpp:306
+#: ../src/dialog_fonts_collector.cpp:311 ../src/preferences.cpp:257
+#: ../src/dialog_kara_timing_copy.cpp:574
+#: ../src/dialog_kara_timing_copy.cpp:576
+#: ../src/dialog_kara_timing_copy.cpp:626
+msgid "Error"
+msgstr "Fehler"
+
+#: ../src/dialog_fonts_collector.cpp:306
+msgid "Could not create destination folder."
+msgstr "Kann Zielordner nicht anlegen."
+
+#: ../src/dialog_fonts_collector.cpp:311
+msgid "Invalid path for .zip file."
+msgstr "Ungültiger Pfad für .zip-Datei"
+
+#: ../src/dialog_fonts_collector.cpp:335
+msgid "Select archive file name"
+msgstr "Archivdatei wählen"
+
+#: ../src/dialog_fonts_collector.cpp:342
+msgid "Select folder to save fonts on"
+msgstr "Ordner fürs Schriftarten-Speichern auswählen"
+
+#: ../src/dialog_fonts_collector.cpp:356
+msgid "N/A"
+msgstr "Nichts"
+
+#: ../src/dialog_fonts_collector.cpp:364
+msgid ""
+"Choose the folder where the fonts will be collected to. It will be created "
+"if it doesn't exist."
+msgstr ""
+"Wählen Sie den Ordner für das Sammeln der Schriftarten. Wenn er nicht "
+"existiert, wird er angelegt."
+
+#: ../src/dialog_fonts_collector.cpp:371
+msgid ""
+"Enter the name of the destination zip file to collect the fonts to. If a "
+"folder is entered, a default name will be used."
+msgstr ""
+"Geben Sie den Namen des zip-Archives am Zielort an, wo die Schriftarten "
+"gespeichert werden sollen. Wenn ein Ordnernamen eingegeben wurde, wird der "
+"Standardname verwendet."
+
+#: ../src/audio_renderer_waveform.cpp:154
+msgid "Maximum"
+msgstr "Maximum"
+
+#: ../src/audio_renderer_waveform.cpp:155
+msgid "Maximum + Average"
+msgstr "Maximum + Durchschnitt"
+
+#: ../src/dialog_dummy_video.cpp:103
+msgid "Dummy video options"
+msgstr "Dummyvideo-Optionen"
+
+#: ../src/dialog_dummy_video.cpp:115
+msgid "Checkerboard &pattern"
+msgstr "Schachbrettmuster"
+
+#: ../src/dialog_dummy_video.cpp:118
+msgid "Video resolution:"
+msgstr "Videoauflösung:"
+
+#: ../src/dialog_dummy_video.cpp:120
+msgid "Color:"
+msgstr "Farbe:"
+
+#: ../src/dialog_dummy_video.cpp:121
+msgid "Frame rate (fps):"
+msgstr "Framerate (fps):"
+
+#: ../src/dialog_dummy_video.cpp:122
+msgid "Duration (frames):"
+msgstr "Laufzeit (Frames):"
+
+#: ../src/dialog_dummy_video.cpp:164
+#, c-format
+msgid "Resulting duration: %s"
+msgstr "Resultierende Länge: %s"
+
+#: ../src/preferences.cpp:61 ../src/preferences.cpp:63
+#: ../src/preferences.cpp:316 ../src/preferences.cpp:341
+msgid "General"
+msgstr "Allgemein"
+
+#: ../src/preferences.cpp:64
+msgid "Check for updates on startup"
+msgstr "Beim Start auf Updates prüfen"
+
+#: ../src/preferences.cpp:65
+msgid "Show main toolbar"
+msgstr "Zeige Werkzeugleiste"
+
+#: ../src/preferences.cpp:66
+#, fuzzy
+msgid "Save UI state in subtitles files"
+msgstr "Untertiteldatei speichern"
+
+#: ../src/preferences.cpp:69
+msgid "Toolbar Icon Size"
+msgstr "Icongröße der Werkzeugleiste"
+
+#: ../src/preferences.cpp:70 ../src/preferences.cpp:195
+msgid "Never"
+msgstr "Nie"
+
+#: ../src/preferences.cpp:70
+msgid "Always"
+msgstr "Immer"
+
+#: ../src/preferences.cpp:70 ../src/preferences.cpp:195
+msgid "Ask"
+msgstr "Fragen"
+
+#: ../src/preferences.cpp:72
+msgid "Automatically load linked files"
+msgstr "Automatisch verknüpfte Dateien laden"
+
+#: ../src/preferences.cpp:73
+msgid "Undo Levels"
+msgstr "Maximale Rückgängig-Schritte"
+
+#: ../src/preferences.cpp:75
+msgid "Recently Used Lists"
+msgstr "Zuletzt verwendet"
+
+#: ../src/preferences.cpp:76 ../src/dialog_autosave.cpp:70
+msgid "Files"
+msgstr "Dateien"
+
+#: ../src/preferences.cpp:77
+msgid "Find/Replace"
+msgstr "Suchen/Ersetzen"
+
+#: ../src/preferences.cpp:83
+#, fuzzy
+msgid "Default styles"
+msgstr "Stil einstellen"
+
+#: ../src/preferences.cpp:85
+#, fuzzy
+msgid "Default style catalogs"
+msgstr "Standard Auslaufbereich-Länge (ms)"
+
+#: ../src/preferences.cpp:89
+msgid ""
+"The chosen style catalogs will be loaded when you start a new file or import "
+"files in the various formats.\n"
+"\n"
+"You can set up style catalogs in the Style Manager."
+msgstr ""
+
+#: ../src/preferences.cpp:114
+#, fuzzy
+msgid "New files"
+msgstr "&Neue Untertitel"
+
+#: ../src/preferences.cpp:115
+msgid "MicroDVD import"
+msgstr ""
+
+#: ../src/preferences.cpp:116
+#, fuzzy
+msgid "SRT import"
+msgstr "Stilimport"
+
+#: ../src/preferences.cpp:117
+#, fuzzy
+msgid "TTXT import"
+msgstr "Stilimport"
+
+#: ../src/preferences.cpp:118
+#, fuzzy
+msgid "Plain text import"
+msgstr "Stilimport"
+
+#: ../src/preferences.cpp:125 ../src/preferences.cpp:354
+msgid "Audio"
+msgstr "Audio"
+
+#: ../src/preferences.cpp:128
+msgid "Default mouse wheel to zoom"
+msgstr "Standard-Mausrad zum Zoomen"
+
+#: ../src/preferences.cpp:129
+msgid "Lock scroll on cursor"
+msgstr "Scrollen auf Cursor festsetzen"
+
+#: ../src/preferences.cpp:130
+msgid "Snap markers by default"
+msgstr "Standardmäßig bei Markierungen einrasten"
+
+#: ../src/preferences.cpp:131
+msgid "Auto-focus on mouse over"
+msgstr "Auto-Fokus, wenn der Mauszeiger darüber ist"
+
+#: ../src/preferences.cpp:132
+msgid "Play audio when stepping in video"
+msgstr "Audio abspielem im Video-Suchlauf"
+
+#: ../src/preferences.cpp:133
+msgid "Left-click-drag moves end marker"
+msgstr "Linke Maustaste halten und ziehen bewegt die Endmarkierung"
+
+#: ../src/preferences.cpp:134
+msgid "Default timing length (ms)"
+msgstr "Standard Timing-Länge (ms)"
+
+#: ../src/preferences.cpp:135
+msgid "Default lead-in length (ms)"
+msgstr "Standard Einlaufbereich-Länge (ms)"
+
+#: ../src/preferences.cpp:136
+msgid "Default lead-out length (ms)"
+msgstr "Standard Auslaufbereich-Länge (ms)"
+
+#: ../src/preferences.cpp:138
+msgid "Marker drag-start sensitivity (px)"
+msgstr "Markierung: Start-Bewegungsempfindlichkeit (px)"
+
+#: ../src/preferences.cpp:139
+msgid "Line boundary thickness (px)"
+msgstr "Liniendicke (px)"
+
+#: ../src/preferences.cpp:140
+msgid "Maximum snap distance (px)"
+msgstr "Max. Einrastdistanz (px)"
+
+#: ../src/preferences.cpp:142
+msgid "Don't show"
+msgstr "Nicht anzeigen"
+
+#: ../src/preferences.cpp:142
+msgid "Show previous"
+msgstr "Vorherige anzeigen"
+
+#: ../src/preferences.cpp:142
+msgid "Show previous and next"
+msgstr "Vorherige und nächste anzeigen"
+
+#: ../src/preferences.cpp:142
+msgid "Show all"
+msgstr "Alle anzeigen"
+
+#: ../src/preferences.cpp:144
+msgid "Show inactive lines"
+msgstr "Zeige inaktive Zeilen"
+
+#: ../src/preferences.cpp:146
+msgid "Include commented inactive lines"
+msgstr "Zeige inaktive Kommentar-Zeilen"
+
+#: ../src/preferences.cpp:148
+msgid "Display Visual Options"
+msgstr "Zeige visuelle Optionen"
+
+#: ../src/preferences.cpp:149
+msgid "Keyframes in dialogue mode"
+msgstr "Keyframes im Dialog-Modus"
+
+#: ../src/preferences.cpp:150
+msgid "Keyframes in karaoke mode"
+msgstr "Keyframes im Karaoke-Modus"
+
+#: ../src/preferences.cpp:151
+msgid "Cursor time"
+msgstr "Cursorzeit"
+
+#: ../src/preferences.cpp:152
+msgid "Video position"
+msgstr "Videoposition"
+
+#: ../src/preferences.cpp:153 ../src/preferences.cpp:246
+msgid "Seconds boundaries"
+msgstr "Sekundengrenze"
+
+#: ../src/preferences.cpp:155
+msgid "Waveform Style"
+msgstr "Wellenformansicht"
+
+#: ../src/preferences.cpp:157
+msgid "Audio labels"
+msgstr "Audio-Positionsmarke"
+
+#: ../src/preferences.cpp:168
+msgid "Show keyframes in slider"
+msgstr "Zeige Keyframes in der Zeitleiste"
+
+#: ../src/preferences.cpp:170
+msgid "Only show visual tools when mouse is over video"
+msgstr ""
+"Nur visuelle Werkzeuge zeigen, wenn die Maus sich über dem Video befindet"
+
+#: ../src/preferences.cpp:172
+msgid "Seek video to line start on selection change"
+msgstr "Springe im Video zum Anfang der ausgewählten Zeile"
+
+#: ../src/preferences.cpp:174
+msgid "Automatically open audio when opening video"
+msgstr "Automatisch die Audiospur öffnen, wenn das Video geöffnet wird"
+
+#: ../src/preferences.cpp:179
+msgid "Default Zoom"
+msgstr "Standardzoom"
+
+#: ../src/preferences.cpp:181
+msgid "Fast jump step in frames"
+msgstr "Schnellsprung-Schritt in Frames"
+
+#: ../src/preferences.cpp:185
+msgid "Screenshot save path"
+msgstr "Screenshot-Ordner"
+
+#: ../src/preferences.cpp:187
+msgid "Script Resolution"
+msgstr "Skriptauflösung"
+
+#: ../src/preferences.cpp:188
+msgid "Use resolution of first video opened"
+msgstr "Nutze die Auflösung des zuerst geöffneten Videos"
+
+#: ../src/preferences.cpp:191
+msgid "Default width"
+msgstr "Standardbreite"
+
+#: ../src/preferences.cpp:193
+msgid "Default height"
+msgstr "Standardhöhe"
+
+#: ../src/preferences.cpp:195
+#, fuzzy
+msgid "Always set"
+msgstr "Immer"
+
+#: ../src/preferences.cpp:195
+msgid "Always resample"
+msgstr ""
+
+#: ../src/preferences.cpp:197
+msgid "Match video resolution on open"
+msgstr "Videoauflösung beim Öffnen abgleichen"
+
+#: ../src/preferences.cpp:204
+msgid "Interface"
+msgstr "Oberfläche"
+
+#: ../src/preferences.cpp:206
+msgid "Edit Box"
+msgstr "Bearbeitungsbox"
+
+#: ../src/preferences.cpp:207
+msgid "Enable call tips"
+msgstr "Aktiviere Infotexte"
+
+#: ../src/preferences.cpp:208
+msgid "Overwrite in time boxes"
+msgstr "Überschreibendes Einfügen in der Zeit-Box"
+
+#: ../src/preferences.cpp:210
+msgid "Enable syntax highlighting"
+msgstr "Aktiviere Syntaxhervorhebung"
+
+#: ../src/preferences.cpp:211
+msgid "Dictionaries path"
+msgstr "Wörterbuch-Ordner"
+
+#: ../src/preferences.cpp:214
+msgid "Character Counter"
+msgstr ""
+
+#: ../src/preferences.cpp:215
+msgid "Maximum characters per line"
+msgstr "Maximale Zeichen pro Zeile"
+
+#: ../src/preferences.cpp:216
+msgid "Characters Per Second Warning Threshold"
+msgstr ""
+
+#: ../src/preferences.cpp:217
+msgid "Characters Per Second Error Threshold"
+msgstr ""
+
+#: ../src/preferences.cpp:218
+msgid "Ignore whitespace"
+msgstr ""
+
+#: ../src/preferences.cpp:219
+msgid "Ignore punctuation"
+msgstr ""
+
+#: ../src/preferences.cpp:221
+msgid "Grid"
+msgstr "Untertitel-Gitter"
+
+#: ../src/preferences.cpp:222
+msgid "Focus grid on click"
+msgstr ""
+
+#: ../src/preferences.cpp:223
+msgid "Highlight visible subtitles"
+msgstr "Hebe sichtbare Untertitel hervor"
+
+#: ../src/preferences.cpp:224
+msgid "Hide overrides symbol"
+msgstr "Symbol für nicht angezeigte Tags"
+
+#: ../src/preferences.cpp:232 ../src/dialog_style_editor.cpp:179
+msgid "Colors"
+msgstr "Farben"
+
+#: ../src/preferences.cpp:240
+msgid "Audio Display"
+msgstr "Audio-Anzeige"
+
+#: ../src/preferences.cpp:241
+msgid "Play cursor"
+msgstr "Wiedergabezeiger"
+
+#: ../src/preferences.cpp:242
+msgid "Line boundary start"
+msgstr "Zeilengrenze (Start)"
+
+#: ../src/preferences.cpp:243
+msgid "Line boundary end"
+msgstr "Zeilengrenze (Ende)"
+
+#: ../src/preferences.cpp:244
+msgid "Line boundary inactive line"
+msgstr "Zeilengrenze (inaktiv)"
+
+#: ../src/preferences.cpp:245
+msgid "Syllable boundaries"
+msgstr "Silbengrenze"
+
+#: ../src/preferences.cpp:248
+msgid "Syntax Highlighting"
+msgstr "Syntaxhervorhebung"
+
+#: ../src/preferences.cpp:249
+#, fuzzy
+msgid "Background"
+msgstr "Fehlermarkierung"
+
+#: ../src/preferences.cpp:250 ../src/preferences.cpp:326
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/preferences.cpp:251
+#, fuzzy
+msgid "Comments"
+msgstr "Kommentare"
+
+#: ../src/preferences.cpp:252
+msgid "Drawings"
+msgstr ""
+
+#: ../src/preferences.cpp:253
+msgid "Brackets"
+msgstr "Geschweifte Klammern"
+
+#: ../src/preferences.cpp:254
+msgid "Slashes and Parentheses"
+msgstr "Schrägstriche und runde Klammern"
+
+#: ../src/preferences.cpp:255
+msgid "Tags"
+msgstr "Tags"
+
+#: ../src/preferences.cpp:256
+msgid "Parameters"
+msgstr "Parameter"
+
+#: ../src/preferences.cpp:258
+msgid "Error Background"
+msgstr "Fehlermarkierung"
+
+#: ../src/preferences.cpp:259
+msgid "Line Break"
+msgstr "Zeilenumbruch"
+
+#: ../src/preferences.cpp:260
+msgid "Karaoke templates"
+msgstr "Karaoke-Vorlage"
+
+#: ../src/preferences.cpp:261
+#, fuzzy
+msgid "Karaoke variables"
+msgstr "Karaoke-Vorlage"
+
+#: ../src/preferences.cpp:267
+msgid "Audio Color Schemes"
+msgstr "Audio-Farbschema"
+
+#: ../src/preferences.cpp:269 ../src/preferences.cpp:370
+msgid "Spectrum"
+msgstr "Spektrum"
+
+#: ../src/preferences.cpp:270
+msgid "Waveform"
+msgstr "Wellenform"
+
+#: ../src/preferences.cpp:272
+msgid "Subtitle Grid"
+msgstr "Untertitel-Gitter"
+
+#: ../src/preferences.cpp:273
+msgid "Standard foreground"
+msgstr "Textfarbe"
+
+#: ../src/preferences.cpp:274
+msgid "Standard background"
+msgstr "Hintergrundfarbe"
+
+#: ../src/preferences.cpp:275
+msgid "Selection foreground"
+msgstr "Textfarbe (Auswahl)"
+
+#: ../src/preferences.cpp:276
+msgid "Selection background"
+msgstr "Hintergrundfarbe (Auswahl)"
+
+#: ../src/preferences.cpp:277
+msgid "Collision foreground"
+msgstr "Vordergrundkollision"
+
+#: ../src/preferences.cpp:278
+msgid "In frame background"
+msgstr "Frame-Hintergrund"
+
+#: ../src/preferences.cpp:279
+msgid "Comment background"
+msgstr "Kommentar-Hintergrundfarbe"
+
+#: ../src/preferences.cpp:280
+msgid "Selected comment background"
+msgstr "Kommentar-Hintergrundfarbe (Auswahl)"
+
+#: ../src/preferences.cpp:281
+msgid "Header background"
+msgstr "Kopfleiste-Hintergrundfarbe"
+
+#: ../src/preferences.cpp:282
+msgid "Left Column"
+msgstr "Linke Spalte"
+
+#: ../src/preferences.cpp:283
+msgid "Active Line Border"
+msgstr "Aktiver Zeilenrahmen"
+
+#: ../src/preferences.cpp:284
+msgid "Lines"
+msgstr "Zeilen"
+
+#: ../src/preferences.cpp:285
+#, fuzzy
+msgid "CPS Error"
+msgstr "Fehler"
+
+#: ../src/preferences.cpp:294
+msgid "Backup"
+msgstr "Backup"
+
+#: ../src/preferences.cpp:296
+msgid "Automatic Save"
+msgstr "Automatisch speichern"
+
+#: ../src/preferences.cpp:297 ../src/preferences.cpp:305
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: ../src/preferences.cpp:300
+msgid "Interval in seconds"
+msgstr "Intervall in Sekunden"
+
+#: ../src/preferences.cpp:301 ../src/preferences.cpp:307
+#: ../src/preferences.cpp:368
+msgid "Path"
+msgstr "Pfad"
+
+#: ../src/preferences.cpp:302
+msgid "Autosave after every change"
+msgstr "Automatisch bei jeder Änderung speichern"
+
+#: ../src/preferences.cpp:304
+msgid "Automatic Backup"
+msgstr "Automatisches Backup"
+
+#: ../src/preferences.cpp:318
+msgid "Base path"
+msgstr "Basisordner"
+
+#: ../src/preferences.cpp:319
+msgid "Include path"
+msgstr "Include-Ordner"
+
+#: ../src/preferences.cpp:320
+msgid "Auto-load path"
+msgstr "Auto-Load-Ordner"
+
+#: ../src/preferences.cpp:322
+msgid "0: Fatal"
+msgstr "0: Fatal"
+
+#: ../src/preferences.cpp:322
+msgid "1: Error"
+msgstr "1: Fehler"
+
+#: ../src/preferences.cpp:322
+msgid "2: Warning"
+msgstr "2: Warnung"
+
+#: ../src/preferences.cpp:322
+msgid "3: Hint"
+msgstr "3: Hinweis"
+
+#: ../src/preferences.cpp:322
+msgid "4: Debug"
+msgstr "4: Debug"
+
+#: ../src/preferences.cpp:322
+msgid "5: Trace"
+msgstr "5: Trace"
+
+#: ../src/preferences.cpp:324
+msgid "Trace level"
+msgstr "Trace-Level"
+
+#: ../src/preferences.cpp:326
+msgid "Below Normal (recommended)"
+msgstr "Unterhalb Normal (empfohlen)"
+
+#: ../src/preferences.cpp:326
+msgid "Lowest"
+msgstr "Niedrigste"
+
+#: ../src/preferences.cpp:328
+msgid "Thread priority"
+msgstr "Threadpriorität"
+
+#: ../src/preferences.cpp:330
+msgid "No scripts"
+msgstr "Keine Skripte"
+
+#: ../src/preferences.cpp:330
+msgid "Subtitle-local scripts"
+msgstr "Zu Untertiteln zugehörige Skripte"
+
+#: ../src/preferences.cpp:330
+msgid "Global autoload scripts"
+msgstr "Globale, automatisch geladene Skripte"
+
+#: ../src/preferences.cpp:330
+msgid "All scripts"
+msgstr "Alle Skripte"
+
+#: ../src/preferences.cpp:332
+msgid "Autoreload on Export"
+msgstr "Automatisch beim Export neu laden"
+
+#: ../src/preferences.cpp:339
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: ../src/preferences.cpp:343
+msgid ""
+"Changing these settings might result in bugs and/or crashes.  Do not touch "
+"these unless you know what you're doing."
+msgstr ""
+"Wenn Sie diese Einstellungen ändern, könnte das zu Bugs und/oder Abstürzen "
+"führen. Ändern Sie nur etwas, wenn Sie wissen, was Sie tun."
+
+#: ../src/preferences.cpp:356 ../src/preferences.cpp:419
+msgid "Expert"
+msgstr "Experte"
+
+#: ../src/preferences.cpp:359
+msgid "Audio provider"
+msgstr "Audio-Provider"
+
+#: ../src/preferences.cpp:362
+msgid "Audio player"
+msgstr "Audio-Abspieler"
+
+#: ../src/preferences.cpp:364
+msgid "Cache"
+msgstr "Cache"
+
+#: ../src/preferences.cpp:365
+msgid "None (NOT RECOMMENDED)"
+msgstr "Keine (Nicht empfohlen)"
+
+#: ../src/preferences.cpp:365
+msgid "RAM"
+msgstr "Ram"
+
+#: ../src/preferences.cpp:365
+msgid "Hard Disk"
+msgstr "Festplatte"
+
+#: ../src/preferences.cpp:367
+msgid "Cache type"
+msgstr "Cache-Methode"
+
+#: ../src/preferences.cpp:372
+msgid "Regular quality"
+msgstr "Normale Qualität"
+
+#: ../src/preferences.cpp:372
+msgid "Better quality"
+msgstr "Bessere Qualität"
+
+#: ../src/preferences.cpp:372
+msgid "High quality"
+msgstr "Hohe Qualität"
+
+#: ../src/preferences.cpp:372
+msgid "Insane quality"
+msgstr "Kranke Qualität"
+
+#: ../src/preferences.cpp:374
+msgid "Quality"
+msgstr "Qualität"
+
+#: ../src/preferences.cpp:376
+msgid "Cache memory max (MB)"
+msgstr "Maximale Cachegröße im Arbeitsspeicher (MB)"
+
+#: ../src/preferences.cpp:382
+msgid "Avisynth down-mixer"
+msgstr "Avisynth-Downmixer"
+
+#: ../src/preferences.cpp:383
+msgid "Force sample rate"
+msgstr "Erzwinge Samplerate"
+
+#: ../src/preferences.cpp:389
+msgid "Ignore"
+msgstr "Ignorieren"
+
+#: ../src/preferences.cpp:389
+msgid "Stop"
+msgstr "Anhalten"
+
+#: ../src/preferences.cpp:389
+msgid "Abort"
+msgstr "Abbruch"
+
+#: ../src/preferences.cpp:391
+msgid "Audio indexing error handling mode"
+msgstr "Audio-Indexfehler-Handhabungsmodus"
+
+#: ../src/preferences.cpp:393
+msgid "Always index all audio tracks"
+msgstr "Immer alle Tonspuren indexieren"
+
+#: ../src/preferences.cpp:398
+msgid "Portaudio device"
+msgstr "Portaudio-Gerät"
+
+#: ../src/preferences.cpp:403
+msgid "OSS Device"
+msgstr "Oss-Gerät"
+
+#: ../src/preferences.cpp:408
+msgid "Buffer latency"
+msgstr "Pufferlatenz"
+
+#: ../src/preferences.cpp:409
+msgid "Buffer length"
+msgstr "Pufferlänge"
+
+#: ../src/preferences.cpp:422
+msgid "Video provider"
+msgstr "Video-Provider"
+
+#: ../src/preferences.cpp:425
+msgid "Subtitles provider"
+msgstr "Untertitel-Provider"
+
+#: ../src/preferences.cpp:428
+msgid "Force BT.601"
+msgstr "Erzwinge BT.601"
+
+#: ../src/preferences.cpp:432
+msgid "Allow pre-2.56a Avisynth"
+msgstr "Erlaube pre-2.56a-Avisynth"
+
+#: ../src/preferences.cpp:434
+msgid "Avisynth memory limit"
+msgstr "Avisynth-Arbeitsspeicherlimit"
+
+#: ../src/preferences.cpp:442
+msgid "Debug log verbosity"
+msgstr "Debuglog-Detailliertheit"
+
+#: ../src/preferences.cpp:444
+msgid "Decoding threads"
+msgstr "Decoder-Threads"
+
+#: ../src/preferences.cpp:445
+msgid "Enable unsafe seeking"
+msgstr "Aktiviere unsicheres Suchen"
+
+#: ../src/preferences.cpp:574
+msgid "Hotkeys"
+msgstr "Hotkeys"
+
+#: ../src/preferences.cpp:672
+msgid ""
+"Are you sure that you want to restore the defaults? All your settings will "
+"be overridden."
+msgstr ""
+"Wollen Sie wirklich die Standardeinstellungen wiederherstellen? Alle Ihre "
+"Einstellungen gehen verloren."
+
+#: ../src/preferences.cpp:672
+msgid "Restore defaults?"
+msgstr "Standardeinstellungen wiederherstellen?"
+
+#: ../src/preferences.cpp:690
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: ../src/preferences.cpp:718
+msgid "&Restore Defaults"
+msgstr "Standardeinstellungen wiederherstellen"
+
+#: ../src/subs_edit_ctrl.cpp:356
+msgid "Spell checker language"
+msgstr "Sprache für Rechtschreibprüfung"
+
+#: ../src/subs_edit_ctrl.cpp:365
+msgid "Cu&t"
+msgstr "&Ausschneiden"
+
+#: ../src/subs_edit_ctrl.cpp:402
+#, c-format
+msgid "Remove \"%s\" from dictionary"
+msgstr "\"%s\" aus dem Wörterbuch entfernen"
+
+#: ../src/subs_edit_ctrl.cpp:407
+msgid "No spell checker suggestions"
+msgstr "Keine Rechtschreibprüfungsvorschläge"
+
+#: ../src/subs_edit_ctrl.cpp:413
+#, c-format
+msgid "Spell checker suggestions for \"%s\""
+msgstr "Rechtschreibprüfung: Vorschlag für \"%s\""
+
+#: ../src/subs_edit_ctrl.cpp:418
+msgid "No correction suggestions"
+msgstr "Kein Korrekturvorschlag"
+
+#: ../src/subs_edit_ctrl.cpp:424
+#, c-format
+msgid "Add \"%s\" to dictionary"
+msgstr "Füge \"%s\" zum Wörterbuch hinzu"
+
+#: ../src/subs_edit_ctrl.cpp:459
+#, c-format
+msgid "Thesaurus suggestions for \"%s\""
+msgstr "Thesaurus: Vorschlag für \"%s\""
+
+#: ../src/subs_edit_ctrl.cpp:462
+msgid "No thesaurus suggestions"
+msgstr "Keine Thesaurus-Vorschläge"
+
+#: ../src/subs_edit_ctrl.cpp:465
+msgid "Thesaurus language"
+msgstr "Thesaurus-Sprache"
+
+#: ../src/subs_edit_ctrl.cpp:474
+msgid "Disable"
+msgstr "Deaktivieren"
 
 #: ../src/menu.cpp:94
 msgid "Empty"
 msgstr "Leer"
 
-#: ../src/menu.cpp:223
+#: ../src/menu.cpp:227
 msgid "&Recent"
 msgstr "Zuletzt geöffnet"
 
-#: ../src/menu.cpp:417
+#: ../src/menu.cpp:410
 msgid "No Automation macros loaded"
 msgstr "Keine Automatisierungsmakros geladen"
 
-#: ../src/dialog_style_manager.cpp:88
-msgid "Move style up"
-msgstr "Verschiebe Stil nach oben"
+#: ../src/dialog_about.cpp:46
+msgid "Translated into LANGUAGE by PERSON\n"
+msgstr "Ins Deutsche übersetzt von Shimapan\n"
 
-#: ../src/dialog_style_manager.cpp:89
-msgid "Move style down"
-msgstr "Verschiebe Stil nach unten"
+#: ../src/dialog_about.cpp:122
+msgid ""
+"\n"
+"See the help file for full credits.\n"
+msgstr ""
+"\n"
+"Siehe Hilfedatei für vollständige Credits.\n"
 
-#: ../src/dialog_style_manager.cpp:90
-msgid "Move style to top"
-msgstr "Verschiebe Stil an die Spitze"
-
-#: ../src/dialog_style_manager.cpp:91
-msgid "Move style to bottom"
-msgstr "Verschiebe Stil ans Ende"
-
-#: ../src/dialog_style_manager.cpp:92
-msgid "Sort styles alphabetically"
-msgstr "Sortiere Stile alphabetisch"
-
-#: ../src/dialog_style_manager.cpp:118
+#: ../src/dialog_about.cpp:123
 #, c-format
-msgid "%s - Copy"
-msgstr "%s - Kopieren"
+msgid "Built by %s on %s."
+msgstr "Kompiliert von %s am %s."
 
-#: ../src/dialog_style_manager.cpp:120
-#, c-format
-msgid "%s - Copy (%d)"
-msgstr "%s - Kopieren (%d)"
-
-#: ../src/dialog_style_manager.cpp:137
-msgid "Could not parse style"
-msgstr "Kann den Stil nicht lesen"
-
-#: ../src/dialog_style_manager.cpp:144
-msgid "Are you sure you want to delete this style?"
-msgstr "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
-
-#: ../src/dialog_style_manager.cpp:145
-#, c-format
-msgid "Are you sure you want to delete these %d styles?"
-msgstr "Sind Sie sicher, daß Sie %d Stile löschen wollen?"
-
-#: ../src/dialog_style_manager.cpp:167
-msgid "Catalog of available storages"
-msgstr "Katalog der verfügbaren Speicher"
-
-#: ../src/dialog_style_manager.cpp:169
-msgid "New"
-msgstr "Neu"
-
-#: ../src/dialog_style_manager.cpp:170
-msgid "Delete"
-msgstr "Löschen"
-
-#: ../src/dialog_style_manager.cpp:176
-msgid "Copy to &current script ->"
-msgstr "In aktuelles Skript kopieren ->"
-
-#: ../src/dialog_style_manager.cpp:183
-msgid "Storage"
-msgstr "Speicher"
-
-#: ../src/dialog_style_manager.cpp:189
-msgid "&Import from script..."
-msgstr "&Importiere aus Skript..."
-
-#: ../src/dialog_style_manager.cpp:190
-msgid "<- Copy to &storage"
-msgstr "<- In Speicher kopieren"
-
-#: ../src/dialog_style_manager.cpp:201
-msgid "Current script"
-msgstr "Aktuelles Skript"
-
-#: ../src/dialog_style_manager.cpp:208 ../src/dialog_progress.cpp:138
-msgid "Close"
-msgstr "Schließen"
-
-#: ../src/dialog_style_manager.cpp:353
-msgid "New storage name:"
-msgstr "Neuer Speichername:"
-
-#: ../src/dialog_style_manager.cpp:353
-msgid "New catalog entry"
-msgstr "Neuer Katalogeintrag"
-
-#: ../src/dialog_style_manager.cpp:368
-msgid "A catalog with that name already exists."
-msgstr "Ein Katalog mit diesem Namen existiert schon."
-
-#: ../src/dialog_style_manager.cpp:368
-msgid "Catalog name conflict"
-msgstr "Katalog-Namenskonflikt"
-
-#: ../src/dialog_style_manager.cpp:375
-#, c-format
-msgid ""
-"The specified catalog name contains one or more illegal characters. They "
-"have been replaced with underscores instead.\n"
-"The catalog has been renamed to \"%s\"."
-msgstr ""
-"Der von Ihnen gewählte Katalog enthält ein oder mehrere ungültige Zeichen. "
-"Diese wurden durch Unterstriche ersetzt.\n"
-"Der Katalog wurde umbenannt zu \"%s\"."
-
-#: ../src/dialog_style_manager.cpp:376
-msgid "Invalid characters"
-msgstr "Ungültige Zeichen"
-
-#: ../src/dialog_style_manager.cpp:389
-#, c-format
-msgid "Are you sure you want to delete the storage \"%s\" from the catalog?"
-msgstr ""
-"Sind Sie sicher, daß Sie den Speicher \"%s\" aus dem Katalog löschen wollen?"
-
-#: ../src/dialog_style_manager.cpp:390
-msgid "Confirm delete"
-msgstr "Löschen bestätigen"
-
-#: ../src/dialog_style_manager.cpp:408
-#, c-format
-msgid ""
-"There is already a style with the name \"%s\" in the current storage. "
-"Overwrite?"
-msgstr ""
-"Es gibt bereits einen Stil mit dem Namen \"%s\" im aktuellen Speicher. "
-"Wollen Sie ihn überschreiben?"
-
-#: ../src/dialog_style_manager.cpp:408 ../src/dialog_style_manager.cpp:435
-#: ../src/dialog_style_manager.cpp:612
-msgid "Style name collision"
-msgstr "Stilnamen-Kollision"
-
-#: ../src/dialog_style_manager.cpp:435 ../src/dialog_style_manager.cpp:611
-#, c-format
-msgid ""
-"There is already a style with the name \"%s\" in the current script. "
-"Overwrite?"
-msgstr ""
-"Es gibt bereits einen Stil mit dem Namen \"%s\" im aktuellen Skript. Wollen "
-"Sie Ihn überschreiben?"
-
-#: ../src/dialog_style_manager.cpp:446
-msgid "style copy"
-msgstr "Stil kopieren"
-
-#: ../src/dialog_style_manager.cpp:475
-msgid "style paste"
-msgstr "Stil einfügen"
-
-#: ../src/dialog_style_manager.cpp:519
-msgid "Confirm delete from storage"
-msgstr "Löschen aus dem Speicher bestätigen"
-
-#: ../src/dialog_style_manager.cpp:557
-msgid "Confirm delete from current"
-msgstr "Aktuelles Löschen bestätigen"
-
-#: ../src/dialog_style_manager.cpp:561
-msgid "style delete"
-msgstr "Stil löschen"
-
-#: ../src/dialog_style_manager.cpp:596
-msgid "The selected file has no available styles."
-msgstr "Die ausgewählte Datei besitzt keine Stile."
-
-#: ../src/dialog_style_manager.cpp:596
-msgid "Error Importing Styles"
-msgstr "Fehler beim Importieren der Stile"
-
-#: ../src/dialog_style_manager.cpp:602
-msgid "Choose styles to import:"
-msgstr "Stile zum Importieren auswählen:"
-
-#: ../src/dialog_style_manager.cpp:602
-msgid "Import Styles"
-msgstr "Importiere Stile"
-
-#: ../src/dialog_style_manager.cpp:628
-msgid "style import"
-msgstr "Stilimport"
-
-#: ../src/dialog_style_manager.cpp:738
-msgid "Are you sure? This cannot be undone!"
-msgstr "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden!"
-
-#: ../src/dialog_style_manager.cpp:738
-msgid "Sort styles"
-msgstr "Stile sortieren"
-
-#: ../src/dialog_style_manager.cpp:781
-msgid "style move"
-msgstr "Stil verschieben"
-
-#: ../src/auto4_base.h:291
-msgid "File was not recognized as a script"
-msgstr "Die Datei wurde nicht als Skript erkannt"
-
-#: ../src/audio_karaoke.cpp:82
-msgid "Discard all uncommitted splits"
-msgstr "Verwerfe alle nicht übernommenen Splits"
-
-#: ../src/audio_karaoke.cpp:86
-msgid "Commit splits"
-msgstr "Splits übernehmen"
-
-#: ../src/audio_karaoke.cpp:250
-msgid "Karaoke tag"
-msgstr "Karaoke-Tag"
-
-#: ../src/audio_karaoke.cpp:253
-msgid "Change karaoke tag to \\k"
-msgstr "Karaoke-Tag auf \\k ändern"
-
-#: ../src/audio_karaoke.cpp:254
-msgid "Change karaoke tag to \\kf"
-msgstr "Karaoke-Tag auf \\kf ändern"
-
-#: ../src/audio_karaoke.cpp:255
-msgid "Change karaoke tag to \\ko"
-msgstr "Karaoke-Tag auf \\ko ändern"
-
-#: ../src/audio_karaoke.cpp:429
-msgid "karaoke split"
-msgstr "Karaoke-Tag"
-
-#: ../src/subs_controller.cpp:74
-#, c-format
-msgid "File backup saved as \"%s\"."
-msgstr "Backup-Kopie gespeichert als \"%s\"."
-
-#: ../src/subs_controller.cpp:223
-#, c-format
-msgid "Do you want to save changes to %s?"
-msgstr "Wollen Sie die Änderungen in %s speichern?"
-
-#: ../src/subs_controller.cpp:223
-msgid "Unsaved changes"
-msgstr "Ungespeicherte Änderungen"
-
-#: ../src/subs_controller.cpp:346
-msgid "Untitled"
-msgstr "Unbenannt"
-
-#: ../src/subs_controller.cpp:348
-msgid "untitled"
-msgstr "unbenannt"
-
-#: ../src/dialog_timing_processor.cpp:121
-msgid "Apply to styles"
-msgstr "Auf alle Stile anwenden"
-
-#: ../src/dialog_timing_processor.cpp:123
-msgid "Select styles to process. Unchecked ones will be ignored."
-msgstr ""
-"Die zu bearbeitenden Stile auswählen. Nicht ausgewählte Stile werden nicht "
-"angetastet."
-
-#: ../src/dialog_timing_processor.cpp:125 ../src/dialog_paste_over.cpp:82
-msgid "&All"
-msgstr "Alle"
-
-#: ../src/dialog_timing_processor.cpp:126
-msgid "Select all styles"
-msgstr "Wählt alle Stile aus"
-
-#: ../src/dialog_timing_processor.cpp:128 ../src/dialog_paste_over.cpp:84
-msgid "&None"
-msgstr "Keine"
-
-#: ../src/dialog_timing_processor.cpp:129
-msgid "Deselect all styles"
-msgstr "Hebt die Stilauswahl auf"
-
-#: ../src/dialog_timing_processor.cpp:133
-msgid "Affect &selection only"
-msgstr "Auf Auswahl beschränken"
-
-#: ../src/dialog_timing_processor.cpp:138
-msgid "Lead-in/Lead-out"
-msgstr "Einlaufbereiche/Auslaufbereiche"
-
-#: ../src/dialog_timing_processor.cpp:140
-msgid "Add lead &in:"
-msgstr "Einlaufbereich hinzufügen:"
-
-#: ../src/dialog_timing_processor.cpp:142
-msgid "Enable adding of lead-ins to lines"
-msgstr "Den Zeilen Einlaufbereiche hinzufügen"
-
-#: ../src/dialog_timing_processor.cpp:143
-msgid "Lead in to be added, in milliseconds"
-msgstr "Hinzuzufügende Einlaufbereiche in ms"
-
-#: ../src/dialog_timing_processor.cpp:145
-msgid "Add lead &out:"
-msgstr "Auslaufbereiche hinzufügen:"
-
-#: ../src/dialog_timing_processor.cpp:147
-msgid "Enable adding of lead-outs to lines"
-msgstr "Den Zeilen Auslaufbereiche hinzufügen"
-
-#: ../src/dialog_timing_processor.cpp:148
-msgid "Lead out to be added, in milliseconds"
-msgstr "Hinzuzufügende Auslaufbereich in ms"
-
-#: ../src/dialog_timing_processor.cpp:153
-msgid "Make adjacent subtitles continuous"
-msgstr "Die angrenzenden Untertitel kontinuierlich machen"
-
-#: ../src/dialog_timing_processor.cpp:154
-msgid "&Enable"
-msgstr "Aktivieren"
-
-#: ../src/dialog_timing_processor.cpp:156
-msgid ""
-"Enable snapping of subtitles together if they are within a certain distance "
-"of each other"
-msgstr ""
-"Untertitel, die weniger als einen bestimmten Abstand voneinander haben, "
-"durchgängig machen"
-
-#: ../src/dialog_timing_processor.cpp:159
-msgid "Max gap:"
-msgstr "Max. Lücke:"
-
-#: ../src/dialog_timing_processor.cpp:160
-msgid ""
-"Maximum difference between start and end time for two subtitles to be made "
-"continuous, in milliseconds"
-msgstr ""
-"Maximaler Abstand zwischen Untertiteln, die zusammenhängend gemacht werden "
-"(in ms)"
-
-#: ../src/dialog_timing_processor.cpp:161
-msgid "Max overlap:"
-msgstr "Max. Überlappung:"
-
-#: ../src/dialog_timing_processor.cpp:162
-msgid ""
-"Maximum overlap between the end and start time for two subtitles to be made "
-"continuous, in milliseconds"
-msgstr ""
-"Maximale Überlappung zwischen Untertiteln, die zusammenhängend gemacht "
-"werden (in ms)"
-
-#: ../src/dialog_timing_processor.cpp:165
-msgid ""
-"Sets how to set the adjoining of lines. If set totally to left, it will "
-"extend or shrink start time of the second line; if totally to right, it will "
-"extend or shrink the end time of the first line."
-msgstr ""
-"Stellt ein, wie angrenzende Zeilen gesetzt werden. Ganz links gesetzt, wird "
-"die Startzeit der zweiten Zeile verlängert oder verkürzt, ganz rechts wird "
-"die Endzeit der ersten Zeile verlängert oder verkürzt."
-
-#: ../src/dialog_timing_processor.cpp:168
-msgid "Bias: Start <- "
-msgstr "Gewichtung: Anfang <- "
-
-#: ../src/dialog_timing_processor.cpp:170
-msgid " -> End"
-msgstr " -> Ende"
-
-#: ../src/dialog_timing_processor.cpp:178
-msgid "Keyframe snapping"
-msgstr "Einrasten auf Keyframes"
-
-#: ../src/dialog_timing_processor.cpp:181
-msgid "E&nable"
-msgstr "Aktivieren"
-
-#: ../src/dialog_timing_processor.cpp:182
-msgid ""
-"Enable snapping of subtitles to nearest keyframe, if distance is within "
-"threshold"
-msgstr ""
-"Aktiviert das Einrasten auf den nächstgelegenen Keyframe, falls dieser "
-"innerhalb des festgelegten Bereichs liegt"
-
-#: ../src/dialog_timing_processor.cpp:193
-msgid "Starts before thres.:"
-msgstr "Fängt vor Bereich an:"
-
-#: ../src/dialog_timing_processor.cpp:194
-msgid ""
-"Threshold for 'before start' distance, that is, how many milliseconds a "
-"subtitle must start before a keyframe to snap to it"
-msgstr ""
-"Bereich für 'vor Anfang', d.h. wieviele Millisekunden ein Untertitel vor "
-"einem Keyframe anfangen darf, um darauf einzurasten"
-
-#: ../src/dialog_timing_processor.cpp:196
-msgid "Starts after thres.:"
-msgstr "Fängt nach Bereich an:"
-
-#: ../src/dialog_timing_processor.cpp:197
-msgid ""
-"Threshold for 'after start' distance, that is, how many milliseconds a "
-"subtitle must start after a keyframe to snap to it"
-msgstr ""
-"Bereich für 'nach Anfang', d.h. wieviele Millisekunden ein Untertitel nach "
-"einem Keyframe anfangen darf, um darauf einzurasten"
-
-#: ../src/dialog_timing_processor.cpp:201
-msgid "Ends before thres.:"
-msgstr "Hört vor Bereich auf:"
-
-#: ../src/dialog_timing_processor.cpp:202
-msgid ""
-"Threshold for 'before end' distance, that is, how many milliseconds a "
-"subtitle must end before a keyframe to snap to it"
-msgstr ""
-"Bereich für 'vor Ende', d.h. wieviele Millisekunden ein Untertitel vor einem "
-"Keyframe enden darf, um darauf einzurasten"
-
-#: ../src/dialog_timing_processor.cpp:204
-msgid "Ends after thres.:"
-msgstr "Hört nach Bereich auf:"
-
-#: ../src/dialog_timing_processor.cpp:205
-msgid ""
-"Threshold for 'after end' distance, that is, how many milliseconds a "
-"subtitle must end after a keyframe to snap to it"
-msgstr ""
-"Bereich für 'nach Ende', d.h. wieviele Millisekunden ein Untertitel nach "
-"einem Keyframe enden darf, um darauf einzurasten"
-
-#: ../src/dialog_timing_processor.cpp:319
-#, c-format
-msgid "One of the lines in the file (%i) has negative duration. Aborting."
-msgstr "Eine der Zeilen in der Datei (%i) hat eine negative Dauer. Abbruch."
-
-#: ../src/dialog_timing_processor.cpp:320
-msgid "Invalid script"
-msgstr "Ungültiges Skript"
-
-#: ../src/dialog_timing_processor.cpp:416
-msgid "timing processor"
-msgstr "Timingverarbeitung"
-
-#: ../src/dialog_translation.cpp:80
-msgid "Original"
-msgstr "Original"
-
-#: ../src/dialog_translation.cpp:102
-msgid "Translation"
-msgstr "Übersetzung"
-
-#: ../src/dialog_translation.cpp:110 ../src/dialog_styling_assistant.cpp:89
-msgid "Keys"
-msgstr "Tasten"
-
-#: ../src/dialog_translation.cpp:115 ../src/dialog_styling_assistant.cpp:94
-msgid "Previous line"
-msgstr "Vorherige Zeile"
-
-#: ../src/dialog_translation.cpp:116 ../src/dialog_styling_assistant.cpp:95
-msgid "Next line"
-msgstr "Nächste Zeile"
-
-#: ../src/dialog_translation.cpp:117
-msgid "Insert original"
-msgstr "Original einfügen"
-
-#: ../src/dialog_translation.cpp:118 ../src/dialog_styling_assistant.cpp:96
-msgid "Play video"
-msgstr "Video abspielen"
-
-#: ../src/dialog_translation.cpp:119 ../src/dialog_styling_assistant.cpp:97
-msgid "Play audio"
-msgstr "Audio abspielen"
-
-#: ../src/dialog_translation.cpp:120
-msgid "Delete line"
-msgstr "Zeile löschen"
-
-#: ../src/dialog_translation.cpp:123
-msgid "Enable &preview"
-msgstr "Vorschau aktivieren"
-
-#: ../src/dialog_translation.cpp:131 ../src/dialog_styling_assistant.cpp:112
-msgid "Actions"
-msgstr "Aktionen"
-
-#: ../src/dialog_translation.cpp:133 ../src/dialog_styling_assistant.cpp:115
-msgid "Play &Audio"
-msgstr "Audio abspielen"
-
-#: ../src/dialog_translation.cpp:138 ../src/dialog_styling_assistant.cpp:119
-msgid "Play &Video"
-msgstr "Video abspielen"
-
-#: ../src/dialog_translation.cpp:164
-msgid "There is nothing to translate in the file."
-msgstr "In der Datei ist nichts zu übersetzen."
-
-#: ../src/dialog_translation.cpp:182 ../src/dialog_translation.cpp:284
-msgid "No more lines to translate."
-msgstr "Keine weiteren Zeilen zum Übersetzen."
-
-#: ../src/dialog_translation.cpp:190 ../src/dialog_translation.cpp:242
-#, c-format
-msgid "Current line: %d/%d"
-msgstr "Aktuelle Zeile: %d/%d"
-
-#: ../src/dialog_translation.cpp:279
-msgid "translation assistant"
-msgstr "Übersetzungsassistent"
-
-#: ../src/dialog_kara_timing_copy.cpp:64
+#: ../src/dialog_kara_timing_copy.cpp:57
 msgid "Source: "
 msgstr "Quelle:"
 
-#: ../src/dialog_kara_timing_copy.cpp:65
+#: ../src/dialog_kara_timing_copy.cpp:58
 msgid "Dest: "
 msgstr "Ziel:"
 
-#: ../src/dialog_kara_timing_copy.cpp:598
+#: ../src/dialog_kara_timing_copy.cpp:470
 msgid "Kanji timing"
 msgstr "Kanji-Timing"
 
-#: ../src/dialog_kara_timing_copy.cpp:605 ../src/dialog_paste_over.cpp:67
-#: ../src/base_grid.cpp:488 ../src/base_grid.cpp:905
-#: ../src/dialog_search_replace.cpp:85
+#: ../src/dialog_kara_timing_copy.cpp:475 ../src/dialog_paste_over.cpp:73
+#: ../src/grid_column.cpp:334 ../src/grid_column.cpp:335
 msgid "Text"
 msgstr "Text"
 
-#: ../src/dialog_kara_timing_copy.cpp:606
+#: ../src/dialog_kara_timing_copy.cpp:476
 msgid "Styles"
 msgstr "Stile"
 
-#: ../src/dialog_kara_timing_copy.cpp:608
+#: ../src/dialog_kara_timing_copy.cpp:478
 msgid "Shortcut Keys"
 msgstr "Shortcut-Tasten"
 
-#: ../src/dialog_kara_timing_copy.cpp:609
+#: ../src/dialog_kara_timing_copy.cpp:479
 msgid "Commands"
 msgstr "Befehle"
 
-#: ../src/dialog_kara_timing_copy.cpp:617
+#: ../src/dialog_kara_timing_copy.cpp:487
 msgid "Attempt to &interpolate kanji."
 msgstr "Versuche, Kanji zu interpolieren."
 
-#: ../src/dialog_kara_timing_copy.cpp:624
+#: ../src/dialog_kara_timing_copy.cpp:494
 msgid ""
 "When the destination textbox has focus, use the following keys:\n"
 "\n"
@@ -3963,92 +4508,462 @@ msgstr ""
 "Eingabe-Taste: Verknüpfen, Zeile akzeptieren wenn fertig\n"
 "Rücktaste: Letzte Verknüpfung lösen"
 
-#: ../src/dialog_kara_timing_copy.cpp:627
+#: ../src/dialog_kara_timing_copy.cpp:497
 msgid "S&tart!"
 msgstr "Los!"
 
-#: ../src/dialog_kara_timing_copy.cpp:628
+#: ../src/dialog_kara_timing_copy.cpp:498
 msgid "&Link"
 msgstr "Verknüpfen"
 
-#: ../src/dialog_kara_timing_copy.cpp:629
+#: ../src/dialog_kara_timing_copy.cpp:499
 msgid "&Unlink"
 msgstr "Verknüpfung lösen"
 
-#: ../src/dialog_kara_timing_copy.cpp:630
+#: ../src/dialog_kara_timing_copy.cpp:500
 msgid "Skip &Source Line"
 msgstr "Überspringe Quellzeile"
 
-#: ../src/dialog_kara_timing_copy.cpp:631
+#: ../src/dialog_kara_timing_copy.cpp:501
 msgid "Skip &Dest Line"
 msgstr "Überspringe Zielzeile"
 
-#: ../src/dialog_kara_timing_copy.cpp:632
+#: ../src/dialog_kara_timing_copy.cpp:502
 msgid "&Go Back a Line"
 msgstr "Eine Zeile zurückgehen"
 
-#: ../src/dialog_kara_timing_copy.cpp:633
+#: ../src/dialog_kara_timing_copy.cpp:503
 msgid "&Accept Line"
 msgstr "Zeile akzeptieren"
 
-#: ../src/dialog_kara_timing_copy.cpp:634 ../src/dialog_automation.cpp:78
-#: ../src/dialog_attachments.cpp:77 ../src/dialog_version_check.cpp:142
+#: ../src/dialog_kara_timing_copy.cpp:504 ../src/dialog_automation.cpp:122
+#: ../src/dialog_attachments.cpp:89 ../src/dialog_version_check.cpp:126
 msgid "&Close"
 msgstr "&Schließen"
 
-#: ../src/dialog_kara_timing_copy.cpp:698
+#: ../src/dialog_kara_timing_copy.cpp:566
 msgid "kanji timing"
 msgstr "Kanji-Timing"
 
-#: ../src/dialog_kara_timing_copy.cpp:706
+#: ../src/dialog_kara_timing_copy.cpp:574
 msgid "Select source and destination styles first."
 msgstr "Wahlen Sie zuerst Quell- und Zielstile."
 
-#: ../src/dialog_kara_timing_copy.cpp:708
+#: ../src/dialog_kara_timing_copy.cpp:576
 msgid "The source and destination styles must be different."
 msgstr "Die Quell- und Zielstile müssen unterschiedlich sein."
 
-#: ../src/dialog_kara_timing_copy.cpp:753
+#: ../src/dialog_kara_timing_copy.cpp:626
 msgid "Group all of the source text."
 msgstr "Gruppiere alle Quelltexte."
 
-#: ../src/font_file_lister.cpp:137
+#: ../src/hotkey.cpp:175
+#, fuzzy
+msgid "Invalid command name for hotkey"
+msgstr "'%s' ist kein gültiger Kommandoname"
+
+#: ../src/dialog_paste_over.cpp:55
+msgid "Select Fields to Paste Over"
+msgstr "Wählen Sie Felder zum Überschreiben"
+
+#: ../src/dialog_paste_over.cpp:58
+msgid "Fields"
+msgstr "Felder"
+
+#: ../src/dialog_paste_over.cpp:59
+msgid "Please select the fields that you want to paste over:"
+msgstr "Bitte wählen Sie die Felder, die Sie überschreiben möchten:"
+
+#: ../src/dialog_paste_over.cpp:63
+#, fuzzy
+msgid "Comment"
+msgstr "Kommentar"
+
+#: ../src/dialog_paste_over.cpp:67 ../src/grid_column.cpp:177
+#: ../src/grid_column.cpp:178
+msgid "Style"
+msgstr "Stil"
+
+#: ../src/dialog_paste_over.cpp:68 ../src/subs_edit_box.cpp:140
+#: ../src/grid_column.cpp:205 ../src/grid_column.cpp:206
+msgid "Actor"
+msgstr "Sprecher"
+
+#: ../src/dialog_paste_over.cpp:69
+msgid "Margin Left"
+msgstr "Linker Rand"
+
+#: ../src/dialog_paste_over.cpp:70
+msgid "Margin Right"
+msgstr "Rechter Rand"
+
+#: ../src/dialog_paste_over.cpp:71
+msgid "Margin Vertical"
+msgstr "Vertikaler Rand"
+
+#: ../src/dialog_paste_over.cpp:92
+msgid "&Times"
+msgstr "Zeiten"
+
+#: ../src/dialog_paste_over.cpp:94
+msgid "T&ext"
+msgstr "Text"
+
+#: ../src/main.cpp:274
+#, c-format
+msgid ""
+"Oops, Aegisub has crashed!\n"
+"\n"
+"An attempt has been made to save a copy of your file to:\n"
+"\n"
+"%s\n"
+"\n"
+"Aegisub will now close."
+msgstr ""
+"Au weia, Aegisub ist abgestürzt!\n"
+"\n"
+"Es wurde versucht, eine Kopie Ihrer Änderungen in eine Datei zu schreiben:\n"
+"\n"
+"%s\n"
+"\n"
+"Aegisub wird nun beendet."
+
+#: ../src/main.cpp:302
+msgid ""
+"Do you want Aegisub to check for updates whenever it starts? You can still "
+"do it manually via the Help menu."
+msgstr ""
+"Wollen Sie immer auf Updates prüfen, wenn Aegisub startet? Sie können dies "
+"auch manuell über das Hilfe-Menü tun."
+
+#: ../src/main.cpp:302
+msgid "Check for updates?"
+msgstr "Auf Updates prüfen?"
+
+#: ../src/main.cpp:387 ../src/main.cpp:392
+msgid "Program error"
+msgstr "Programmfehler"
+
+#: ../src/main.cpp:406
+#, c-format
+msgid ""
+"An unexpected error has occurred. Please save your work and restart "
+"Aegisub.\n"
+"\n"
+"Error Message: %s"
+msgstr ""
+
+#: ../src/subs_edit_box.cpp:119
+msgid "&Comment"
+msgstr "Kommentar"
+
+#: ../src/subs_edit_box.cpp:120
+msgid "Comment this line out. Commented lines don't show up on screen."
+msgstr ""
+"Diese Zeile auskommentieren. Auskommentierte Zeilen erscheinen nicht im "
+"Video."
+
+#: ../src/subs_edit_box.cpp:127
+msgid "Style for this line"
+msgstr "Stil für diese Zeile"
+
+#: ../src/subs_edit_box.cpp:129 ../src/subs_edit_box.cpp:130
+#, fuzzy
+msgid "Edit"
+msgstr "&Bearbeiten"
+
+#: ../src/subs_edit_box.cpp:140
+msgid ""
+"Actor name for this speech. This is only for reference, and is mainly "
+"useless."
+msgstr ""
+"Sprechername für diese Zeile. Nur für Referenzzwecke, hat keinerlei "
+"sichtbare Auswirkungen."
+
+#: ../src/subs_edit_box.cpp:145
+msgid ""
+"Effect for this line. This can be used to store extra information for "
+"karaoke scripts, or for the effects supported by the renderer."
+msgstr ""
+"Effekt für diese Zeile. Kann benutzt werden, um gesonderte Informationen für "
+"Karaokeskripte abzulegen, oder um vom Renderer unterstützte Effekte zu "
+"aktivieren."
+
+#: ../src/subs_edit_box.cpp:151
+msgid "Number of characters in the longest line of this subtitle."
+msgstr "Anzahl der Zeichen in der längsten Zeile dieses Untertitels."
+
+#: ../src/subs_edit_box.cpp:158
+msgid "Layer number"
+msgstr "Ebenennummer"
+
+#: ../src/subs_edit_box.cpp:162
+msgid "Start time"
+msgstr "Startzeit"
+
+#: ../src/subs_edit_box.cpp:163
+msgid "End time"
+msgstr "Endzeit"
+
+#: ../src/subs_edit_box.cpp:165
+msgid "Line duration"
+msgstr "Dauer der Zeile"
+
+#: ../src/subs_edit_box.cpp:168
+msgid "Left Margin (0 = default from style)"
+msgstr "Linker Rand (0 = Voreinstellung des Stils)"
+
+#: ../src/subs_edit_box.cpp:168
+msgid "left margin change"
+msgstr "Linken Rand ändern"
+
+#: ../src/subs_edit_box.cpp:169
+msgid "Right Margin (0 = default from style)"
+msgstr "Rechter Rand (0 = Voreinstellung des Stils)"
+
+#: ../src/subs_edit_box.cpp:169
+msgid "right margin change"
+msgstr "Rechten Rand ändern"
+
+#: ../src/subs_edit_box.cpp:170
+msgid "Vertical Margin (0 = default from style)"
+msgstr "Vertikaler Rand (0 = Voreinstellung des Stils)"
+
+#: ../src/subs_edit_box.cpp:170
+msgid "vertical margin change"
+msgstr "Vertikalen Rand ändern"
+
+#: ../src/subs_edit_box.cpp:189
+msgid "T&ime"
+msgstr "Zeit"
+
+#: ../src/subs_edit_box.cpp:189
+msgid "Time by h:mm:ss.cs"
+msgstr "Zeit als h:mm:ss.cs"
+
+#: ../src/subs_edit_box.cpp:190
+msgid "F&rame"
+msgstr "Frame"
+
+#: ../src/subs_edit_box.cpp:190
+msgid "Time by frame number"
+msgstr "Zeit als Framenummer"
+
+#: ../src/subs_edit_box.cpp:193
+msgid "Show Original"
+msgstr "Original anzeigen"
+
+#: ../src/subs_edit_box.cpp:194
+msgid ""
+"Show the contents of the subtitle line when it was first selected above the "
+"edit box. This is sometimes useful when editing subtitles or translating "
+"subtitles into another language."
+msgstr ""
+"Zeigt den Inhalt der Untertitel-Zeile an, als sie zuerst ausgewählt wurde. "
+"Dies kann hilfreich sein, wenn Untertitel bearbeitet werden oder in eine "
+"andere Sprache übersetzt werden."
+
+#: ../src/subs_edit_box.cpp:441
+msgid "modify text"
+msgstr "Text ändern"
+
+#: ../src/subs_edit_box.cpp:516
+msgid "modify times"
+msgstr "Zeiten ändern"
+
+#: ../src/subs_edit_box.cpp:590 ../src/dialog_style_editor.cpp:453
+msgid "style change"
+msgstr "Stil wechseln"
+
+#: ../src/subs_edit_box.cpp:596
+msgid "actor change"
+msgstr "Sprecher ändern"
+
+#: ../src/subs_edit_box.cpp:601
+msgid "layer change"
+msgstr "Ebene ändern"
+
+#: ../src/subs_edit_box.cpp:606
+msgid "effect change"
+msgstr "Effekt ändern"
+
+#: ../src/subs_edit_box.cpp:611
+msgid "comment change"
+msgstr "Kommentar ändern"
+
+#: ../src/dialog_selection.cpp:106
+msgid "Select"
+msgstr "Auswählen"
+
+#: ../src/dialog_selection.cpp:117
+msgid "Match"
+msgstr "Übereinstimmung"
+
+#: ../src/dialog_selection.cpp:121
+msgid "&Matches"
+msgstr "Übereinstimmungen"
+
+#: ../src/dialog_selection.cpp:122
+msgid "&Doesn't Match"
+msgstr "Keine Übereinstimmung"
+
+#: ../src/dialog_selection.cpp:123
+msgid "Match c&ase"
+msgstr "Groß-/Kleinschreibung beachten"
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Exact match"
+msgstr "Genaue Übereinstimmung"
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Contains"
+msgstr "Enthält"
+
+#: ../src/dialog_selection.cpp:132
+msgid "&Regular Expression match"
+msgstr "Regulärer Ausdruck"
+
+#: ../src/dialog_selection.cpp:133
+msgid "Mode"
+msgstr "Modus"
+
+#: ../src/dialog_selection.cpp:137 ../src/dialog_search_replace.cpp:87
+msgid "&Text"
+msgstr "Text"
+
+#: ../src/dialog_selection.cpp:137
+msgid "&Style"
+msgstr "Stil"
+
+#: ../src/dialog_selection.cpp:137
+msgid "Act&or"
+msgstr "Sprecher"
+
+#: ../src/dialog_selection.cpp:137
+msgid "E&ffect"
+msgstr "Effekt"
+
+#: ../src/dialog_selection.cpp:138 ../src/dialog_search_replace.cpp:90
+msgid "In Field"
+msgstr "In Feld"
+
+#: ../src/dialog_selection.cpp:142
+msgid "Match dialogues/comments"
+msgstr "Dialoge/Kommentare vergleichen"
+
+#: ../src/dialog_selection.cpp:143
+msgid "D&ialogues"
+msgstr "Dialoge"
+
+#: ../src/dialog_selection.cpp:144
+msgid "Comme&nts"
+msgstr "Kommentare"
+
+#: ../src/dialog_selection.cpp:149
+msgid "Set se&lection"
+msgstr "Auswahl setzen"
+
+#: ../src/dialog_selection.cpp:149
+msgid "&Add to selection"
+msgstr "Auswahl erweitern"
+
+#: ../src/dialog_selection.cpp:149
+msgid "S&ubtract from selection"
+msgstr "Von Auswahl entfernen"
+
+#: ../src/dialog_selection.cpp:149
+msgid "Intersect &with selection"
+msgstr "Schnittmenge mit Auswahl"
+
+#: ../src/dialog_selection.cpp:211
+#, fuzzy, c-format
+msgid "Selection was set to one line"
+msgid_plural "Selection was set to %u lines"
+msgstr[0] "Es wurde eine Zeile ausgewählt"
+msgstr[1] "Es wurde eine Zeile ausgewählt"
+
+#: ../src/dialog_selection.cpp:212
+msgid "Selection was set to no lines"
+msgstr "Es wurde keine Zeile ausgewählt"
+
+#: ../src/dialog_selection.cpp:218
+#, fuzzy, c-format
+msgid "One line was added to selection"
+msgid_plural "%u lines were added to selection"
+msgstr[0] "Eine Zeile wurde zur Auswahl hinzugefügt"
+msgstr[1] "Eine Zeile wurde zur Auswahl hinzugefügt"
+
+#: ../src/dialog_selection.cpp:219
+msgid "No lines were added to selection"
+msgstr "Keine Zeile wurde zur Auswahl hinzugefügt"
+
+#: ../src/dialog_selection.cpp:230
+#, fuzzy, c-format
+msgid "One line was removed from selection"
+msgid_plural "%u lines were removed from selection"
+msgstr[0] "Eine Zeile wurde aus der Auswahl entfernt"
+msgstr[1] "Eine Zeile wurde aus der Auswahl entfernt"
+
+#: ../src/dialog_selection.cpp:231
+msgid "No lines were removed from selection"
+msgstr "Keine Zeile wurde aus der Auswahl entfernt"
+
+#: ../src/dialog_selection.cpp:236
+msgid "Selection"
+msgstr "Auswahl"
+
+#: ../src/font_file_lister.cpp:72
+#, c-format
+msgid "Style '%s' does not exist\n"
+msgstr ""
+
+#: ../src/font_file_lister.cpp:138
 #, c-format
 msgid "Could not find font '%s'\n"
 msgstr "Konnte Schriftart '%s' nicht finden\n"
 
-#: ../src/font_file_lister.cpp:144
+#: ../src/font_file_lister.cpp:145
 #, c-format
 msgid "Found '%s' at '%s'\n"
 msgstr "'%s' in '%s' gefunden\n"
 
 #: ../src/font_file_lister.cpp:149
 #, c-format
+msgid "'%s' does not have a bold variant.\n"
+msgstr ""
+
+#: ../src/font_file_lister.cpp:151
+#, c-format
+msgid "'%s' does not have an italic variant.\n"
+msgstr ""
+
+#: ../src/font_file_lister.cpp:155
+#, c-format
 msgid "'%s' is missing %d glyphs used.\n"
 msgstr "'%s' fehlen %d verwendete Zeichen.\n"
 
-#: ../src/font_file_lister.cpp:151
+#: ../src/font_file_lister.cpp:157
 #, c-format
 msgid "'%s' is missing the following glyphs used: %s\n"
 msgstr "'%s' fehlen die folgenden, verwendeten Zeichen: %s\n"
 
-#: ../src/font_file_lister.cpp:160
+#: ../src/font_file_lister.cpp:168
 msgid "Used in styles:\n"
 msgstr "Benutzt in Stilen:\n"
 
-#: ../src/font_file_lister.cpp:166
+#: ../src/font_file_lister.cpp:174
 msgid "Used on lines:"
 msgstr "Benutzt in Zeilen:"
 
-#: ../src/font_file_lister.cpp:178
+#: ../src/font_file_lister.cpp:186
 msgid "Parsing file\n"
 msgstr "Lese Datei\n"
 
-#: ../src/font_file_lister.cpp:192
+#: ../src/font_file_lister.cpp:200
 msgid "Searching for font files\n"
 msgstr "Suche nach Schriftarten\n"
 
-#: ../src/font_file_lister.cpp:194
+#: ../src/font_file_lister.cpp:202
 msgid ""
 "Done\n"
 "\n"
@@ -4056,564 +4971,34 @@ msgstr ""
 "Fertig\n"
 "\n"
 
-#: ../src/font_file_lister.cpp:201
+#: ../src/font_file_lister.cpp:209
 msgid "All fonts found.\n"
 msgstr "Fertig. Alle Schriftarten gefunden.\n"
 
-#: ../src/font_file_lister.cpp:203
-#, c-format
-msgid "%d fonts could not be found.\n"
-msgstr "%d Schriftarten konnten nicht gefunden werden.\n"
+#: ../src/font_file_lister.cpp:211
+#, fuzzy, c-format
+msgid "One font could not be found\n"
+msgid_plural "%d fonts could not be found.\n"
+msgstr[0] "%d Schriftarten konnten nicht gefunden werden.\n"
+msgstr[1] "%d Schriftarten konnten nicht gefunden werden.\n"
 
-#: ../src/font_file_lister.cpp:205
-#, c-format
-msgid "%d fonts were found, but were missing glyphs used in the script.\n"
-msgstr ""
+#: ../src/font_file_lister.cpp:214
+#, fuzzy, c-format
+msgid "One font was found, but was missing glyphs used in the script.\n"
+msgid_plural ""
+"%d fonts were found, but were missing glyphs used in the script.\n"
+msgstr[0] ""
+"%d Schriftarten wurden gefunden, aber es fehlen Zeichen, die im Skript "
+"benutzt werden.\n"
+msgstr[1] ""
 "%d Schriftarten wurden gefunden, aber es fehlen Zeichen, die im Skript "
 "benutzt werden.\n"
 
-#: ../src/font_file_lister_fontconfig.cpp:85
-msgid "Updating font cache\n"
-msgstr "Aktualisiere Schriftartencache\n"
-
-#: ../src/visual_tool.cpp:130
-msgid "visual typesetting"
-msgstr "Visuelles Typesetting"
-
-#: ../src/dialog_fonts_collector.cpp:91
-msgid "Symlinking fonts to folder...\n"
-msgstr "Verknüpfe Schriftarten in Ordner...\n"
-
-#: ../src/dialog_fonts_collector.cpp:95
-msgid "Copying fonts to folder...\n"
-msgstr "Kopiere Schriftarten in Ordner...\n"
-
-#: ../src/dialog_fonts_collector.cpp:98
-msgid "Copying fonts to archive...\n"
-msgstr "Kopiere Schriftarten in Archiv...\n"
-
-#: ../src/dialog_fonts_collector.cpp:159
-#, c-format
-msgid "* Copied %s.\n"
-msgstr "* Kopiert: %s\n"
-
-#: ../src/dialog_fonts_collector.cpp:161
-#, c-format
-msgid "* %s already exists on destination.\n"
-msgstr "* %s existiert bereits am Zielort.\n"
-
-#: ../src/dialog_fonts_collector.cpp:163
-#, c-format
-msgid "* Symlinked %s.\n"
-msgstr "* Verknüpft: %s\n"
-
-#: ../src/dialog_fonts_collector.cpp:165
-#, c-format
-msgid "* Failed to copy %s.\n"
-msgstr "* Kopieren fehlgeschlagen: %s\n"
-
-#: ../src/dialog_fonts_collector.cpp:171
-msgid "Done. All fonts copied."
-msgstr "Fertig. Alle Schriftarten kopiert."
-
-#: ../src/dialog_fonts_collector.cpp:173
-msgid "Done. Some fonts could not be copied."
-msgstr "Fertig. Einige Schriftarten konnten nicht kopiert werden."
-
-#: ../src/dialog_fonts_collector.cpp:176
-msgid ""
-"\n"
-"Over 32 MB of fonts were copied. Some of the fonts may not be loaded by the "
-"player if they are all attached to a Matroska file."
-msgstr ""
-"\n"
-"Mehr als 32 MB an Schriftarten wurden kopiert. Einige der Schriftarten "
-"können vielleicht nicht vom Video-Abspieler geladen werden, wenn alle davon "
-"an eine Matroska-Datei angehängt werden."
-
-#: ../src/dialog_fonts_collector.cpp:191
-msgid "Check fonts for availability"
-msgstr "Teste, ob alle Schriftarten verfügbar sind"
-
-#: ../src/dialog_fonts_collector.cpp:192
-msgid "Copy fonts to folder"
-msgstr "Kopiere Schriftarten in Ordner"
-
-#: ../src/dialog_fonts_collector.cpp:193
-msgid "Copy fonts to subtitle file's folder"
-msgstr "Kopiere Schriftarten in den Ordner der Untertitel-Datei"
-
-#: ../src/dialog_fonts_collector.cpp:194
-msgid "Copy fonts to zipped archive"
-msgstr "Kopiere Schriftarten in Archiv"
-
-#: ../src/dialog_fonts_collector.cpp:196
-msgid "Symlink fonts to folder"
-msgstr "Verknüpfe Schriftarten in Ordner"
-
-#: ../src/dialog_fonts_collector.cpp:199 ../src/dialog_selection.cpp:136
-msgid "Action"
-msgstr "Aktion"
-
-#: ../src/dialog_fonts_collector.cpp:205
-msgid "Destination"
-msgstr "Ziel"
-
-#: ../src/dialog_fonts_collector.cpp:209
-msgid "&Browse..."
-msgstr "&Durchsuchen..."
-
-#: ../src/dialog_fonts_collector.cpp:218
-msgid "Log"
-msgstr "Log"
-
-#: ../src/dialog_fonts_collector.cpp:231
-msgid "&Start!"
-msgstr "&Los!"
-
-#: ../src/dialog_fonts_collector.cpp:268
-msgid "Invalid destination."
-msgstr "Ungültiges Ziel."
-
-#: ../src/dialog_fonts_collector.cpp:273
-msgid "Could not create destination folder."
-msgstr "Kann Zielordner nicht anlegen."
-
-#: ../src/dialog_fonts_collector.cpp:278
-msgid "Invalid path for .zip file."
-msgstr "Ungültiger Pfad für .zip-Datei"
-
-#: ../src/dialog_fonts_collector.cpp:302
-msgid "Select archive file name"
-msgstr "Archivdatei wählen"
-
-#: ../src/dialog_fonts_collector.cpp:309
-msgid "Select folder to save fonts on"
-msgstr "Ordner fürs Schriftarten-Speichern auswählen"
-
-#: ../src/dialog_fonts_collector.cpp:323
-msgid "N/A"
-msgstr "Nichts"
-
-#: ../src/dialog_fonts_collector.cpp:331
-msgid ""
-"Choose the folder where the fonts will be collected to. It will be created "
-"if it doesn't exist."
-msgstr ""
-"Wählen Sie den Ordner für das Sammeln der Schriftarten. Wenn er nicht "
-"existiert, wird er angelegt."
-
-#: ../src/dialog_fonts_collector.cpp:338
-msgid ""
-"Enter the name of the destination zip file to collect the fonts to. If a "
-"folder is entered, a default name will be used."
-msgstr ""
-"Geben Sie den Namen des zip-Archives am Zielort an, wo die Schriftarten "
-"gespeichert werden sollen. Wenn ein Ordnernamen eingegeben wurde, wird der "
-"Standardname verwendet."
-
-#: ../src/audio_provider_ram.cpp:69
-msgid "Reading into RAM"
-msgstr "Lade in Arbeitsspeicher"
-
-#: ../src/dialog_style_editor.cpp:144
-msgid "Style Editor"
-msgstr "Stil-Editor"
-
-#: ../src/dialog_style_editor.cpp:176
-msgid "Font"
-msgstr "Schriftart"
-
-#: ../src/dialog_style_editor.cpp:178
-msgid "Margins"
-msgstr "Ränder"
-
-#: ../src/dialog_style_editor.cpp:179 ../src/dialog_style_editor.cpp:272
-msgid "Outline"
-msgstr "Umrandung"
-
-#: ../src/dialog_style_editor.cpp:180
-msgid "Miscellaneous"
-msgstr "Verschiedenes"
-
-#: ../src/dialog_style_editor.cpp:181
-msgid "Preview"
-msgstr "Vorschau"
-
-#: ../src/dialog_style_editor.cpp:187
-msgid "&Bold"
-msgstr "Fett"
-
-#: ../src/dialog_style_editor.cpp:188
-msgid "&Italic"
-msgstr "Kursiv"
-
-#: ../src/dialog_style_editor.cpp:189
-msgid "&Underline"
-msgstr "Unterstrichen"
-
-#: ../src/dialog_style_editor.cpp:190
-msgid "&Strikeout"
-msgstr "Durchgestrichen"
-
-#: ../src/dialog_style_editor.cpp:199
-msgid "Alignment"
-msgstr "Ausrichtung"
-
-#: ../src/dialog_style_editor.cpp:202
-msgid "&Opaque box"
-msgstr "Undurchsichtiger Kasten"
-
-#: ../src/dialog_style_editor.cpp:210
-msgid "Style name"
-msgstr "Stilname"
-
-#: ../src/dialog_style_editor.cpp:211
-msgid "Font face"
-msgstr "Schriftart"
-
-#: ../src/dialog_style_editor.cpp:212
-msgid "Font size"
-msgstr "Schriftgröße"
-
-#: ../src/dialog_style_editor.cpp:213
-msgid "Choose primary color"
-msgstr "Wähle Primärfarbe"
-
-#: ../src/dialog_style_editor.cpp:214
-msgid "Choose secondary color"
-msgstr "Wähle Sekundärfarbe"
-
-#: ../src/dialog_style_editor.cpp:215
-msgid "Choose outline color"
-msgstr "Wähle Umrandungsfarbe"
-
-#: ../src/dialog_style_editor.cpp:216
-msgid "Choose shadow color"
-msgstr "Wähle Schattenfarbe"
-
-#: ../src/dialog_style_editor.cpp:217
-msgid "Distance from left edge, in pixels"
-msgstr "Abstand vom linken Rand in Pixeln"
-
-#: ../src/dialog_style_editor.cpp:218
-msgid "Distance from right edge, in pixels"
-msgstr "Abstand vom rechten Rand in Pixeln"
-
-#: ../src/dialog_style_editor.cpp:219
-msgid "Distance from top/bottom edge, in pixels"
-msgstr "Abstand von oberem/unterem Rand in Pixeln"
-
-#: ../src/dialog_style_editor.cpp:220
-msgid ""
-"When selected, display an opaque box behind the subtitles instead of an "
-"outline around the text"
-msgstr ""
-"Zeigt statt einer Umrandung einen undurchsichtigen Kasten hinter den "
-"Untertiteln an"
-
-#: ../src/dialog_style_editor.cpp:221
-msgid "Outline width, in pixels"
-msgstr "Umrandungsdicke in Pixeln"
-
-#: ../src/dialog_style_editor.cpp:222
-msgid "Shadow distance, in pixels"
-msgstr "Schattenentfernung in Pixeln"
-
-#: ../src/dialog_style_editor.cpp:223
-msgid "Scale X, in percentage"
-msgstr "Horizontale Skalierung (%)"
-
-#: ../src/dialog_style_editor.cpp:224
-msgid "Scale Y, in percentage"
-msgstr "Vertikale Skalierung (%)"
-
-#: ../src/dialog_style_editor.cpp:225
-msgid "Angle to rotate in Z axis, in degrees"
-msgstr "Rotationswinkel um die Z-Achse in Grad"
-
-#: ../src/dialog_style_editor.cpp:226
-msgid ""
-"Encoding, only useful in unicode if the font doesn't have the proper unicode "
-"mapping"
-msgstr ""
-"Kodierung, nur sinnvoll im Unicode, falls die Schriftart keine richtigen "
-"Unicode-Tabellen besitzt."
-
-#: ../src/dialog_style_editor.cpp:227
-msgid "Character spacing, in pixels"
-msgstr "Zeichenabstand in Pixeln"
-
-#: ../src/dialog_style_editor.cpp:228
-msgid "Alignment in screen, in numpad style"
-msgstr "Bildschirmausrichtung (wie Ziffernblock)"
-
-#: ../src/dialog_style_editor.cpp:272
-msgid "Primary"
-msgstr "Primär"
-
-#: ../src/dialog_style_editor.cpp:272
-msgid "Secondary"
-msgstr "Sekundär"
-
-#: ../src/dialog_style_editor.cpp:272
-msgid "Shadow"
-msgstr "Schatten"
-
-#: ../src/dialog_style_editor.cpp:283 ../src/base_grid.cpp:488
-#: ../src/base_grid.cpp:771 ../src/base_grid.cpp:902
-msgid "Left"
-msgstr "Links"
-
-#: ../src/dialog_style_editor.cpp:283 ../src/base_grid.cpp:488
-#: ../src/base_grid.cpp:772 ../src/base_grid.cpp:903
-msgid "Right"
-msgstr "Rechts"
-
-#: ../src/dialog_style_editor.cpp:283 ../src/base_grid.cpp:488
-#: ../src/base_grid.cpp:773 ../src/base_grid.cpp:904
-msgid "Vert"
-msgstr "Vertikal"
-
-#: ../src/dialog_style_editor.cpp:301
-msgid "Outline:"
-msgstr "Umrandung:"
-
-#: ../src/dialog_style_editor.cpp:302
-msgid "Shadow:"
-msgstr "Schatten:"
-
-#: ../src/dialog_style_editor.cpp:307
-msgid "Scale X%:"
-msgstr "X-Skal. %:"
-
-#: ../src/dialog_style_editor.cpp:308
-msgid "Scale Y%:"
-msgstr "Y-Skal. %:"
-
-#: ../src/dialog_style_editor.cpp:309
-msgid "Rotation:"
-msgstr "Rotation:"
-
-#: ../src/dialog_style_editor.cpp:310
-msgid "Spacing:"
-msgstr "Zwischenabst.:"
-
-#: ../src/dialog_style_editor.cpp:313
-msgid "Encoding:"
-msgstr "Zeichensatz:"
-
-#: ../src/dialog_style_editor.cpp:323
-msgid "Preview of current style"
-msgstr "Vorschau des aktuellen Stils"
-
-#: ../src/dialog_style_editor.cpp:326
-msgid "Text to be used for the preview"
-msgstr "Text, der als Vorschau verwendet wird"
-
-#: ../src/dialog_style_editor.cpp:327
-msgid "Color of preview background"
-msgstr "Farbe für den Vorschauhintergrund"
-
-#: ../src/dialog_style_editor.cpp:408
-msgid "There is already a style with this name. Please choose another name."
-msgstr ""
-"Es gibt bereits einen Stil mit diesem Namen. Bitte wählen Sie einen anderen "
-"Namen."
-
-#: ../src/dialog_style_editor.cpp:408
-msgid "Style name conflict"
-msgstr "Stilnamen-Konflikt"
-
-#: ../src/dialog_style_editor.cpp:420
-msgid ""
-"Do you want to change all instances of this style in the script to this new "
-"name?"
-msgstr "Wollen Sie den Stilnamen des Skriptes in allen Vorkommen ersetzen?"
-
-#: ../src/dialog_style_editor.cpp:421
-msgid "Update script?"
-msgstr "Skript aktualisieren?"
-
-#: ../src/audio_box.cpp:91
-msgid "Horizontal zoom"
-msgstr "Horizontale Vergrößerung"
-
-#: ../src/audio_box.cpp:92
-msgid "Vertical zoom"
-msgstr "Vertikale Vergrößerung"
-
-#: ../src/audio_box.cpp:93
-msgid "Audio Volume"
-msgstr "Lautstärke"
-
-#: ../src/dialog_export.cpp:78
-msgid "Export"
-msgstr "Exportieren"
-
-#: ../src/dialog_export.cpp:99
-msgid "Move &Up"
-msgstr "Nach oben"
-
-#: ../src/dialog_export.cpp:100
-msgid "Move &Down"
-msgstr "Nach unten"
-
-#: ../src/dialog_export.cpp:102 ../src/dialog_selected_choices.cpp:32
-msgid "Select &None"
-msgstr "Auswahl aufheben"
-
-#: ../src/dialog_export.cpp:118
-msgid "Text encoding:"
-msgstr "Zeichensatz:"
-
-#: ../src/dialog_export.cpp:126
-msgid "Filters"
-msgstr "Filter"
-
-#: ../src/dialog_export.cpp:133
-msgid "Export..."
-msgstr "Exportieren..."
-
-#: ../src/dialog_export.cpp:166
-msgid "Export subtitles file"
-msgstr "Untertitel exportieren"
-
-#: ../src/subtitle_format_ebu3264.cpp:409
-#, c-format
-msgid "Line over maximum length: %s"
-msgstr "Zeile länger als die max. Länge: %s"
-
-#: ../src/dialog_dummy_video.cpp:91
-msgid "Dummy video options"
-msgstr "Dummyvideo-Optionen"
-
-#: ../src/dialog_dummy_video.cpp:109
-msgid "Checkerboard &pattern"
-msgstr "Schachbrettmuster"
-
-#: ../src/dialog_dummy_video.cpp:112
-msgid "Video resolution:"
-msgstr "Videoauflösung:"
-
-#: ../src/dialog_dummy_video.cpp:114
-msgid "Color:"
-msgstr "Farbe:"
-
-#: ../src/dialog_dummy_video.cpp:115
-msgid "Frame rate (fps):"
-msgstr "Framerate (fps):"
-
-#: ../src/dialog_dummy_video.cpp:116
-msgid "Duration (frames):"
-msgstr "Laufzeit (Frames):"
-
-#: ../src/dialog_dummy_video.cpp:158
-#, c-format
-msgid "Resulting duration: %s"
-msgstr "Resultierende Länge: %s"
-
-#: ../src/export_fixstyle.cpp:51
-msgid "Fix Styles"
-msgstr "Stile korrigieren"
-
-#: ../src/export_fixstyle.cpp:51
-msgid ""
-"Fixes styles by replacing any style that isn't available on file with "
-"Default."
-msgstr ""
-"Korrigiert Stil-Angaben, indem nicht vorhandene Stile durch \"Default\" "
-"ersetzt werden."
-
-#: ../src/visual_tool_drag.cpp:59
-msgid "Toggle between \\move and \\pos"
-msgstr "Wechsle zwischen \\move und \\pos"
-
-#: ../src/visual_tool_drag.cpp:321 ../src/visual_tool_cross.cpp:63
-msgid "positioning"
-msgstr "Positionierung"
-
-#: ../src/dialog_colorpicker.cpp:550
-msgid "Select Color"
-msgstr "Farbe wählen"
-
-#: ../src/dialog_colorpicker.cpp:564
-msgid "Color spectrum"
-msgstr "Farbspektrum"
-
-#: ../src/dialog_colorpicker.cpp:568
-msgid "RGB/R"
-msgstr "Rgb-R"
-
-#: ../src/dialog_colorpicker.cpp:568
-msgid "RGB/G"
-msgstr "Rgb-G"
-
-#: ../src/dialog_colorpicker.cpp:568
-msgid "RGB/B"
-msgstr "Rgb-B"
-
-#: ../src/dialog_colorpicker.cpp:568
-msgid "HSL/L"
-msgstr "Hsl-L"
-
-#: ../src/dialog_colorpicker.cpp:568
-msgid "HSV/H"
-msgstr "Hsv-H"
-
-#: ../src/dialog_colorpicker.cpp:575
-msgid "RGB color"
-msgstr "Rgb-Farbschema"
-
-#: ../src/dialog_colorpicker.cpp:576
-msgid "HSL color"
-msgstr "Hsl-Farbschema"
-
-#: ../src/dialog_colorpicker.cpp:577
-msgid "HSV color"
-msgstr "Hsv-Farbschema"
-
-#: ../src/dialog_colorpicker.cpp:602
-msgid "Spectrum mode:"
-msgstr "Spektrumsmodus:"
-
-#: ../src/dialog_colorpicker.cpp:619
-msgid "Red:"
-msgstr "Rot:"
-
-#: ../src/dialog_colorpicker.cpp:619
-msgid "Green:"
-msgstr "Grün:"
-
-#: ../src/dialog_colorpicker.cpp:619
-msgid "Blue:"
-msgstr "Blau:"
-
-#: ../src/dialog_colorpicker.cpp:622
-msgid "Alpha:"
-msgstr "Transparenz:"
-
-#: ../src/dialog_colorpicker.cpp:629 ../src/dialog_colorpicker.cpp:632
-msgid "Hue:"
-msgstr "Ton:"
-
-#: ../src/dialog_colorpicker.cpp:629 ../src/dialog_colorpicker.cpp:632
-msgid "Sat.:"
-msgstr "Sätt.:"
-
-#: ../src/dialog_colorpicker.cpp:629
-msgid "Lum.:"
-msgstr "Hell.:"
-
-#: ../src/dialog_colorpicker.cpp:632
-msgid "Value:"
-msgstr "Wert:"
-
-#: ../src/export_framerate.cpp:59
+#: ../src/export_framerate.cpp:52
 msgid "Transform Framerate"
 msgstr "Framerate anpassen"
 
-#: ../src/export_framerate.cpp:60
+#: ../src/export_framerate.cpp:53
 msgid ""
 "Transform subtitle times, including those in override tags, from an input "
 "framerate to an output framerate.\n"
@@ -4631,544 +5016,144 @@ msgstr ""
 "Dies kann auch dafür benutzt werden, um Untertitel in andere Video-"
 "Geschwindigkeiten zu konvertieren, wie z.B. Ntsc zu Pal."
 
-#: ../src/export_framerate.cpp:85 ../src/dialog_resample.cpp:79
-#: ../src/dialog_properties.cpp:85
-msgid "From &video"
-msgstr "Vom Video"
-
-#: ../src/export_framerate.cpp:107
+#: ../src/export_framerate.cpp:92
 msgid "V&ariable"
 msgstr "Variabel"
 
-#: ../src/export_framerate.cpp:111
+#: ../src/export_framerate.cpp:96
 msgid "&Constant: "
 msgstr "Konstant: "
 
-#: ../src/export_framerate.cpp:123
+#: ../src/export_framerate.cpp:108
 msgid "&Reverse transformation"
 msgstr "Umgekehrte Transformation"
 
-#: ../src/export_framerate.cpp:131
+#: ../src/export_framerate.cpp:116
 msgid "Input framerate: "
 msgstr "Quellframerate: "
 
-#: ../src/export_framerate.cpp:133
+#: ../src/export_framerate.cpp:118
 msgid "Output: "
 msgstr "Ziel: "
 
-#: ../src/dialog_selection.cpp:92
-msgid "Select"
-msgstr "Auswählen"
-
-#: ../src/dialog_selection.cpp:103
-msgid "Match"
-msgstr "Übereinstimmung"
-
-#: ../src/dialog_selection.cpp:107
-msgid "&Matches"
-msgstr "Übereinstimmungen"
-
-#: ../src/dialog_selection.cpp:108
-msgid "&Doesn't Match"
-msgstr "Keine Übereinstimmung"
-
-#: ../src/dialog_selection.cpp:109
-msgid "Match c&ase"
-msgstr "Groß-/Kleinschreibung beachten"
-
-#: ../src/dialog_selection.cpp:118
-msgid "&Exact match"
-msgstr "Genaue Übereinstimmung"
-
-#: ../src/dialog_selection.cpp:118
-msgid "&Contains"
-msgstr "Enthält"
-
-#: ../src/dialog_selection.cpp:118
-msgid "&Regular Expression match"
-msgstr "Regulärer Ausdruck"
-
-#: ../src/dialog_selection.cpp:119
-msgid "Mode"
-msgstr "Modus"
-
-#: ../src/dialog_selection.cpp:123
-msgid "&Text"
-msgstr "Text"
-
-#: ../src/dialog_selection.cpp:123
-msgid "&Style"
-msgstr "Stil"
-
-#: ../src/dialog_selection.cpp:123
-msgid "Act&or"
-msgstr "Sprecher"
-
-#: ../src/dialog_selection.cpp:123
-msgid "E&ffect"
-msgstr "Effekt"
-
-#: ../src/dialog_selection.cpp:124 ../src/dialog_search_replace.cpp:88
-msgid "In Field"
-msgstr "In Feld"
-
-#: ../src/dialog_selection.cpp:128
-msgid "Match dialogues/comments"
-msgstr "Dialoge/Kommentare vergleichen"
-
-#: ../src/dialog_selection.cpp:129
-msgid "D&ialogues"
-msgstr "Dialoge"
-
-#: ../src/dialog_selection.cpp:130
-msgid "Comme&nts"
-msgstr "Kommentare"
-
-#: ../src/dialog_selection.cpp:135
-msgid "Set se&lection"
-msgstr "Auswahl setzen"
-
-#: ../src/dialog_selection.cpp:135
-msgid "&Add to selection"
-msgstr "Auswahl erweitern"
-
-#: ../src/dialog_selection.cpp:135
-msgid "S&ubtract from selection"
-msgstr "Von Auswahl entfernen"
-
-#: ../src/dialog_selection.cpp:135
-msgid "Intersect &with selection"
-msgstr "Schnittmenge mit Auswahl"
-
-#: ../src/dialog_selection.cpp:197
-msgid "Selection was set to no lines"
-msgstr "Es wurde keine Zeile ausgewählt"
-
-#: ../src/dialog_selection.cpp:198
-msgid "Selection was set to one line"
-msgstr "Es wurde eine Zeile ausgewählt"
-
-#: ../src/dialog_selection.cpp:199
-#, c-format
-msgid "Selection was set to %u lines"
-msgstr "Es wurden %u Zeilen ausgewählt"
-
-#: ../src/dialog_selection.cpp:206
-msgid "No lines were added to selection"
-msgstr "Keine Zeile wurde zur Auswahl hinzugefügt"
-
-#: ../src/dialog_selection.cpp:207
-msgid "One line was added to selection"
-msgstr "Eine Zeile wurde zur Auswahl hinzugefügt"
-
-#: ../src/dialog_selection.cpp:208
-#, c-format
-msgid "%u lines were added to selection"
-msgstr "%u Zeilen wurden zur Auswahl hinzugefügt"
-
-#: ../src/dialog_selection.cpp:215 ../src/dialog_selection.cpp:224
-msgid "No lines were removed from selection"
-msgstr "Keine Zeile wurde aus der Auswahl entfernt"
-
-#: ../src/dialog_selection.cpp:216 ../src/dialog_selection.cpp:225
-msgid "One line was removed from selection"
-msgstr "Eine Zeile wurde aus der Auswahl entfernt"
-
-#: ../src/dialog_selection.cpp:217 ../src/dialog_selection.cpp:226
-#, c-format
-msgid "%u lines were removed from selection"
-msgstr "%u Zeilen wurden aus der Auswahl entfernt"
-
-#: ../src/dialog_selection.cpp:232
-msgid "Selection"
-msgstr "Auswahl"
-
-#: ../src/auto4_base.cpp:470
-#, c-format
-msgid ""
-"An Automation script failed to load. File name: '%s', error reported: %s"
-msgstr ""
-"Ein Automatisierungsskript konnte nicht geladen werden. Dateiname: '%s', "
-"Fehler: %s"
-
-#: ../src/auto4_base.cpp:477
-#, c-format
-msgid "The file was not recognised as an Automation script: %s"
-msgstr "Die Datei wurde nicht als Automatisierungsskript erkannt: %s"
-
-#: ../src/dialog_shift_times.cpp:60
-msgid "unsaved"
-msgstr "ungespeichert"
-
-#: ../src/dialog_shift_times.cpp:64
-#, c-format
-msgid "%s frames"
-msgstr "%s Frames"
-
-#: ../src/dialog_shift_times.cpp:66
-msgid "backward"
-msgstr "früher"
-
-#: ../src/dialog_shift_times.cpp:66
-msgid "forward"
-msgstr "später"
-
-#: ../src/dialog_shift_times.cpp:70
-msgid "s+e"
-msgstr "S+E"
-
-#: ../src/dialog_shift_times.cpp:71
-msgid "s"
-msgstr "S"
-
-#: ../src/dialog_shift_times.cpp:72
-msgid "e"
-msgstr "E"
-
-#: ../src/dialog_shift_times.cpp:79
-msgid "all"
-msgstr "Alle"
-
-#: ../src/dialog_shift_times.cpp:81
-#, c-format
-msgid "from %d onward"
-msgstr "ab %d "
-
-#: ../src/dialog_shift_times.cpp:83
-msgid "sel "
-msgstr "Ausw."
-
-#: ../src/dialog_shift_times.cpp:110
-msgid "&Time: "
-msgstr "Zeit: "
-
-#: ../src/dialog_shift_times.cpp:111
-msgid "Shift by time"
-msgstr "Um Zeitbetrag verschieben"
-
-#: ../src/dialog_shift_times.cpp:114
-msgid "&Frames: "
-msgstr "Frames: "
-
-#: ../src/dialog_shift_times.cpp:115
-msgid "Shift by frames"
-msgstr "Um Frames verschieben"
-
-#: ../src/dialog_shift_times.cpp:119
-msgid "Enter time in h:mm:ss.cs notation"
-msgstr "Zeit als h:mm:ss.cs eingeben"
-
-#: ../src/dialog_shift_times.cpp:122
-msgid "Enter number of frames to shift by"
-msgstr "Anzahl der Frames eingeben, um die verschoben werden soll"
-
-#: ../src/dialog_shift_times.cpp:124
-msgid "For&ward"
-msgstr "Vorwärts"
-
-#: ../src/dialog_shift_times.cpp:125
-msgid ""
-"Shifts subs forward, making them appear later. Use if they are appearing too "
-"soon."
-msgstr "Untertitel vorwärts verschieben, sodaß sie später angezeigt werden."
-
-#: ../src/dialog_shift_times.cpp:127
-msgid "&Backward"
-msgstr "Rückwärts"
-
-#: ../src/dialog_shift_times.cpp:128
-msgid ""
-"Shifts subs backward, making them appear earlier. Use if they are appearing "
-"too late."
-msgstr "Untertitel rückwärts verschieben, sodaß sie früher angezeigt werden."
-
-#: ../src/dialog_shift_times.cpp:130
-msgid "&All rows"
-msgstr "Alle Zeilen"
-
-#: ../src/dialog_shift_times.cpp:130
-msgid "Selected &rows"
-msgstr "Ausgewählte Zeilen"
-
-#: ../src/dialog_shift_times.cpp:130
-msgid "Selection &onward"
-msgstr "Auswahl"
-
-#: ../src/dialog_shift_times.cpp:131
-msgid "Affect"
-msgstr "Anwenden auf"
-
-#: ../src/dialog_shift_times.cpp:133
-msgid "Start a&nd End times"
-msgstr "Start- und Endzeiten"
-
-#: ../src/dialog_shift_times.cpp:133
-msgid "&Start times only"
-msgstr "Nur Anfangszeiten"
-
-#: ../src/dialog_shift_times.cpp:133
-msgid "&End times only"
-msgstr "Nur Endzeiten"
-
-#: ../src/dialog_shift_times.cpp:134
-msgid "Times"
-msgstr "Anzahl"
-
-#: ../src/dialog_shift_times.cpp:138
-msgid "&Clear"
-msgstr "Löschen"
-
-#: ../src/dialog_shift_times.cpp:170
-msgid "Shift by"
-msgstr "Verschieben um"
-
-#: ../src/dialog_shift_times.cpp:179
-msgid "Load from history"
-msgstr "Aus dem Verlauf laden"
-
-#: ../src/dialog_shift_times.cpp:377
-msgid "shifting"
-msgstr "verschieben"
-
-#: ../src/dialog_paste_over.cpp:50
-msgid "Select Fields to Paste Over"
-msgstr "Wählen Sie Felder zum Überschreiben"
-
-#: ../src/dialog_paste_over.cpp:53
-msgid "Fields"
-msgstr "Felder"
-
-#: ../src/dialog_paste_over.cpp:54
-msgid "Please select the fields that you want to paste over:"
-msgstr "Bitte wählen Sie die Felder, die Sie überschreiben möchten:"
-
-#: ../src/dialog_paste_over.cpp:61 ../src/base_grid.cpp:487
-#: ../src/base_grid.cpp:768 ../src/base_grid.cpp:899
-#: ../src/dialog_search_replace.cpp:85
-msgid "Style"
-msgstr "Stil"
-
-#: ../src/dialog_paste_over.cpp:63
-msgid "Margin Left"
-msgstr "Linker Rand"
-
-#: ../src/dialog_paste_over.cpp:64
-msgid "Margin Right"
-msgstr "Rechter Rand"
-
-#: ../src/dialog_paste_over.cpp:65
-msgid "Margin Vertical"
-msgstr "Vertikaler Rand"
-
-#: ../src/dialog_paste_over.cpp:86
-msgid "&Times"
-msgstr "Zeiten"
-
-#: ../src/dialog_paste_over.cpp:88
-msgid "T&ext"
-msgstr "Text"
-
-#: ../src/audio_display.cpp:695
+#: ../src/audio_display.cpp:677
 #, c-format
 msgid "%d%%, %d pixel/second"
 msgstr "%d%%, %d Pixel/Sekunde"
 
-#: ../src/dialog_autosave.cpp:39
-msgid "Open autosave file"
-msgstr "Autosave-Datei öffnen"
+#: ../src/dialog_progress.cpp:197
+msgid "Cancel"
+msgstr "Abbruch"
 
-#: ../src/dialog_autosave.cpp:48
-msgid "Versions"
-msgstr "Versionen"
+#: ../src/dialog_progress.cpp:245
+msgid "Cancelling..."
+msgstr "Abbrechen..."
 
-#: ../src/dialog_autosave.cpp:58
-msgid "Open"
-msgstr "Öffnen"
+#: ../src/visual_tool_vector_clip.cpp:57
+msgid "Drag control points"
+msgstr "Ziehe Kontrollpunkte"
 
-#: ../src/dialog_autosave.cpp:67
-#, c-format
-msgid "%s [ORIGINAL BACKUP]"
-msgstr "%s [Ursprüngliches Backup]"
+#: ../src/visual_tool_vector_clip.cpp:58
+msgid "Line"
+msgstr "Zeile"
 
-#: ../src/dialog_autosave.cpp:68
-#, c-format
-msgid "%s [RECOVERED]"
-msgstr "%s [Wiederhergestellt]"
+#: ../src/visual_tool_vector_clip.cpp:58
+msgid "Appends a line"
+msgstr "Fügt eine Zeile hinzu"
 
-#: ../src/dialog_video_details.cpp:52
-msgid "Video Details"
-msgstr "Videodetails:"
+#: ../src/visual_tool_vector_clip.cpp:59
+msgid "Bicubic"
+msgstr "Bikubisch"
 
-#: ../src/dialog_video_details.cpp:65
-msgid "File name:"
-msgstr "Dateiname:"
+#: ../src/visual_tool_vector_clip.cpp:59
+msgid "Appends a bezier bicubic curve"
+msgstr "Hängt eine bikubische Bezier-Kurve an"
 
-#: ../src/dialog_video_details.cpp:66
-msgid "FPS:"
-msgstr "fps:"
+#: ../src/visual_tool_vector_clip.cpp:61
+msgid "Convert"
+msgstr "Konvertieren"
 
-#: ../src/dialog_video_details.cpp:67
-msgid "Resolution:"
-msgstr "Auflösung:"
+#: ../src/visual_tool_vector_clip.cpp:61
+msgid "Converts a segment between line and bicubic"
+msgstr "Konvertiert ein Segment zwischen Linie und bikubischer Kurve"
 
-#: ../src/dialog_video_details.cpp:68
-msgid "Length:"
-msgstr "Länge:"
+#: ../src/visual_tool_vector_clip.cpp:62
+msgid "Insert"
+msgstr "Einfügen"
 
-#: ../src/dialog_video_details.cpp:68
-#, c-format
-msgid "%d frames (%s)"
-msgstr "%d Frames (%s)"
+#: ../src/visual_tool_vector_clip.cpp:62
+msgid "Inserts a control point"
+msgstr "Einen Kontrollpunkt hinzufügen"
 
-#: ../src/dialog_video_details.cpp:69
-msgid "Decoder:"
-msgstr "Dekodierer:"
+#: ../src/visual_tool_vector_clip.cpp:63
+msgid "Remove"
+msgstr "Entfernen"
 
-#: ../src/dialog_jumpto.cpp:58
-msgid "Frame: "
-msgstr "Frame: "
+#: ../src/visual_tool_vector_clip.cpp:63
+msgid "Removes a control point"
+msgstr "Einen Kontrollpunkt entfernen"
 
-#: ../src/dialog_jumpto.cpp:59
-msgid "Time: "
-msgstr "Zeit: "
+#: ../src/visual_tool_vector_clip.cpp:65
+msgid "Freehand"
+msgstr "Freihand"
 
-#: ../src/audio_renderer_waveform.cpp:182
-msgid "Maximum"
-msgstr "Maximum"
+#: ../src/visual_tool_vector_clip.cpp:65
+msgid "Draws a freehand shape"
+msgstr "Zeichne eine Freihand-Form"
 
-#: ../src/audio_renderer_waveform.cpp:183
-msgid "Maximum + Average"
-msgstr "Maximum + Durchschnitt"
+#: ../src/visual_tool_vector_clip.cpp:66
+msgid "Freehand smooth"
+msgstr "Weiche Freihand-Kurve"
 
-#: ../src/audio_timing_karaoke.cpp:263
-msgid "karaoke timing"
-msgstr "Karaoke-Timing"
+#: ../src/visual_tool_vector_clip.cpp:66
+msgid "Draws a smoothed freehand shape"
+msgstr "Zeichnet eine geglättete Freihand-Kurve"
 
-#: ../src/dialog_styling_assistant.cpp:67
-#: ../src/dialog_styling_assistant.cpp:68
-msgid "Current line"
-msgstr "Aktuelle Zeile"
+#: ../src/visual_tool_vector_clip.cpp:265
+msgid "delete control point"
+msgstr "Einen Kontrollpunkt entfernen"
 
-#: ../src/dialog_styling_assistant.cpp:74
-msgid "Styles available"
-msgstr "Verfügbare Stile"
-
-#: ../src/dialog_styling_assistant.cpp:82
-msgid "Set style"
-msgstr "Stil einstellen"
-
-#: ../src/dialog_styling_assistant.cpp:98
-msgid "Click on list"
-msgstr "Auf Liste klicken"
-
-#: ../src/dialog_styling_assistant.cpp:99
-msgid "Select style"
-msgstr "Stil wählen"
-
-#: ../src/dialog_styling_assistant.cpp:103
-msgid "&Seek video to line start time"
-msgstr "Zur Anfangszeit der Zeile springen"
-
-#: ../src/dialog_styling_assistant.cpp:177
-msgid "styling assistant"
-msgstr "Stil-Assistent"
-
-#: ../src/frame_main.cpp:288
-msgid ""
-"Do you want Aegisub to check for updates whenever it starts? You can still "
-"do it manually via the Help menu."
-msgstr ""
-"Wollen Sie immer auf Updates prüfen, wenn Aegisub startet? Sie können dies "
-"auch manuell über das Hilfe-Menü tun."
-
-#: ../src/frame_main.cpp:288
-msgid "Check for updates?"
-msgstr "Auf Updates prüfen?"
-
-#: ../src/frame_main.cpp:606
-msgid "Do you want to load/unload the associated files?"
-msgstr "Wollen Sie die verknüpften Dateien laden/entladen?"
-
-#: ../src/frame_main.cpp:606
-msgid "(Un)Load files?"
-msgstr "Dateien (ent)laden?"
-
-#: ../src/subtitles_provider_libass.cpp:102
-msgid "Updating font index"
-msgstr "Aktualisiere Schriftarten-Index"
-
-#: ../src/subtitles_provider_libass.cpp:102
-msgid "This may take several minutes"
-msgstr "Dies könnte ein paar Minuten dauern"
-
-#: ../src/video_box.cpp:65
-msgid "Seek video"
-msgstr "Springe im Video zu..."
-
-#: ../src/video_box.cpp:72
-msgid "Current frame time and number"
-msgstr "Aktuelle Framezeit und -nummer"
-
-#: ../src/video_box.cpp:76
-msgid "Time of this frame relative to start and end of current subs"
-msgstr "Framezeit relativ zu Anfang und Ende der aktuellen Zeile"
-
-#: ../src/dialog_automation.cpp:62
+#: ../src/dialog_automation.cpp:106
 msgid "Automation Manager"
 msgstr "Automatisierungs-Manager"
 
-#: ../src/dialog_automation.cpp:73
+#: ../src/dialog_automation.cpp:117
 msgid "&Add"
 msgstr "&Hinzufügen"
 
-#: ../src/dialog_automation.cpp:74
+#: ../src/dialog_automation.cpp:118
 msgid "&Remove"
 msgstr "&Entfernen"
 
-#: ../src/dialog_automation.cpp:75
+#: ../src/dialog_automation.cpp:119
 msgid "Re&load"
 msgstr "Neu &laden"
 
-#: ../src/dialog_automation.cpp:76
+#: ../src/dialog_automation.cpp:120
 msgid "Show &Info"
 msgstr "Zeige &Informationen"
 
-#: ../src/dialog_automation.cpp:77
+#: ../src/dialog_automation.cpp:121
 msgid "Re&scan Autoload Dir"
 msgstr "Autom.-Laden-Ordner erneut prüfen"
 
-#: ../src/dialog_automation.cpp:90
+#: ../src/dialog_automation.cpp:134
 msgid "Name"
 msgstr "Name"
 
-#: ../src/dialog_automation.cpp:91
+#: ../src/dialog_automation.cpp:135
 msgid "Filename"
 msgstr "Dateiname"
 
-#: ../src/dialog_automation.cpp:92
+#: ../src/dialog_automation.cpp:136
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../src/dialog_automation.cpp:178
+#: ../src/dialog_automation.cpp:222
 msgid "Add Automation script"
 msgstr "Automatisierungsskript hinzufügen"
 
-#: ../src/dialog_automation.cpp:229
-#, c-format
-msgid "    Macro: %s (%s)"
-msgstr "    Makro: %s (%s)"
-
-#: ../src/dialog_automation.cpp:233
-#, c-format
-msgid "    Export filter: %s"
-msgstr "    Exportfilter: %s"
-
-#: ../src/dialog_automation.cpp:237
-#, c-format
-msgid "    Subtitle format handler: %s"
-msgstr "    Untertitelformat-Handler: %s"
-
-#: ../src/dialog_automation.cpp:249
+#: ../src/dialog_automation.cpp:277
 #, c-format
 msgid ""
 "Total scripts loaded: %d\n"
@@ -5179,11 +5164,19 @@ msgstr ""
 "Globale geladene Skripte: %d\n"
 "Lokale geladene Skripte: %d\n"
 
-#: ../src/dialog_automation.cpp:254
+#: ../src/dialog_automation.cpp:282
 msgid "Scripting engines installed:"
 msgstr "Installierte Skriptunterstützung:"
 
-#: ../src/dialog_automation.cpp:258
+#: ../src/dialog_automation.cpp:295
+msgid "Correctly loaded"
+msgstr "Richtig geladen"
+
+#: ../src/dialog_automation.cpp:295
+msgid "Failed to load"
+msgstr "Fehler beim Laden"
+
+#: ../src/dialog_automation.cpp:289
 #, c-format
 msgid ""
 "\n"
@@ -5208,24 +5201,751 @@ msgstr ""
 "\n"
 "Vom Skript zur Verfügung gestellte Features:"
 
-#: ../src/dialog_automation.cpp:264
-msgid "Correctly loaded"
-msgstr "Richtig geladen"
+#: ../src/dialog_automation.cpp:298
+#, c-format
+msgid "    Macro: %s (%s)"
+msgstr "    Makro: %s (%s)"
 
-#: ../src/dialog_automation.cpp:264
-msgid "Failed to load"
-msgstr "Fehler beim Laden"
+#: ../src/dialog_automation.cpp:301
+#, c-format
+msgid "    Export filter: %s"
+msgstr "    Exportfilter: %s"
 
-#: ../src/dialog_automation.cpp:271
+#: ../src/dialog_automation.cpp:305
 msgid "Automation Script Info"
 msgstr "Automatisierungsskript-Informationen"
 
-#: ../src/dialog_detached_video.cpp:65 ../src/dialog_detached_video.cpp:134
+#: ../src/dialog_export.cpp:102
+msgid "Export"
+msgstr "Exportieren"
+
+#: ../src/dialog_export.cpp:123
+msgid "Move &Up"
+msgstr "Nach oben"
+
+#: ../src/dialog_export.cpp:124
+msgid "Move &Down"
+msgstr "Nach unten"
+
+#: ../src/dialog_export.cpp:142
+msgid "Text encoding:"
+msgstr "Zeichensatz:"
+
+#: ../src/dialog_export.cpp:150
+msgid "Filters"
+msgstr "Filter"
+
+#: ../src/dialog_export.cpp:157
+msgid "Export..."
+msgstr "Exportieren..."
+
+#: ../src/dialog_export.cpp:189
+msgid "Export subtitles file"
+msgstr "Untertitel exportieren"
+
+#: ../src/dialog_search_replace.cpp:46
+msgid "Replace"
+msgstr "Ersetzen"
+
+#: ../src/dialog_search_replace.cpp:67
+msgid "Find what:"
+msgstr "Suche nach:"
+
+#: ../src/dialog_search_replace.cpp:78
+msgid "&Match case"
+msgstr "Groß-/Kleinschreibung beachten"
+
+#: ../src/dialog_search_replace.cpp:79
+msgid "&Use regular expressions"
+msgstr "Reguläre Ausdrücke verwenden"
+
+#: ../src/dialog_search_replace.cpp:81
+msgid "S&kip Override Tags"
+msgstr "Tags überspringen"
+
+#: ../src/dialog_search_replace.cpp:87
+#, fuzzy
+msgid "St&yle"
+msgstr "Stilname"
+
+#: ../src/dialog_search_replace.cpp:87
+#, fuzzy
+msgid "A&ctor"
+msgstr "Sprecher"
+
+#: ../src/dialog_search_replace.cpp:88
+#, fuzzy
+msgid "A&ll rows"
+msgstr "Alle Zeilen"
+
+#: ../src/dialog_search_replace.cpp:91
+msgid "Limit to"
+msgstr "Begrenzen auf"
+
+#: ../src/dialog_search_replace.cpp:93
+msgid "&Find next"
+msgstr "Nächstes finden"
+
+#: ../src/dialog_search_replace.cpp:94
+msgid "Replace &next"
+msgstr "Nächstes ersetzen"
+
+#: ../src/dialog_autosave.cpp:66
+msgid "Open autosave file"
+msgstr "Autosave-Datei öffnen"
+
+#: ../src/dialog_autosave.cpp:75
+msgid "Versions"
+msgstr "Versionen"
+
+#: ../src/dialog_autosave.cpp:85
+msgid "Open"
+msgstr "Öffnen"
+
+#: ../src/dialog_autosave.cpp:94
+#, c-format
+msgid "%s [ORIGINAL BACKUP]"
+msgstr "%s [Ursprüngliches Backup]"
+
+#: ../src/dialog_autosave.cpp:95
+#, c-format
+msgid "%s [RECOVERED]"
+msgstr "%s [Wiederhergestellt]"
+
+#: ../src/audio_box.cpp:73
+msgid "Horizontal zoom"
+msgstr "Horizontale Vergrößerung"
+
+#: ../src/audio_box.cpp:74
+msgid "Vertical zoom"
+msgstr "Vertikale Vergrößerung"
+
+#: ../src/audio_box.cpp:75
+msgid "Audio Volume"
+msgstr "Lautstärke"
+
+#: ../src/grid_column.cpp:82
+msgid "#"
+msgstr "#"
+
+#: ../src/grid_column.cpp:83
+msgid "Line Number"
+msgstr "Zeilennummer"
+
+#: ../src/grid_column.cpp:106
+msgid "L"
+msgstr "L"
+
+#: ../src/grid_column.cpp:128
+msgid "Start"
+msgstr "Start"
+
+#: ../src/grid_column.cpp:146
+msgid "End"
+msgstr "Ende"
+
+#: ../src/grid_column.cpp:237 ../src/dialog_style_editor.cpp:288
+msgid "Left"
+msgstr "Links"
+
+#: ../src/grid_column.cpp:238
+#, fuzzy
+msgid "Left Margin"
+msgstr "Ränder"
+
+#: ../src/grid_column.cpp:242 ../src/dialog_style_editor.cpp:288
+msgid "Right"
+msgstr "Rechts"
+
+#: ../src/grid_column.cpp:243
+#, fuzzy
+msgid "Right Margin"
+msgstr "Rechten Rand ändern"
+
+#: ../src/grid_column.cpp:247 ../src/dialog_style_editor.cpp:288
+msgid "Vert"
+msgstr "Vertikal"
+
+#: ../src/grid_column.cpp:248
+#, fuzzy
+msgid "Vertical Margin"
+msgstr "Vertikalen Rand ändern"
+
+#: ../src/grid_column.cpp:266
+#, fuzzy
+msgid "CPS"
+msgstr "fps"
+
+#: ../src/grid_column.cpp:267
+msgid "Characters Per Second"
+msgstr ""
+
+#: ../src/dialog_text_import.cpp:47
+msgid "Text import options"
+msgstr "Textimportoptionen"
+
+#: ../src/dialog_text_import.cpp:54
+msgid "Actor separator:"
+msgstr "Sprecher-Trennzeichen:"
+
+#: ../src/dialog_text_import.cpp:56
+msgid "Comment starter:"
+msgstr "Kommentar-Starter:"
+
+#: ../src/dialog_text_import.cpp:61
+msgid "Include blank lines"
+msgstr "Einschließlich leerer Zeilen"
+
+#: ../src/video_box.cpp:57
+msgid "Seek video"
+msgstr "Springe im Video zu..."
+
+#: ../src/video_box.cpp:62
+msgid "Current frame time and number"
+msgstr "Aktuelle Framezeit und -nummer"
+
+#: ../src/video_box.cpp:65
+msgid "Time of this frame relative to start and end of current subs"
+msgstr "Framezeit relativ zu Anfang und Ende der aktuellen Zeile"
+
+#: ../src/ass_style.cpp:193
+msgid "ANSI"
+msgstr "Ansi"
+
+#: ../src/ass_style.cpp:195
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/ass_style.cpp:196
+msgid "Mac"
+msgstr "Mac"
+
+#: ../src/ass_style.cpp:197
+msgid "Shift_JIS"
+msgstr "Shift-Jis"
+
+#: ../src/ass_style.cpp:198
+msgid "Hangeul"
+msgstr "Hangeul"
+
+#: ../src/ass_style.cpp:199
+msgid "Johab"
+msgstr "Johab"
+
+#: ../src/ass_style.cpp:200
+msgid "GB2312"
+msgstr "GB2312"
+
+#: ../src/ass_style.cpp:201
+msgid "Chinese BIG5"
+msgstr "Chinesisch (Big5)"
+
+#: ../src/ass_style.cpp:202
+msgid "Greek"
+msgstr "Griechisch"
+
+#: ../src/ass_style.cpp:203
+msgid "Turkish"
+msgstr "Türkisch"
+
+#: ../src/ass_style.cpp:204
+msgid "Vietnamese"
+msgstr "Vietnamesisch"
+
+#: ../src/ass_style.cpp:205
+msgid "Hebrew"
+msgstr "Hebräisch"
+
+#: ../src/ass_style.cpp:206
+msgid "Arabic"
+msgstr "Arabisch"
+
+#: ../src/ass_style.cpp:207
+msgid "Baltic"
+msgstr "Baltisch"
+
+#: ../src/ass_style.cpp:208
+msgid "Russian"
+msgstr "Russisch"
+
+#: ../src/ass_style.cpp:209
+msgid "Thai"
+msgstr "Thai"
+
+#: ../src/ass_style.cpp:210
+msgid "East European"
+msgstr "Osteuropäisch"
+
+#: ../src/ass_style.cpp:211
+msgid "OEM"
+msgstr "Oem"
+
+#: ../src/dialog_colorpicker.cpp:542
+msgid "Select Color"
+msgstr "Farbe wählen"
+
+#: ../src/dialog_colorpicker.cpp:556
+msgid "Color spectrum"
+msgstr "Farbspektrum"
+
+#: ../src/dialog_colorpicker.cpp:560
+msgid "RGB/R"
+msgstr "Rgb-R"
+
+#: ../src/dialog_colorpicker.cpp:560
+msgid "RGB/G"
+msgstr "Rgb-G"
+
+#: ../src/dialog_colorpicker.cpp:560
+msgid "RGB/B"
+msgstr "Rgb-B"
+
+#: ../src/dialog_colorpicker.cpp:560
+msgid "HSL/L"
+msgstr "Hsl-L"
+
+#: ../src/dialog_colorpicker.cpp:560
+msgid "HSV/H"
+msgstr "Hsv-H"
+
+#: ../src/dialog_colorpicker.cpp:567
+msgid "RGB color"
+msgstr "Rgb-Farbschema"
+
+#: ../src/dialog_colorpicker.cpp:568
+msgid "HSL color"
+msgstr "Hsl-Farbschema"
+
+#: ../src/dialog_colorpicker.cpp:569
+msgid "HSV color"
+msgstr "Hsv-Farbschema"
+
+#: ../src/dialog_colorpicker.cpp:594
+msgid "Spectrum mode:"
+msgstr "Spektrumsmodus:"
+
+#: ../src/dialog_colorpicker.cpp:611
+msgid "Red:"
+msgstr "Rot:"
+
+#: ../src/dialog_colorpicker.cpp:611
+msgid "Green:"
+msgstr "Grün:"
+
+#: ../src/dialog_colorpicker.cpp:611
+msgid "Blue:"
+msgstr "Blau:"
+
+#: ../src/dialog_colorpicker.cpp:614
+msgid "Alpha:"
+msgstr "Transparenz:"
+
+#: ../src/dialog_colorpicker.cpp:621 ../src/dialog_colorpicker.cpp:624
+msgid "Hue:"
+msgstr "Ton:"
+
+#: ../src/dialog_colorpicker.cpp:621 ../src/dialog_colorpicker.cpp:624
+msgid "Sat.:"
+msgstr "Sätt.:"
+
+#: ../src/dialog_colorpicker.cpp:621
+msgid "Lum.:"
+msgstr "Hell.:"
+
+#: ../src/dialog_colorpicker.cpp:624
+msgid "Value:"
+msgstr "Wert:"
+
+#: ../src/charset_detect.cpp:80
+msgid ""
+"Aegisub could not narrow down the character set to a single one.\n"
+"Please pick one below:"
+msgstr ""
+"Aegisub kann den Zeichensatz nicht eindeutig zuweisen.\n"
+"Bitte wählen Sie einen aus:"
+
+#: ../src/charset_detect.cpp:81
+msgid "Choose character set"
+msgstr "Zeichensatz auswählen"
+
+#: ../src/dialog_detached_video.cpp:66 ../src/dialog_detached_video.cpp:134
 #, c-format
 msgid "Video: %s"
 msgstr "Video: %s"
 
-#: ../src/dialog_export_ebu3264.cpp:85
+#: ../src/subtitle_format.cpp:100
+#, c-format
+msgid "From video (%g)"
+msgstr "Vom Video (%g)"
+
+#: ../src/subtitle_format.cpp:102
+msgid "From video (VFR)"
+msgstr "Vom Video (vfr)"
+
+#: ../src/subtitle_format.cpp:108
+msgid "15.000 FPS"
+msgstr "15.000 fps"
+
+#: ../src/subtitle_format.cpp:109
+msgid "23.976 FPS (Decimated NTSC)"
+msgstr "23.976 fps (Dezimiertes Ntsc)"
+
+#: ../src/subtitle_format.cpp:110
+msgid "24.000 FPS (FILM)"
+msgstr "24.000 fps (Film)"
+
+#: ../src/subtitle_format.cpp:111
+msgid "25.000 FPS (PAL)"
+msgstr "25.000 fps (Pal)"
+
+#: ../src/subtitle_format.cpp:112
+msgid "29.970 FPS (NTSC)"
+msgstr "29.970 fps (Ntsc)"
+
+#: ../src/subtitle_format.cpp:114
+msgid "29.970 FPS (NTSC with SMPTE dropframe)"
+msgstr "29.970 fps (Ntsc mit Smpte-Frame)"
+
+#: ../src/subtitle_format.cpp:115
+msgid "30.000 FPS"
+msgstr "30.000 fps"
+
+#: ../src/subtitle_format.cpp:116
+msgid "50.000 FPS (PAL x2)"
+msgstr "50.000 fps (Pal x2)"
+
+#: ../src/subtitle_format.cpp:117
+msgid "59.940 FPS (NTSC x2)"
+msgstr "59.940 fps (Ntsc x2)"
+
+#: ../src/subtitle_format.cpp:118
+msgid "60.000 FPS"
+msgstr "60.000 fps"
+
+#: ../src/subtitle_format.cpp:119
+msgid "119.880 FPS (NTSC x4)"
+msgstr "119.880 fps (Ntsc x4)"
+
+#: ../src/subtitle_format.cpp:120
+msgid "120.000 FPS"
+msgstr "120.000 fps"
+
+#: ../src/subtitle_format.cpp:124
+msgid "Please choose the appropriate FPS for the subtitles:"
+msgstr "Bitte wählen Sie die entsprechende Framerate für den Untertitel:"
+
+#: ../src/subtitle_format.cpp:124
+msgid "FPS"
+msgstr "fps"
+
+#: ../src/ffmpegsource_common.cpp:94
+msgid "Indexing"
+msgstr "Indiziere"
+
+#: ../src/ffmpegsource_common.cpp:95
+msgid "Reading timecodes and frame/sample data"
+msgstr "Lese Zeitcodes und Frame-/Sample-Daten"
+
+#: ../src/ffmpegsource_common.cpp:141
+#, c-format
+msgid "Track %02d: %s"
+msgstr "Spur %02d: %s"
+
+#: ../src/ffmpegsource_common.cpp:146
+msgid "Multiple video tracks detected, please choose the one you wish to load:"
+msgstr ""
+"Mehrere Videospuren erkannt, wählen Sie bitte die, die Sie laden möchten:"
+
+#: ../src/ffmpegsource_common.cpp:146
+msgid "Multiple audio tracks detected, please choose the one you wish to load:"
+msgstr ""
+"Mehrere Tonspuren erkannt, wählen Sie bitte die, die Sie laden möchten:"
+
+#: ../src/ffmpegsource_common.cpp:147
+msgid "Choose video track"
+msgstr "Wähle Videospur"
+
+#: ../src/ffmpegsource_common.cpp:147
+msgid "Choose audio track"
+msgstr "Wähle Tonspur"
+
+#: ../src/resolution_resampler.cpp:287
+msgid "resolution resampling"
+msgstr "Auflösungs-Resampling"
+
+#: ../src/project.cpp:187
+msgid "Do you want to load/unload the associated files?"
+msgstr "Wollen Sie die verknüpften Dateien laden/entladen?"
+
+#: ../src/project.cpp:198
+#, fuzzy
+msgid "Unload audio"
+msgstr "Audio laden"
+
+#: ../src/project.cpp:198
+#, fuzzy, c-format
+msgid "Load audio file: %s"
+msgstr "Audio laden"
+
+#: ../src/project.cpp:200
+#, fuzzy
+msgid "Unload video"
+msgstr "Video abspielen"
+
+#: ../src/project.cpp:200
+#, fuzzy, c-format
+msgid "Load video file: %s"
+msgstr "Öffnet eine Videodatei"
+
+#: ../src/project.cpp:202
+#, fuzzy
+msgid "Unload timecodes"
+msgstr "Zeitcodes ersetzen?"
+
+#: ../src/project.cpp:202
+#, fuzzy, c-format
+msgid "Load timecodes file: %s"
+msgstr "Speichere Zeitcode-Datei"
+
+#: ../src/project.cpp:204
+#, fuzzy
+msgid "Unload keyframes"
+msgstr "Schließe Keyframe-Datei"
+
+#: ../src/project.cpp:204
+#, fuzzy, c-format
+msgid "Load keyframes file: %s"
+msgstr "Speichere Keyframe-Datei"
+
+#: ../src/project.cpp:206
+msgid "(Un)Load files?"
+msgstr "Dateien (ent)laden?"
+
+#: ../src/project.cpp:255
+msgid "The audio file was not found: "
+msgstr ""
+
+#: ../src/project.cpp:263
+msgid ""
+"None of the available audio providers recognised the selected file as "
+"containing audio data.\n"
+"\n"
+"The following providers were tried:\n"
+msgstr ""
+
+#: ../src/project.cpp:266
+msgid ""
+"None of the available audio providers have a codec available to handle the "
+"selected file.\n"
+"\n"
+"The following providers were tried:\n"
+msgstr ""
+
+#: ../src/dialog_style_editor.cpp:127
+msgid "Style Editor"
+msgstr "Stil-Editor"
+
+#: ../src/dialog_style_editor.cpp:178
+msgid "Font"
+msgstr "Schriftart"
+
+#: ../src/dialog_style_editor.cpp:180
+msgid "Margins"
+msgstr "Ränder"
+
+#: ../src/dialog_style_editor.cpp:181 ../src/dialog_style_editor.cpp:277
+msgid "Outline"
+msgstr "Umrandung"
+
+#: ../src/dialog_style_editor.cpp:182
+msgid "Miscellaneous"
+msgstr "Verschiedenes"
+
+#: ../src/dialog_style_editor.cpp:183
+msgid "Preview"
+msgstr "Vorschau"
+
+#: ../src/dialog_style_editor.cpp:189
+msgid "&Bold"
+msgstr "Fett"
+
+#: ../src/dialog_style_editor.cpp:190
+msgid "&Italic"
+msgstr "Kursiv"
+
+#: ../src/dialog_style_editor.cpp:191
+msgid "&Underline"
+msgstr "Unterstrichen"
+
+#: ../src/dialog_style_editor.cpp:192
+msgid "&Strikeout"
+msgstr "Durchgestrichen"
+
+#: ../src/dialog_style_editor.cpp:204
+msgid "Alignment"
+msgstr "Ausrichtung"
+
+#: ../src/dialog_style_editor.cpp:207
+msgid "&Opaque box"
+msgstr "Undurchsichtiger Kasten"
+
+#: ../src/dialog_style_editor.cpp:215
+msgid "Style name"
+msgstr "Stilname"
+
+#: ../src/dialog_style_editor.cpp:216
+msgid "Font face"
+msgstr "Schriftart"
+
+#: ../src/dialog_style_editor.cpp:217
+msgid "Font size"
+msgstr "Schriftgröße"
+
+#: ../src/dialog_style_editor.cpp:218
+msgid "Choose primary color"
+msgstr "Wähle Primärfarbe"
+
+#: ../src/dialog_style_editor.cpp:219
+msgid "Choose secondary color"
+msgstr "Wähle Sekundärfarbe"
+
+#: ../src/dialog_style_editor.cpp:220
+msgid "Choose outline color"
+msgstr "Wähle Umrandungsfarbe"
+
+#: ../src/dialog_style_editor.cpp:221
+msgid "Choose shadow color"
+msgstr "Wähle Schattenfarbe"
+
+#: ../src/dialog_style_editor.cpp:222
+msgid "Distance from left edge, in pixels"
+msgstr "Abstand vom linken Rand in Pixeln"
+
+#: ../src/dialog_style_editor.cpp:223
+msgid "Distance from right edge, in pixels"
+msgstr "Abstand vom rechten Rand in Pixeln"
+
+#: ../src/dialog_style_editor.cpp:224
+msgid "Distance from top/bottom edge, in pixels"
+msgstr "Abstand von oberem/unterem Rand in Pixeln"
+
+#: ../src/dialog_style_editor.cpp:225
+msgid ""
+"When selected, display an opaque box behind the subtitles instead of an "
+"outline around the text"
+msgstr ""
+"Zeigt statt einer Umrandung einen undurchsichtigen Kasten hinter den "
+"Untertiteln an"
+
+#: ../src/dialog_style_editor.cpp:226
+msgid "Outline width, in pixels"
+msgstr "Umrandungsdicke in Pixeln"
+
+#: ../src/dialog_style_editor.cpp:227
+msgid "Shadow distance, in pixels"
+msgstr "Schattenentfernung in Pixeln"
+
+#: ../src/dialog_style_editor.cpp:228
+msgid "Scale X, in percentage"
+msgstr "Horizontale Skalierung (%)"
+
+#: ../src/dialog_style_editor.cpp:229
+msgid "Scale Y, in percentage"
+msgstr "Vertikale Skalierung (%)"
+
+#: ../src/dialog_style_editor.cpp:230
+msgid "Angle to rotate in Z axis, in degrees"
+msgstr "Rotationswinkel um die Z-Achse in Grad"
+
+#: ../src/dialog_style_editor.cpp:231
+msgid ""
+"Encoding, only useful in unicode if the font doesn't have the proper unicode "
+"mapping"
+msgstr ""
+"Kodierung, nur sinnvoll im Unicode, falls die Schriftart keine richtigen "
+"Unicode-Tabellen besitzt."
+
+#: ../src/dialog_style_editor.cpp:232
+msgid "Character spacing, in pixels"
+msgstr "Zeichenabstand in Pixeln"
+
+#: ../src/dialog_style_editor.cpp:233
+msgid "Alignment in screen, in numpad style"
+msgstr "Bildschirmausrichtung (wie Ziffernblock)"
+
+#: ../src/dialog_style_editor.cpp:277
+msgid "Primary"
+msgstr "Primär"
+
+#: ../src/dialog_style_editor.cpp:277
+msgid "Secondary"
+msgstr "Sekundär"
+
+#: ../src/dialog_style_editor.cpp:277
+msgid "Shadow"
+msgstr "Schatten"
+
+#: ../src/dialog_style_editor.cpp:306
+msgid "Outline:"
+msgstr "Umrandung:"
+
+#: ../src/dialog_style_editor.cpp:307
+msgid "Shadow:"
+msgstr "Schatten:"
+
+#: ../src/dialog_style_editor.cpp:312
+msgid "Scale X%:"
+msgstr "X-Skal. %:"
+
+#: ../src/dialog_style_editor.cpp:313
+msgid "Scale Y%:"
+msgstr "Y-Skal. %:"
+
+#: ../src/dialog_style_editor.cpp:314
+msgid "Rotation:"
+msgstr "Rotation:"
+
+#: ../src/dialog_style_editor.cpp:315
+msgid "Spacing:"
+msgstr "Zwischenabst.:"
+
+#: ../src/dialog_style_editor.cpp:318
+msgid "Encoding:"
+msgstr "Zeichensatz:"
+
+#: ../src/dialog_style_editor.cpp:328
+msgid "Preview of current style"
+msgstr "Vorschau des aktuellen Stils"
+
+#: ../src/dialog_style_editor.cpp:331
+msgid "Text to be used for the preview"
+msgstr "Text, der als Vorschau verwendet wird"
+
+#: ../src/dialog_style_editor.cpp:332
+msgid "Color of preview background"
+msgstr "Farbe für den Vorschauhintergrund"
+
+#: ../src/dialog_style_editor.cpp:413
+msgid "There is already a style with this name. Please choose another name."
+msgstr ""
+"Es gibt bereits einen Stil mit diesem Namen. Bitte wählen Sie einen anderen "
+"Namen."
+
+#: ../src/dialog_style_editor.cpp:413
+msgid "Style name conflict"
+msgstr "Stilnamen-Konflikt"
+
+#: ../src/dialog_style_editor.cpp:425
+msgid ""
+"Do you want to change all instances of this style in the script to this new "
+"name?"
+msgstr "Wollen Sie den Stilnamen des Skriptes in allen Vorkommen ersetzen?"
+
+#: ../src/dialog_style_editor.cpp:426
+msgid "Update script?"
+msgstr "Skript aktualisieren?"
+
+#: ../src/dialog_export_ebu3264.cpp:84
 msgid ""
 "Time code offset in incorrect format. Ensure it is entered as four groups of "
 "two digits separated by colons."
@@ -5234,7 +5954,7 @@ msgstr ""
 "sie vier Gruppen aus je zwei Zahlen, die durch Doppelpunkte getrennt sind, "
 "eingegeben haben."
 
-#: ../src/dialog_export_ebu3264.cpp:85
+#: ../src/dialog_export_ebu3264.cpp:84
 msgid "EBU STL export"
 msgstr "Als Ebu-Stl exportieren"
 
@@ -5354,112 +6074,33 @@ msgstr "Zeitcodes"
 msgid "Display standard"
 msgstr "Display"
 
-#: ../src/audio_provider.cpp:189
-msgid "Load audio"
-msgstr "Audio laden"
+#: ../src/subs_controller.cpp:158
+#, c-format
+msgid "File backup saved as \"%s\"."
+msgstr "Backup-Kopie gespeichert als \"%s\"."
 
-#: ../src/dialog_resample.cpp:67
-msgid "&Symmetrical"
-msgstr "Symmetrisch"
+#: ../src/subs_controller.cpp:260
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Wollen Sie die Änderungen in %s speichern?"
 
-#: ../src/dialog_resample.cpp:82
-msgid "&Change aspect ratio"
-msgstr "Seitenverhältnis ändern"
+#: ../src/subs_controller.cpp:260
+msgid "Unsaved changes"
+msgstr "Ungespeicherte Änderungen"
 
-#: ../src/dialog_resample.cpp:97
-msgid "Margin offset"
-msgstr "Ränderversatz"
+#: ../src/subs_controller.cpp:395
+msgid "Untitled"
+msgstr "Unbenannt"
 
-#: ../src/dialog_resample.cpp:102
-msgid "x"
-msgstr "x"
+#: ../src/subs_controller.cpp:397
+msgid "untitled"
+msgstr "unbenannt"
 
-#: ../src/dialog_resample.cpp:106 ../src/dialog_properties.cpp:80
-msgid "Resolution"
-msgstr "Auflösung"
+#: ../src/dialog_video_properties.cpp:44
+msgid "Resolution mismatch"
+msgstr "Auflösungen stimmen nicht überein"
 
-#: ../src/dialog_resample.cpp:255
-msgid "resolution resampling"
-msgstr "Auflösungs-Resampling"
-
-#: ../src/dialog_properties.cpp:58
-msgid "Script Properties"
-msgstr "Skripteigenschaften"
-
-#: ../src/dialog_properties.cpp:64
-msgid "Script"
-msgstr "Skript"
-
-#: ../src/dialog_properties.cpp:67
-msgid "Title:"
-msgstr "Titel:"
-
-#: ../src/dialog_properties.cpp:68
-msgid "Original script:"
-msgstr "Ursprüngliches Skript:"
-
-#: ../src/dialog_properties.cpp:69
-msgid "Translation:"
-msgstr "Übersetzung:"
-
-#: ../src/dialog_properties.cpp:70
-msgid "Editing:"
-msgstr "Bearbeitung:"
-
-#: ../src/dialog_properties.cpp:71
-msgid "Timing:"
-msgstr "Timing:"
-
-#: ../src/dialog_properties.cpp:72
-msgid "Synch point:"
-msgstr "Sync-Punkt:"
-
-#: ../src/dialog_properties.cpp:73
-msgid "Updated by:"
-msgstr "Aktualisiert von:"
-
-#: ../src/dialog_properties.cpp:74
-msgid "Update details:"
-msgstr "Aktualisierungsdetails:"
-
-#: ../src/dialog_properties.cpp:100
-msgid "0: Smart wrapping, top line is wider"
-msgstr "0: Intelligent umbrechen, obere Zeile ist breiter"
-
-#: ../src/dialog_properties.cpp:101
-msgid "1: End-of-line word wrapping, only \\N breaks"
-msgstr "1: Am Ende der Zeile oder bei \\N umbrechen"
-
-#: ../src/dialog_properties.cpp:102
-msgid "2: No word wrapping, both \\n and \\N break"
-msgstr "2: Kein Umbruch, nur manuell mit \\n und \\N"
-
-#: ../src/dialog_properties.cpp:103
-msgid "3: Smart wrapping, bottom line is wider"
-msgstr "3: Intelligent umbrechen, untere Zeile ist breiter"
-
-#: ../src/dialog_properties.cpp:107
-msgid "Wrap Style: "
-msgstr "Umbruch-Stil:"
-
-#: ../src/dialog_properties.cpp:110
-msgid "Scale Border and Shadow"
-msgstr "Skaliert Umrahmung und Schatten"
-
-#: ../src/dialog_properties.cpp:111
-msgid ""
-"Scale border and shadow together with script/render resolution. If this is "
-"unchecked, relative border and shadow size will depend on renderer."
-msgstr ""
-"Skaliert Ränder und Schatten mit der Skript-/Render-Auflösung. Wenn dies "
-"deaktiviert ist, wird die relative Rand- und Schattengröße beim Rendern "
-"verwendet."
-
-#: ../src/dialog_properties.cpp:151
-msgid "property changes"
-msgstr "Änderungen der Eigenschaften"
-
-#: ../src/video_context.cpp:155
+#: ../src/dialog_video_properties.cpp:46
 #, c-format
 msgid ""
 "The resolution of the loaded video and the resolution specified for the "
@@ -5478,170 +6119,211 @@ msgstr ""
 "\n"
 "Untertitel-Auflösung anpassen, sodaß sie zum Video paßt?"
 
-#: ../src/video_context.cpp:156
-msgid "Resolution mismatch"
-msgstr "Auflösungen stimmen nicht überein"
+#: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
+#, fuzzy
+msgid "Set to video resolution"
+msgstr "Videoauflösung:"
 
-#: ../src/video_context.cpp:177
-msgid ""
-"You already have timecodes loaded. Would you like to replace them with "
-"timecodes from the video file?"
+#: ../src/dialog_video_properties.cpp:55
+msgid "Resample script (stretch to new aspect ratio)"
 msgstr ""
-"Es sind bereits Zeitcodes geladen. Durch Zeitcodes aus der Videodatei "
-"ersetzen?"
 
-#: ../src/video_context.cpp:177
-msgid "Replace timecodes?"
-msgstr "Zeitcodes ersetzen?"
+#: ../src/dialog_video_properties.cpp:56
+msgid "Resample script (add borders)"
+msgstr ""
 
-#: ../src/video_context.cpp:217
+#: ../src/dialog_video_properties.cpp:57
+msgid "Resample script (remove borders)"
+msgstr ""
+
+#: ../src/dialog_video_properties.cpp:64
+#, fuzzy
+msgid "Resample script"
+msgstr "Auflösung anpassen"
+
+#: ../src/dialog_video_properties.cpp:163
 msgid "change script resolution"
 msgstr "Skriptauflösung ändern"
 
-#: ../src/ffmpegsource_common.cpp:101
-msgid "Indexing"
-msgstr "Indiziere"
-
-#: ../src/ffmpegsource_common.cpp:101
-msgid "Reading timecodes and frame/sample data"
-msgstr "Lese Zeitcodes und Frame-/Sample-Daten"
-
-#: ../src/ffmpegsource_common.cpp:153
-#, c-format
-msgid "Track %02d: %s"
-msgstr "Spur %02d: %s"
-
-#: ../src/ffmpegsource_common.cpp:158
-msgid "Multiple video tracks detected, please choose the one you wish to load:"
-msgstr ""
-"Mehrere Videospuren erkannt, wählen Sie bitte die, die Sie laden möchten:"
-
-#: ../src/ffmpegsource_common.cpp:158
-msgid "Multiple audio tracks detected, please choose the one you wish to load:"
-msgstr ""
-"Mehrere Tonspuren erkannt, wählen Sie bitte die, die Sie laden möchten:"
-
-#: ../src/ffmpegsource_common.cpp:159
-msgid "Choose video track"
-msgstr "Wähle Videospur"
-
-#: ../src/ffmpegsource_common.cpp:159
-msgid "Choose audio track"
-msgstr "Wähle Tonspur"
-
-#: ../src/main.cpp:340
-#, c-format
-msgid ""
-"Oops, Aegisub has crashed!\n"
-"\n"
-"An attempt has been made to save a copy of your file to:\n"
-"\n"
-"%s\n"
-"\n"
-"Aegisub will now close."
-msgstr ""
-"Au weia, Aegisub ist abgestürzt!\n"
-"\n"
-"Es wurde versucht, eine Kopie Ihrer Änderungen in eine Datei zu schreiben:\n"
-"\n"
-"%s\n"
-"\n"
-"Aegisub wird nun beendet."
-
-#: ../src/main.cpp:360 ../src/main.cpp:369
-msgid "Program error"
-msgstr "Programmfehler"
-
-#: ../src/dialog_attachments.cpp:56
+#: ../src/dialog_attachments.cpp:68
 msgid "Attachment List"
 msgstr "Anhangsliste"
 
-#: ../src/dialog_attachments.cpp:64
+#: ../src/dialog_attachments.cpp:76
 msgid "Attach &Font"
 msgstr "&Schriftart anhängen"
 
-#: ../src/dialog_attachments.cpp:65
+#: ../src/dialog_attachments.cpp:77
 msgid "Attach &Graphics"
 msgstr "&Bild anhängen"
 
-#: ../src/dialog_attachments.cpp:66
+#: ../src/dialog_attachments.cpp:78
 msgid "E&xtract"
 msgstr "E&xtrahieren"
 
-#: ../src/dialog_attachments.cpp:98
+#: ../src/dialog_attachments.cpp:110
 msgid "Attachment name"
 msgstr "Name des Anhangs"
 
-#: ../src/dialog_attachments.cpp:99
+#: ../src/dialog_attachments.cpp:111
 msgid "Size"
 msgstr "Größe"
 
-#: ../src/dialog_attachments.cpp:100
+#: ../src/dialog_attachments.cpp:112
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../src/dialog_attachments.cpp:127 ../src/dialog_attachments.cpp:136
+#: ../src/dialog_attachments.cpp:138 ../src/dialog_attachments.cpp:147
 msgid "Choose file to be attached"
 msgstr "Anzuhängende Datei auswählen"
 
-#: ../src/dialog_attachments.cpp:131
+#: ../src/dialog_attachments.cpp:142
 msgid "attach font file"
 msgstr "Schriftartendatei anhängen"
 
-#: ../src/dialog_attachments.cpp:141
+#: ../src/dialog_attachments.cpp:152
 msgid "attach graphics file"
 msgstr "Bilddatei anhängen"
 
-#: ../src/dialog_attachments.cpp:153
+#: ../src/dialog_attachments.cpp:164
 msgid "Select the path to save the files to:"
 msgstr "Ordner zum Speichern der Dateien:"
 
-#: ../src/dialog_attachments.cpp:156
+#: ../src/dialog_attachments.cpp:167
 msgid "Select the path to save the file to:"
 msgstr "Ordner zum Speichern der Datei:"
 
-#: ../src/dialog_attachments.cpp:182
+#: ../src/dialog_attachments.cpp:189
 msgid "remove attachment"
 msgstr "Anhang entfernen"
 
-#: ../src/dialog_version_check.cpp:110
+#: ../src/dialog_translation.cpp:77
+msgid "Original"
+msgstr "Original"
+
+#: ../src/dialog_translation.cpp:100
+msgid "Translation"
+msgstr "Übersetzung"
+
+#: ../src/dialog_translation.cpp:115
+msgid "Insert original"
+msgstr "Original einfügen"
+
+#: ../src/dialog_translation.cpp:118
+msgid "Delete line"
+msgstr "Zeile löschen"
+
+#: ../src/dialog_translation.cpp:121
+msgid "Enable &preview"
+msgstr "Vorschau aktivieren"
+
+#: ../src/dialog_translation.cpp:178 ../src/dialog_translation.cpp:278
+msgid "No more lines to translate."
+msgstr "Keine weiteren Zeilen zum Übersetzen."
+
+#: ../src/dialog_translation.cpp:186 ../src/dialog_translation.cpp:236
+#, c-format
+msgid "Current line: %d/%d"
+msgstr "Aktuelle Zeile: %d/%d"
+
+#: ../src/dialog_translation.cpp:273
+msgid "translation assistant"
+msgstr "Übersetzungsassistent"
+
+#: ../src/visual_tool.cpp:122
+msgid "visual typesetting"
+msgstr "Visuelles Typesetting"
+
+#: ../src/dialog_resample.cpp:119
+msgid "&Symmetrical"
+msgstr "Symmetrisch"
+
+#: ../src/dialog_resample.cpp:143
+#, fuzzy
+msgid "From s&cript"
+msgstr "Keine Skripte"
+
+#: ../src/dialog_resample.cpp:146
+msgid "Stretch"
+msgstr ""
+
+#: ../src/dialog_resample.cpp:146
+msgid "Add borders"
+msgstr ""
+
+#: ../src/dialog_resample.cpp:146
+#, fuzzy
+msgid "Remove borders"
+msgstr "Entfernen"
+
+#: ../src/dialog_resample.cpp:146
+msgid "Manual"
+msgstr ""
+
+#: ../src/dialog_resample.cpp:147
+msgid "Aspect Ratio Handling"
+msgstr ""
+
+#: ../src/dialog_resample.cpp:162
+msgid "Margin offset"
+msgstr "Ränderversatz"
+
+#: ../src/dialog_resample.cpp:167 ../src/dialog_resample.cpp:181
+msgid "x"
+msgstr "x"
+
+#: ../src/dialog_resample.cpp:172 ../src/dialog_resample.cpp:186
+msgid "YCbCr Matrix:"
+msgstr ""
+
+#: ../src/dialog_resample.cpp:175
+#, fuzzy
+msgid "Source Resolution"
+msgstr "Skriptauflösung"
+
+#: ../src/dialog_resample.cpp:189
+#, fuzzy
+msgid "Destination Resolution"
+msgstr "Auflösung anpassen"
+
+#: ../src/dialog_version_check.cpp:94
 msgid "Version Checker"
 msgstr "Auf neue Version prüfen"
 
-#: ../src/dialog_version_check.cpp:135
+#: ../src/dialog_version_check.cpp:119
 msgid "&Auto Check for Updates"
 msgstr "Automatisch auf Updates prüfen"
 
-#: ../src/dialog_version_check.cpp:140
+#: ../src/dialog_version_check.cpp:124
 msgid "Remind me again in a &week"
 msgstr "Mich in einer Woche erneut erinnern"
 
-#: ../src/dialog_version_check.cpp:304
+#: ../src/dialog_version_check.cpp:288
 msgid "Could not connect to updates server."
 msgstr "Konnte keine Verbindung zum Update-Server herstellen."
 
-#: ../src/dialog_version_check.cpp:327
+#: ../src/dialog_version_check.cpp:310
 msgid "Could not download from updates server."
 msgstr "Konnte nichts vom Update-Server herunterladen."
 
-#: ../src/dialog_version_check.cpp:329
+#: ../src/dialog_version_check.cpp:312
 #, c-format
 msgid "HTTP request failed, got HTTP response %d."
 msgstr "http-Anforderung fehlgeschlagen, bekam http-Antwort %d"
 
-#: ../src/dialog_version_check.cpp:361
+#: ../src/dialog_version_check.cpp:343
 msgid "An update to Aegisub was found."
 msgstr "Es wurde ein Update für Aegisub gefunden."
 
-#: ../src/dialog_version_check.cpp:363
+#: ../src/dialog_version_check.cpp:345
 msgid "Several possible updates to Aegisub were found."
 msgstr "Mehrere mögliche Updates für Aegisub wurden gefunden."
 
-#: ../src/dialog_version_check.cpp:365
+#: ../src/dialog_version_check.cpp:347
 msgid "There are no updates to Aegisub."
 msgstr "Keine Updates für Aegisub vorhanden."
 
-#: ../src/dialog_version_check.cpp:394
+#: ../src/dialog_version_check.cpp:375
 #, c-format
 msgid ""
 "There was an error checking for updates to Aegisub:\n"
@@ -5655,308 +6337,11 @@ msgstr ""
 "Wenn andere Anwendungen auf das Internet zugreifen können, ist dies "
 "wahrscheinlich ein temporäres Server-Problem auf unserer Seite."
 
-#: ../src/dialog_version_check.cpp:398
+#: ../src/dialog_version_check.cpp:379
 msgid "An unknown error occurred while checking for updates to Aegisub."
 msgstr ""
 "Es ist ein unbekannter Fehler während der Überprüfung auf Updates für "
 "Aegisub aufgetreten."
-
-#: ../src/dialog_spellchecker.cpp:79
-msgid "Misspelled word:"
-msgstr "Falsch geschriebenes Wort:"
-
-#: ../src/dialog_spellchecker.cpp:81 ../src/dialog_search_replace.cpp:71
-msgid "Replace with:"
-msgstr "Ersetzen durch:"
-
-#: ../src/dialog_spellchecker.cpp:136 ../src/dialog_search_replace.cpp:78
-msgid "&Skip Comments"
-msgstr "Überspringe Kommentare"
-
-#: ../src/dialog_spellchecker.cpp:137
-msgid "Ignore &UPPERCASE words"
-msgstr "Worte in Großbuchstaben ignorieren"
-
-#: ../src/dialog_spellchecker.cpp:141
-msgid "&Replace"
-msgstr "Ersetzen"
-
-#: ../src/dialog_spellchecker.cpp:144 ../src/dialog_search_replace.cpp:93
-msgid "Replace &all"
-msgstr "Alle ersetzen"
-
-#: ../src/dialog_spellchecker.cpp:151
-msgid "&Ignore"
-msgstr "Ignorieren"
-
-#: ../src/dialog_spellchecker.cpp:154
-msgid "Ignore a&ll"
-msgstr "Alle ignorieren"
-
-#: ../src/dialog_spellchecker.cpp:160
-msgid "Add to &dictionary"
-msgstr "Zum Wörterbuch hinzufügen"
-
-#: ../src/dialog_spellchecker.cpp:166
-msgid "Remove fro&m dictionary"
-msgstr "Aus dem Wörterbuch entfernen"
-
-#: ../src/dialog_spellchecker.cpp:237
-msgid "Aegisub has finished checking spelling of this script."
-msgstr "Aegisub hat die Rechtschreibprüfung für dieses Skript abgeschlossen."
-
-#: ../src/dialog_spellchecker.cpp:237 ../src/dialog_spellchecker.cpp:241
-msgid "Spell checking complete."
-msgstr "&Rechtschreibprüfung abgeschlossen"
-
-#: ../src/dialog_spellchecker.cpp:241
-msgid "Aegisub has found no spelling mistakes in this script."
-msgstr "Aegisub hat keine Rechtschreibfehler in diesem Skript gefunden."
-
-#: ../src/dialog_spellchecker.cpp:289 ../src/dialog_spellchecker.cpp:303
-msgid "spell check replace"
-msgstr "Rechtschreibprüfung ersetzen"
-
-#: ../src/charset_detect.cpp:82
-msgid ""
-"Aegisub could not narrow down the character set to a single one.\n"
-"Please pick one below:"
-msgstr ""
-"Aegisub kann den Zeichensatz nicht eindeutig zuweisen.\n"
-"Bitte wählen Sie einen aus:"
-
-#: ../src/charset_detect.cpp:83
-msgid "Choose character set"
-msgstr "Zeichensatz auswählen"
-
-#: ../src/ass_style.cpp:232
-msgid "ANSI"
-msgstr "Ansi"
-
-#: ../src/ass_style.cpp:234
-msgid "Symbol"
-msgstr "Symbol"
-
-#: ../src/ass_style.cpp:235
-msgid "Mac"
-msgstr "Mac"
-
-#: ../src/ass_style.cpp:236
-msgid "Shift_JIS"
-msgstr "Shift-Jis"
-
-#: ../src/ass_style.cpp:237
-msgid "Hangeul"
-msgstr "Hangeul"
-
-#: ../src/ass_style.cpp:238
-msgid "Johab"
-msgstr "Johab"
-
-#: ../src/ass_style.cpp:239
-msgid "GB2312"
-msgstr "GB2312"
-
-#: ../src/ass_style.cpp:240
-msgid "Chinese BIG5"
-msgstr "Chinesisch (Big5)"
-
-#: ../src/ass_style.cpp:241
-msgid "Greek"
-msgstr "Griechisch"
-
-#: ../src/ass_style.cpp:242
-msgid "Turkish"
-msgstr "Türkisch"
-
-#: ../src/ass_style.cpp:243
-msgid "Vietnamese"
-msgstr "Vietnamesisch"
-
-#: ../src/ass_style.cpp:244
-msgid "Hebrew"
-msgstr "Hebräisch"
-
-#: ../src/ass_style.cpp:245
-msgid "Arabic"
-msgstr "Arabisch"
-
-#: ../src/ass_style.cpp:246
-msgid "Baltic"
-msgstr "Baltisch"
-
-#: ../src/ass_style.cpp:247
-msgid "Russian"
-msgstr "Russisch"
-
-#: ../src/ass_style.cpp:248
-msgid "Thai"
-msgstr "Thai"
-
-#: ../src/ass_style.cpp:249
-msgid "East European"
-msgstr "Osteuropäisch"
-
-#: ../src/ass_style.cpp:250
-msgid "OEM"
-msgstr "Oem"
-
-#: ../src/base_grid.cpp:487 ../src/base_grid.cpp:895
-msgid "#"
-msgstr "#"
-
-#: ../src/base_grid.cpp:487 ../src/base_grid.cpp:896
-msgid "L"
-msgstr "L"
-
-#: ../src/base_grid.cpp:487 ../src/base_grid.cpp:766 ../src/base_grid.cpp:897
-msgid "Start"
-msgstr "Start"
-
-#: ../src/base_grid.cpp:487 ../src/base_grid.cpp:767 ../src/base_grid.cpp:898
-msgid "End"
-msgstr "Ende"
-
-#: ../src/base_grid.cpp:764
-msgid "Line Number"
-msgstr "Zeilennummer"
-
-#: ../src/ass_karaoke.cpp:320
-msgid "splitting"
-msgstr "Splitten"
-
-#: ../src/subtitle_format.cpp:121
-#, c-format
-msgid "From video (%g)"
-msgstr "Vom Video (%g)"
-
-#: ../src/subtitle_format.cpp:123
-msgid "From video (VFR)"
-msgstr "Vom Video (vfr)"
-
-#: ../src/subtitle_format.cpp:129
-msgid "15.000 FPS"
-msgstr "15.000 fps"
-
-#: ../src/subtitle_format.cpp:130
-msgid "23.976 FPS (Decimated NTSC)"
-msgstr "23.976 fps (Dezimiertes Ntsc)"
-
-#: ../src/subtitle_format.cpp:131
-msgid "24.000 FPS (FILM)"
-msgstr "24.000 fps (Film)"
-
-#: ../src/subtitle_format.cpp:132
-msgid "25.000 FPS (PAL)"
-msgstr "25.000 fps (Pal)"
-
-#: ../src/subtitle_format.cpp:133
-msgid "29.970 FPS (NTSC)"
-msgstr "29.970 fps (Ntsc)"
-
-#: ../src/subtitle_format.cpp:135
-msgid "29.970 FPS (NTSC with SMPTE dropframe)"
-msgstr "29.970 fps (Ntsc mit Smpte-Frame)"
-
-#: ../src/subtitle_format.cpp:136
-msgid "30.000 FPS"
-msgstr "30.000 fps"
-
-#: ../src/subtitle_format.cpp:137
-msgid "50.000 FPS (PAL x2)"
-msgstr "50.000 fps (Pal x2)"
-
-#: ../src/subtitle_format.cpp:138
-msgid "59.940 FPS (NTSC x2)"
-msgstr "59.940 fps (Ntsc x2)"
-
-#: ../src/subtitle_format.cpp:139
-msgid "60.000 FPS"
-msgstr "60.000 fps"
-
-#: ../src/subtitle_format.cpp:140
-msgid "119.880 FPS (NTSC x4)"
-msgstr "119.880 fps (Ntsc x4)"
-
-#: ../src/subtitle_format.cpp:141
-msgid "120.000 FPS"
-msgstr "120.000 fps"
-
-#: ../src/subtitle_format.cpp:144
-msgid "Please choose the appropriate FPS for the subtitles:"
-msgstr "Bitte wählen Sie die entsprechende Framerate für den Untertitel:"
-
-#: ../src/subtitle_format.cpp:144
-msgid "FPS"
-msgstr "fps"
-
-#: ../src/audio_provider_hd.cpp:129
-msgid "Reading to Hard Disk cache"
-msgstr "Lese in den Festplattencaches"
-
-#: ../src/dialog_progress.cpp:150
-msgid "Cancel"
-msgstr "Abbruch"
-
-#: ../src/dialog_progress.cpp:180
-msgid "Cancelling..."
-msgstr "Abbrechen..."
-
-#: ../src/dialog_search_replace.cpp:46
-msgid "Replace"
-msgstr "Ersetzen"
-
-#: ../src/dialog_search_replace.cpp:66
-msgid "Find what:"
-msgstr "Suche nach:"
-
-#: ../src/dialog_search_replace.cpp:76
-msgid "&Match case"
-msgstr "Groß-/Kleinschreibung beachten"
-
-#: ../src/dialog_search_replace.cpp:77
-msgid "&Use regular expressions"
-msgstr "Reguläre Ausdrücke verwenden"
-
-#: ../src/dialog_search_replace.cpp:79
-msgid "S&kip Override Tags"
-msgstr "Tags überspringen"
-
-#: ../src/dialog_search_replace.cpp:86
-msgid "All rows"
-msgstr "Alle Zeilen"
-
-#: ../src/dialog_search_replace.cpp:86
-msgid "Selected rows"
-msgstr "Ausgewählte Zeilen"
-
-#: ../src/dialog_search_replace.cpp:89
-msgid "Limit to"
-msgstr "Begrenzen auf"
-
-#: ../src/dialog_search_replace.cpp:91
-msgid "&Find next"
-msgstr "Nächstes finden"
-
-#: ../src/dialog_search_replace.cpp:92
-msgid "Replace &next"
-msgstr "Nächstes ersetzen"
-
-#: ../src/mkv_wrap.cpp:172
-msgid "Choose which track to read:"
-msgstr "Wählen Sie die Spur aus, den sie lesen wollen: "
-
-#: ../src/mkv_wrap.cpp:172
-msgid "Multiple subtitle tracks found"
-msgstr "Mehrere Untertitelspuren gefunden"
-
-#: ../src/mkv_wrap.cpp:210
-msgid "Parsing Matroska"
-msgstr "Analysiere Matroska"
-
-#: ../src/mkv_wrap.cpp:210
-msgid "Reading subtitles from Matroska file."
-msgstr "Lese Untertitel aus Matroska-Datei"
 
 #: default_menu.json:0
 msgid "&Insert (before)"
@@ -6058,9 +6443,100 @@ msgstr "Seitenverhältnis ändern"
 msgid "&Export As..."
 msgstr "Exportiere als..."
 
-#: default_hotkey.json:590:
+#: default_hotkey.json:602:
 msgid "Subtitle Edit Box"
 msgstr "Untertitel-Bearbeitungsbox"
+
+#: ../automation/autoload/macro-1-edgeblur.lua:6
+msgid "Add edgeblur"
+msgstr ""
+
+#: ../automation/autoload/macro-1-edgeblur.lua:7
+msgid "A demo macro showing how to do simple line modification in Automation 4"
+msgstr ""
+
+#: ../automation/autoload/macro-1-edgeblur.lua:21
+#, fuzzy
+msgid "Adds \\be1 tags to all selected lines"
+msgstr "Vertauscht die ausgewählten Zeilen miteinander"
+
+#: ../automation/autoload/karaoke-auto-leadin.lua:32
+#, fuzzy
+msgid "Automatic karaoke lead-in"
+msgstr "Automatisch speichern"
+
+#: ../automation/autoload/karaoke-auto-leadin.lua:33
+#, fuzzy
+msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
+msgstr "Fügt die markierten Zeilen zu einer zusammen (als Karaoke)"
+
+#: ../automation/autoload/cleantags-autoload.lua:31
+#, fuzzy
+msgid "Clean Tags"
+msgstr "Tags verstecken"
+
+#: ../automation/autoload/cleantags-autoload.lua:32
+msgid ""
+"Clean subtitle lines by re-arranging ASS tags and override blocks within the "
+"lines"
+msgstr ""
+
+#: ../automation/autoload/kara-templater.lua:36
+#, fuzzy
+msgid "Karaoke Templater"
+msgstr "Karaoke-Vorlage"
+
+#: ../automation/autoload/kara-templater.lua:37
+msgid ""
+"Macro and export filter to apply karaoke effects using the template language"
+msgstr ""
+
+#: ../automation/autoload/kara-templater.lua:858
+#, fuzzy
+msgid "Apply karaoke template"
+msgstr "Karaoke-Vorlage"
+
+#: ../automation/autoload/kara-templater.lua:858
+msgid "Applies karaoke effects from templates"
+msgstr ""
+
+#: ../automation/autoload/kara-templater.lua:859
+#, fuzzy
+msgid "Karaoke template"
+msgstr "Karaoke-Vorlage"
+
+#: ../automation/autoload/kara-templater.lua:859
+msgid ""
+"Apply karaoke effect templates to the subtitles.\n"
+"\n"
+"See the help file for information on how to use this."
+msgstr ""
+
+#: ../automation/autoload/strip-tags.lua:17
+msgid "Strip tags"
+msgstr ""
+
+#: ../automation/autoload/strip-tags.lua:18
+msgid "Remove all override tags from selected lines"
+msgstr ""
+
+#: ../automation/autoload/strip-tags.lua:28
+msgid "strip tags"
+msgstr ""
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:77
+#, fuzzy
+msgid "Make fullwidth"
+msgstr "Standardbreite"
+
+#: ../automation/autoload/macro-2-mkfullwitdh.lua:80
+msgid "Convert Latin letters to SJIS fullwidth letters"
+msgstr ""
+
+#: aegisub.desktop:4
+#, fuzzy
+msgid "Aegisub"
+msgstr "Über Aegisub"
 
 #: aegisub.desktop:5
 msgid "Subtitle Editor"
@@ -6069,3 +6545,124 @@ msgstr "Untertitel-Editor"
 #: aegisub.desktop:6
 msgid "Create and edit subtitles for film and videos."
 msgstr "Erzeugt und bearbeitet Untertitel für Filme und Videos."
+
+#: packages/win_installer/fragment_strings.iss:1
+msgid "Installing runtime libraries..."
+msgstr ""
+
+#: packages/win_installer/fragment_strings.iss:1
+msgid "Create a start menu icon"
+msgstr ""
+
+#: packages/win_installer/fragment_strings.iss:1
+msgid "Automatically check for new versions of Aegisub"
+msgstr ""
+
+#: packages/win_installer/fragment_strings.iss:1
+#, fuzzy
+msgid "Update Checker:"
+msgstr "Rechtschreibprüfung"
+
+#: packages/win_installer/fragment_strings.iss:1
+msgid ""
+"This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n"
+"%nAegisub is covered by the GNU General Public License version 2. This means "
+"you may use the application for any purpose without charge, but that no "
+"warranties of any kind are given either.%n%nSee the Aegisub website for "
+"information on obtaining the source code."
+msgstr ""
+
+#~ msgid "Allow grid to take focus"
+#~ msgstr "Gitter darf Fokus annehmen"
+
+#~ msgid "File name"
+#~ msgstr "Dateiname"
+
+#~ msgid "Find words in subtitles"
+#~ msgstr "Suche nach Wörtern in den Untertiteln"
+
+#~ msgid "Saves subtitles"
+#~ msgstr "Speichert die Untertitel-Datei"
+
+#~ msgid "Copy subtitles"
+#~ msgstr "Kopiere Untertitel"
+
+#~ msgid "D&uplicate and Shift by 1 Frame"
+#~ msgstr "&Duplizieren und um 1 Frame verschieben"
+
+#~ msgid "Duplicate and Shift by 1 Frame"
+#~ msgstr "&Duplizieren und um 1 Frame verschieben"
+
+#~ msgid ""
+#~ "Duplicate lines and shift them to the frame after the original end frame"
+#~ msgstr ""
+#~ "Zeilen duplizieren und zum Frame nach dem ursprünglichen End-Frame "
+#~ "verschieben"
+
+#~ msgid "Du&plicate and Shift by 1 Frame Backwards"
+#~ msgstr "Du&plizieren und um 1 Frame rückwärts verschieben"
+
+#~ msgid "Duplicate and Shift by 1 Frame Backwards"
+#~ msgstr "Duplizieren und um 1 Frame rückwärts verschieben"
+
+#~ msgid ""
+#~ "Duplicate selected lines and shift them to the frame before the original "
+#~ "start frame"
+#~ msgstr ""
+#~ "Ausgewählte Zeilen duplizieren und auf den Frame vor dem ursprünglichen "
+#~ "Anfangs-Frame verschieben"
+
+#~ msgid "All Fil&es"
+#~ msgstr "Alle Dateien"
+
+#~ msgid "Resource files"
+#~ msgstr "Ressourcen-Dateien"
+
+#~ msgid "Closes the currently open keyframes list"
+#~ msgstr "Schließt die aktuelle Keyframe-Datei"
+
+#~ msgid "Changes resolution and modifies subtitles to conform to change"
+#~ msgstr "Verändert die Auflösung und paßt die Untertitel entsprechend an"
+
+#~ msgid "Are you sure you want to delete these %d styles?"
+#~ msgstr "Sind Sie sicher, daß Sie %d Stile löschen wollen?"
+
+#~ msgid "Reading into RAM"
+#~ msgstr "Lade in Arbeitsspeicher"
+
+#~ msgid "Selection was set to %u lines"
+#~ msgstr "Es wurden %u Zeilen ausgewählt"
+
+#~ msgid "%u lines were added to selection"
+#~ msgstr "%u Zeilen wurden zur Auswahl hinzugefügt"
+
+#~ msgid "%u lines were removed from selection"
+#~ msgstr "%u Zeilen wurden aus der Auswahl entfernt"
+
+#~ msgid ""
+#~ "An Automation script failed to load. File name: '%s', error reported: %s"
+#~ msgstr ""
+#~ "Ein Automatisierungsskript konnte nicht geladen werden. Dateiname: '%s', "
+#~ "Fehler: %s"
+
+#~ msgid "%d frames (%s)"
+#~ msgstr "%d Frames (%s)"
+
+#~ msgid "    Subtitle format handler: %s"
+#~ msgstr "    Untertitelformat-Handler: %s"
+
+#~ msgid "&Change aspect ratio"
+#~ msgstr "Seitenverhältnis ändern"
+
+#~ msgid ""
+#~ "You already have timecodes loaded. Would you like to replace them with "
+#~ "timecodes from the video file?"
+#~ msgstr ""
+#~ "Es sind bereits Zeitcodes geladen. Durch Zeitcodes aus der Videodatei "
+#~ "ersetzen?"
+
+#~ msgid "Reading to Hard Disk cache"
+#~ msgstr "Lese in den Festplattencaches"
+
+#~ msgid "Selected rows"
+#~ msgstr "Ausgewählte Zeilen"

--- a/po/de.po
+++ b/po/de.po
@@ -7,15 +7,17 @@ msgstr ""
 "Project-Id-Version: Aegisub 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-07-01 10:53-0700\n"
-"PO-Revision-Date: 2013-07-17 22:15+0100\n"
-"Last-Translator: Shimapan <erokawaii@yandex.ru>\n"
+"PO-Revision-Date: 2020-07-26 17:57+0200\n"
+"Last-Translator: Oneric <oneric@nomail>\n"
 "Language-Team: Pantsu ga daisuki <erokawaii@yandex.ru>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.4\n"
+"Previous-Translator: Shimapan <erokawaii@yandex.ru>\n"
+"X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../src/dialog_shift_times.cpp:92
 msgid "unsaved"
@@ -53,11 +55,11 @@ msgstr "Alle"
 #: ../src/dialog_shift_times.cpp:113
 #, c-format
 msgid "from %d onward"
-msgstr "ab %d "
+msgstr "ab %d"
 
 #: ../src/dialog_shift_times.cpp:115
 msgid "sel "
-msgstr "Ausw."
+msgstr "Ausw. "
 
 #: ../src/dialog_shift_times.cpp:133 ../src/command/time.cpp:153
 msgid "Shift Times"
@@ -95,7 +97,7 @@ msgstr "Vorwärts"
 msgid ""
 "Shifts subs forward, making them appear later. Use if they are appearing too "
 "soon."
-msgstr "Untertitel vorwärts verschieben, sodaß sie später angezeigt werden."
+msgstr "Untertitel vorwärts verschieben, sodass sie später angezeigt werden."
 
 #: ../src/dialog_shift_times.cpp:159
 msgid "&Backward"
@@ -105,7 +107,7 @@ msgstr "Rückwärts"
 msgid ""
 "Shifts subs backward, making them appear earlier. Use if they are appearing "
 "too late."
-msgstr "Untertitel rückwärts verschieben, sodaß sie früher angezeigt werden."
+msgstr "Untertitel rückwärts verschieben, sodass sie früher angezeigt werden."
 
 #: ../src/dialog_shift_times.cpp:162
 msgid "&All rows"
@@ -113,7 +115,7 @@ msgstr "Alle Zeilen"
 
 #: ../src/dialog_shift_times.cpp:162 ../src/dialog_search_replace.cpp:88
 msgid "Selected &rows"
-msgstr "Ausgewählte Zeilen"
+msgstr "Ausgewählte Reihen"
 
 #: ../src/dialog_shift_times.cpp:162
 msgid "Selection &onward"
@@ -205,11 +207,13 @@ msgid "&Paste"
 msgstr "&Einfügen"
 
 #: ../src/auto4_base.cpp:460
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Failed to load Automation script '%s':\n"
 "%s"
-msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
+msgstr ""
+"Konnte Automatisierungsskript '%s' nicht laden:\n"
+"%s"
 
 #: ../src/auto4_base.cpp:467
 #, c-format
@@ -237,10 +241,10 @@ msgid "replace"
 msgstr "Ersetzen"
 
 #: ../src/search_replace_engine.cpp:332
-#, fuzzy, c-format
+#, c-format
 msgid "One match was replaced."
 msgid_plural "%d matches were replaced."
-msgstr[0] "%i Vorkommen ersetzt."
+msgstr[0] "Ein Vorkommen ersetzt."
 msgstr[1] "%i Vorkommen ersetzt."
 
 #: ../src/search_replace_engine.cpp:335
@@ -266,12 +270,13 @@ msgstr "Zeile länger als die max. Länge: %s"
 
 #: ../src/dialog_video_details.cpp:44
 msgid "Video Details"
-msgstr "Videodetails:"
+msgstr "Videodetails"
 
 #: ../src/dialog_video_details.cpp:58
 msgid "File name:"
 msgstr "Dateiname:"
 
+# Ja, im Deutschen wird fps kleingeschrieben
 #: ../src/dialog_video_details.cpp:59
 msgid "FPS:"
 msgstr "fps:"
@@ -285,11 +290,11 @@ msgid "Length:"
 msgstr "Länge:"
 
 #: ../src/dialog_video_details.cpp:61
-#, fuzzy, c-format
+#, c-format
 msgid "1 frame"
 msgid_plural "%d frames (%s)"
-msgstr[0] "%s Frames"
-msgstr[1] "%s Frames"
+msgstr[0] "1 Frame"
+msgstr[1] "%d Frames (%s)"
 
 #: ../src/dialog_video_details.cpp:63
 msgid "Decoder:"
@@ -358,7 +363,7 @@ msgstr "Hinzuzufügende Einlaufbereiche in ms"
 
 #: ../src/dialog_timing_processor.cpp:181
 msgid "Add lead &out:"
-msgstr "Auslaufbereiche hinzufügen:"
+msgstr "Auslaufbereich hinzufügen:"
 
 #: ../src/dialog_timing_processor.cpp:183
 msgid "Enable adding of lead-outs to lines"
@@ -451,7 +456,7 @@ msgid ""
 "Threshold for 'before start' distance, that is, how many milliseconds a "
 "subtitle must start before a keyframe to snap to it"
 msgstr ""
-"Bereich für 'vor Anfang', d.h. wieviele Millisekunden ein Untertitel vor "
+"Bereich für 'vor Anfang', d.h. wie viele Millisekunden ein Untertitel vor "
 "einem Keyframe anfangen darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:232
@@ -463,7 +468,7 @@ msgid ""
 "Threshold for 'after start' distance, that is, how many milliseconds a "
 "subtitle must start after a keyframe to snap to it"
 msgstr ""
-"Bereich für 'nach Anfang', d.h. wieviele Millisekunden ein Untertitel nach "
+"Bereich für 'nach Anfang', d.h. wie viele Millisekunden ein Untertitel nach "
 "einem Keyframe anfangen darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:237
@@ -475,8 +480,8 @@ msgid ""
 "Threshold for 'before end' distance, that is, how many milliseconds a "
 "subtitle must end before a keyframe to snap to it"
 msgstr ""
-"Bereich für 'vor Ende', d.h. wieviele Millisekunden ein Untertitel vor einem "
-"Keyframe enden darf, um darauf einzurasten"
+"Bereich für 'vor Ende', d.h. wie viele Millisekunden ein Untertitel vor "
+"einem Keyframe enden darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:240
 msgid "Ends after thres.:"
@@ -487,7 +492,7 @@ msgid ""
 "Threshold for 'after end' distance, that is, how many milliseconds a "
 "subtitle must end after a keyframe to snap to it"
 msgstr ""
-"Bereich für 'nach Ende', d.h. wieviele Millisekunden ein Untertitel nach "
+"Bereich für 'nach Ende', d.h. wie viele Millisekunden ein Untertitel nach "
 "einem Keyframe enden darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:349
@@ -505,7 +510,7 @@ msgstr "Timingverarbeitung"
 
 #: ../src/mkv_wrap.cpp:213
 msgid "Choose which track to read:"
-msgstr "Wählen Sie die Spur aus, den sie lesen wollen: "
+msgstr "Wählen Sie die Spur aus, den sie lesen wollen:"
 
 #: ../src/mkv_wrap.cpp:213
 msgid "Multiple subtitle tracks found"
@@ -517,7 +522,7 @@ msgstr "Analysiere Matroska"
 
 #: ../src/mkv_wrap.cpp:251
 msgid "Reading subtitles from Matroska file."
-msgstr "Lese Untertitel aus Matroska-Datei"
+msgstr "Lese Untertitel aus Matroska-Datei."
 
 #: ../src/dialog_styling_assistant.cpp:55 ../src/command/tool.cpp:123
 msgid "Styling Assistant"
@@ -658,11 +663,11 @@ msgid "Could not parse style"
 msgstr "Kann den Stil nicht lesen"
 
 #: ../src/dialog_style_manager.cpp:248
-#, fuzzy, c-format
+#, c-format
 msgid "Are you sure you want to delete this style?"
 msgid_plural "Are you sure you want to delete these %d styles?"
-msgstr[0] "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
-msgstr[1] "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
+msgstr[0] "Sind Sie sicher, dass Sie diesen Stil löschen wollen?"
+msgstr[1] "Sind Sie sicher, dass Sie diese %d Stile löschen wollen?"
 
 #: ../src/dialog_style_manager.cpp:259 ../src/command/tool.cpp:165
 msgid "Styles Manager"
@@ -739,7 +744,7 @@ msgstr "Ungültige Zeichen"
 #, c-format
 msgid "Are you sure you want to delete the storage \"%s\" from the catalog?"
 msgstr ""
-"Sind Sie sicher, daß Sie den Speicher \"%s\" aus dem Katalog löschen wollen?"
+"Sind Sie sicher, dass Sie den Speicher \"%s\" aus dem Katalog löschen wollen?"
 
 #: ../src/dialog_style_manager.cpp:491
 msgid "Confirm delete"
@@ -830,9 +835,8 @@ msgid "Close Timecodes File"
 msgstr "Zeitcode-Datei schließen"
 
 #: ../src/command/timecode.cpp:54
-#, fuzzy
 msgid "Close the currently open timecodes file"
-msgstr "Schließt die derzeit offene Datei mit Zeitcodes"
+msgstr "Schließe die derzeit offene Zeitcode-Datei"
 
 #: ../src/command/timecode.cpp:69
 msgid "Open Timecodes File..."
@@ -840,25 +844,23 @@ msgstr "Öffne Zeitcode-Datei..."
 
 #: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
 msgid "Open Timecodes File"
-msgstr "Öffne Zeitcode-Datei..."
+msgstr "Öffne Zeitcode-Datei"
 
 #: ../src/command/timecode.cpp:71
-#, fuzzy
 msgid "Open a VFR timecodes v1 or v2 file"
-msgstr "Öffnet eine Datei mit vfr-Zeitcodes, Typ v1 oder v2"
+msgstr "Öffne eine Datei mit VFR-Zeitcodes, Typ v1 oder v2"
 
 #: ../src/command/timecode.cpp:84
 msgid "Save Timecodes File..."
-msgstr "Speichere Zeitcode-Datei"
+msgstr "Speichere Zeitcode-Datei..."
 
 #: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
 msgid "Save Timecodes File"
 msgstr "Speichere Zeitcode-Datei"
 
 #: ../src/command/timecode.cpp:86
-#, fuzzy
 msgid "Save a VFR timecodes v2 file"
-msgstr "Speichere eine Datei mit vfr-Timecodes, Typ v2"
+msgstr "Speichere eine VFR-Zeitcode-Datei, Typ v2"
 
 #: ../src/command/command.cpp:31
 #, c-format
@@ -874,9 +876,8 @@ msgid "Cinematic (2.35)"
 msgstr "Kinoformat (2.35)"
 
 #: ../src/command/video.cpp:86
-#, fuzzy
 msgid "Force video to 2.35 aspect ratio"
-msgstr "Erzwingt 2.35:1-Seitenverhältnis für das Video"
+msgstr "Zwinge Video ins 47:20-„Kinoformat“ (2.35)"
 
 #: ../src/command/video.cpp:102
 msgid "C&ustom..."
@@ -884,12 +885,11 @@ msgstr "Benutzerdefiniert..."
 
 #: ../src/command/video.cpp:103
 msgid "Custom"
-msgstr "Benutzerdefiniert..."
+msgstr "Benutzerdefiniert"
 
 #: ../src/command/video.cpp:104
-#, fuzzy
 msgid "Force video to a custom aspect ratio"
-msgstr "Erzwingt ein benutzerdefiniertes Seitenverhältnis"
+msgstr "Erzwinge ein benutzerdefiniertes Seitenverhältnis"
 
 #: ../src/command/video.cpp:115
 msgid ""
@@ -909,7 +909,7 @@ msgstr "Seitenverhältnis angeben"
 
 #: ../src/command/video.cpp:135
 msgid "Invalid value! Aspect ratio must be between 0.5 and 5.0."
-msgstr "Ungültiger Wert! Seitenverhältnis muß zwischen 0.5 und 5.0 liegen."
+msgstr "Ungültiger Wert! Seitenverhältnis muss zwischen 0.5 und 5.0 liegen."
 
 #: ../src/command/video.cpp:135
 msgid "Invalid Aspect Ratio"
@@ -924,9 +924,8 @@ msgid "Default"
 msgstr "Vorgabe"
 
 #: ../src/command/video.cpp:147
-#, fuzzy
 msgid "Use video's original aspect ratio"
-msgstr "Beläßt das ursprüngliche Seitenverhältnis des Videos"
+msgstr "Verwende ursprüngliches Seitenverhältnis des Videos"
 
 #: ../src/command/video.cpp:163
 msgid "&Fullscreen (4:3)"
@@ -937,9 +936,8 @@ msgid "Fullscreen (4:3)"
 msgstr "&Vollbildformat (4:3)"
 
 #: ../src/command/video.cpp:165
-#, fuzzy
 msgid "Force video to 4:3 aspect ratio"
-msgstr "Erzwingt 4:3-Seitenverhältnis für das Video"
+msgstr "Zwinge das Video ins 4:3-Format"
 
 #: ../src/command/video.cpp:181
 msgid "&Widescreen (16:9)"
@@ -950,9 +948,8 @@ msgid "Widescreen (16:9)"
 msgstr "&Breitbildformat (16:9)"
 
 #: ../src/command/video.cpp:183
-#, fuzzy
 msgid "Force video to 16:9 aspect ratio"
-msgstr "Erzwingt 19:9-Seitenverhältnis für das Video"
+msgstr "Zwinge das Video ins 16:9-Format"
 
 #: ../src/command/video.cpp:200
 msgid "&Close Video"
@@ -963,9 +960,8 @@ msgid "Close Video"
 msgstr "Video &schließen"
 
 #: ../src/command/video.cpp:202
-#, fuzzy
 msgid "Close the currently open video file"
-msgstr "Schließt die derzeit offene Videodatei"
+msgstr "Schließe die derzeit offene Videodatei"
 
 #: ../src/command/video.cpp:211 ../src/command/video.cpp:212
 msgid "Copy coordinates to Clipboard"
@@ -979,18 +975,17 @@ msgstr ""
 "Zwischenablage"
 
 #: ../src/command/video.cpp:222 ../src/command/video.cpp:223
-#, fuzzy
 msgid "Cycle active subtitles provider"
-msgstr "Untertitel-Provider"
+msgstr "Wechsle Untertitel-Provider durch"
 
 #: ../src/command/video.cpp:224
 msgid "Cycle through the available subtitles providers"
-msgstr ""
+msgstr "Wechsle zyklisch durch die verfügbaren Untertitel-Provider"
 
 #: ../src/command/video.cpp:235
-#, fuzzy, c-format
+#, c-format
 msgid "Subtitles provider set to %s"
-msgstr "Untertitel-Provider"
+msgstr "Untertitel-Provider %s gewählt"
 
 #: ../src/command/video.cpp:242
 msgid "&Detach Video"
@@ -1001,7 +996,6 @@ msgid "Detach Video"
 msgstr "Video abkoppeln"
 
 #: ../src/command/video.cpp:244
-#, fuzzy
 msgid ""
 "Detach the video display from the main window, displaying it in a separate "
 "Window"
@@ -1011,26 +1005,25 @@ msgstr ""
 
 #: ../src/command/video.cpp:262
 msgid "Show &Video Details"
-msgstr "Zeige Videodetails..."
+msgstr "Zeige &Videodetails"
 
 #: ../src/command/video.cpp:263
 msgid "Show Video Details"
-msgstr "Zeige Videodetails..."
+msgstr "Zeige Videodetails"
 
 #: ../src/command/video.cpp:264
-#, fuzzy
 msgid "Show video details"
-msgstr "Zeigt die Videodetails an"
+msgstr "Zeige die Videodetails an"
 
 #: ../src/command/video.cpp:274 ../src/command/video.cpp:275
 msgid "Toggle video slider focus"
 msgstr "Wechsle Video-Schieberegeler"
 
 #: ../src/command/video.cpp:276
-#, fuzzy
 msgid ""
 "Toggle focus between the video slider and the previous thing to have focus"
-msgstr "Wechsle Fokus zwischen dem Videoschieberegler und anderen sachen"
+msgstr ""
+"Wechsle Fokus zwischen dem Videoschieberegler und dem vorigem/aktuellen Fokus"
 
 #: ../src/command/video.cpp:297 ../src/command/video.cpp:298
 msgid "Copy image to Clipboard"
@@ -1063,7 +1056,6 @@ msgid "Next Boundary"
 msgstr "Nächste Grenze"
 
 #: ../src/command/video.cpp:332
-#, fuzzy
 msgid "Seek to the next beginning or end of a subtitle"
 msgstr "Springe zur nächsten Untertitelgrenze"
 
@@ -1093,7 +1085,6 @@ msgid "Previous Boundary"
 msgstr "Vorherige Grenze"
 
 #: ../src/command/video.cpp:399
-#, fuzzy
 msgid "Seek to the previous beginning or end of a subtitle"
 msgstr "Springe zur vorherigen Untertitelgrenze"
 
@@ -1149,7 +1140,6 @@ msgid "Jump Video to End"
 msgstr "Video: ans Ende springen"
 
 #: ../src/command/video.cpp:538
-#, fuzzy
 msgid "Jump the video to the end frame of current subtitle"
 msgstr "Springt mit dem Video zum Ende des aktuellen Untertitels"
 
@@ -1162,7 +1152,6 @@ msgid "Jump Video to Start"
 msgstr "Video: an den Anfang springen"
 
 #: ../src/command/video.cpp:551
-#, fuzzy
 msgid "Jump the video to the start frame of current subtitle"
 msgstr "Springt mit dem Video zum Anfang des aktuellen Untertitels"
 
@@ -1175,9 +1164,8 @@ msgid "Open Video"
 msgstr "Öffne Video"
 
 #: ../src/command/video.cpp:564
-#, fuzzy
 msgid "Open a video file"
-msgstr "Öffnet eine Videodatei"
+msgstr "Öffne eine Videodatei"
 
 #: ../src/command/video.cpp:567 ../src/command/audio.cpp:83
 msgid "Video Formats"
@@ -1196,9 +1184,8 @@ msgid "Use Dummy Video"
 msgstr "Benutze Dummy-Video"
 
 #: ../src/command/video.cpp:580
-#, fuzzy
 msgid "Open a placeholder video clip with solid color"
-msgstr "Öffnet einen einfarbigen Videoclip"
+msgstr "Öffne einen einfarbigen Videoclip"
 
 #: ../src/command/video.cpp:592 ../src/command/video.cpp:593
 msgid "Toggle autoscroll of video"
@@ -1207,6 +1194,7 @@ msgstr "Automatisches Scrollen des Videos ein-/ausschalten"
 #: ../src/command/video.cpp:594
 msgid "Toggle automatically seeking video to the start time of selected lines"
 msgstr ""
+"Automatisches Scrollen des Videos zum Start der gewählten Zeile umschalten"
 
 #: ../src/command/video.cpp:609 ../src/command/video.cpp:610
 msgid "Play"
@@ -1414,7 +1402,7 @@ msgstr "Durchgestrichen ein/aus"
 
 #: ../src/command/edit.cpp:479
 msgid "Font Face..."
-msgstr "Schriftart"
+msgstr "Schriftart..."
 
 #: ../src/command/edit.cpp:480 ../src/preferences_base.cpp:251
 msgid "Font Face"
@@ -1422,7 +1410,7 @@ msgstr "Schriftart"
 
 #: ../src/command/edit.cpp:481
 msgid "Select a font face and size"
-msgstr "Schriftart und Größe auswählen"
+msgstr "Schriftart und -größe auswählen"
 
 #: ../src/command/edit.cpp:508
 msgid "set font"
@@ -1449,9 +1437,8 @@ msgid "Copy Lines"
 msgstr "Kopiere Zeilen"
 
 #: ../src/command/edit.cpp:600
-#, fuzzy
 msgid "Copy subtitles to the clipboard"
-msgstr "Bild in die Zwischenablage kopieren"
+msgstr "Kopiere Untertitel in die Zwischenablage"
 
 #: ../src/command/edit.cpp:621
 msgid "Cu&t Lines"
@@ -1506,26 +1493,28 @@ msgid "Duplicate the selected lines"
 msgstr "Markierte Zeilen duplizieren"
 
 #: ../src/command/edit.cpp:726 ../src/command/edit.cpp:727
-#, fuzzy
 msgid "Split lines after current frame"
-msgstr "Zeile nach der aktuellen einfügen"
+msgstr "Teile Zeile nach dem aktuellen Frame"
 
 #: ../src/command/edit.cpp:728
 msgid ""
 "Split the current line into a line which ends on the current frame and a "
 "line which starts on the next frame"
 msgstr ""
+"Teile die aktuelle Zeile in zwei auf. Eine wird bis zum aktuellen Frame "
+"gehen, die andere erst im nächsten Frame beginnen"
 
 #: ../src/command/edit.cpp:738 ../src/command/edit.cpp:739
-#, fuzzy
 msgid "Split lines before current frame"
-msgstr "Zeile vor aktueller einfügen"
+msgstr "Teile Zeile vor aktuellem Frame"
 
 #: ../src/command/edit.cpp:740
 msgid ""
 "Split the current line into a line which ends on the previous frame and a "
 "line which starts on the current frame"
 msgstr ""
+"Teile die aktuelle Zeile in zwei auf. Eine wird im vorigem Frame enden, die "
+"andere im aktuellen Frame beginnen"
 
 #: ../src/command/edit.cpp:775
 msgid "As &Karaoke"
@@ -1536,9 +1525,8 @@ msgid "As Karaoke"
 msgstr "Als Karaoke"
 
 #: ../src/command/edit.cpp:777
-#, fuzzy
 msgid "Join selected lines in a single one, as karaoke"
-msgstr "Fügt die markierten Zeilen zu einer zusammen (als Karaoke)"
+msgstr "Kombiniert gewählte Zeilen zu einer einzigen (als Karaoke)"
 
 #: ../src/command/edit.cpp:780
 msgid "join as karaoke"
@@ -1553,11 +1541,8 @@ msgid "Concatenate"
 msgstr "&Zusammenfügen (verbinden)"
 
 #: ../src/command/edit.cpp:788
-#, fuzzy
 msgid "Join selected lines in a single one, concatenating text together"
-msgstr ""
-"Fügt die ausgewählten Zeilen zu einer einzigen zusammen, der Text wird "
-"aneinandergehängt"
+msgstr "Kombiniert gewählte Zeilen zu einer, Text wird aneinandergehängt"
 
 #: ../src/command/edit.cpp:791 ../src/command/edit.cpp:802
 msgid "join lines"
@@ -1572,13 +1557,12 @@ msgid "Keep First"
 msgstr "Erhalte erste"
 
 #: ../src/command/edit.cpp:799
-#, fuzzy
 msgid ""
 "Join selected lines in a single one, keeping text of first and discarding "
 "remaining"
 msgstr ""
-"Fügt die ausgewählten Zeilen zu einer, erhält den ersten Text und verwirft "
-"den restlichen"
+"Kombiniert gewählte Zeilen zu einer, erhält den ersten Text und verwirft den "
+"Rest"
 
 #: ../src/command/edit.cpp:840
 msgid "&Paste Lines"
@@ -1598,7 +1582,7 @@ msgstr "Zeilen überschreiben..."
 
 #: ../src/command/edit.cpp:872
 msgid "Paste Lines Over"
-msgstr "Zeilen überschreiben..."
+msgstr "Zeilen überschreiben"
 
 #: ../src/command/edit.cpp:873
 msgid "Paste subtitles over others"
@@ -1613,9 +1597,8 @@ msgid "Recombine Lines"
 msgstr "Zeilen kombinieren"
 
 #: ../src/command/edit.cpp:958
-#, fuzzy
 msgid "Recombine subtitles which have been split and merged"
-msgstr "Untertitel kombinieren, wenn sie aufgeteilt und zusammengeführt wurden"
+msgstr "Untertitel rekombinieren, falls sie zuvor geteilt und vereinigt wurden"
 
 #: ../src/command/edit.cpp:1028
 msgid "combining"
@@ -1626,9 +1609,8 @@ msgid "Split Lines (by karaoke)"
 msgstr "Auftrennen (entlang Karaoke)"
 
 #: ../src/command/edit.cpp:1036
-#, fuzzy
 msgid "Use karaoke timing to split line into multiple smaller lines"
-msgstr "Nutzt Karaoketiming, um die Zeilen in viele kürzere Zeilen zu splitten"
+msgstr "Zeilen anhand des Karaoke-Timing in viele kürzere Zeilen zerhacken"
 
 #: ../src/command/edit.cpp:1070
 msgid "splitting"
@@ -1637,15 +1619,15 @@ msgstr "Splitten"
 #: ../src/command/edit.cpp:1098 ../src/command/edit.cpp:1099
 #: ../src/subs_edit_ctrl.cpp:375
 msgid "Split at cursor (estimate times)"
-msgstr "Bei Cursor auftrennen (Zeiten annähern)"
+msgstr "Bei Cursor auftrennen (Zeiten vermuten)"
 
 #: ../src/command/edit.cpp:1100
 msgid ""
 "Split the current line at the cursor, dividing the original line's duration "
 "between the new ones"
 msgstr ""
-"Aktuelle Zeile am Cursor aufteilen und die ursprüngliche Zeitdauer zwischen "
-"den neuen Zeilen auteilen"
+"Aktuelle Zeile am Textcursor zerteilen; Zeitdauer wird nach Textmenge "
+"aufgeteilt"
 
 #: ../src/command/edit.cpp:1114 ../src/command/edit.cpp:1115
 #: ../src/subs_edit_ctrl.cpp:374
@@ -1657,27 +1639,24 @@ msgid ""
 "Split the current line at the cursor, setting both lines to the original "
 "line's times"
 msgstr ""
-"Aktuelle Zeile am Cursor aufteilen und beide Zeilen auf die ursprüngliche "
-"Zeitdauer setzen"
+"Aktuelle Zeile am Textcursor zerteilen; beide Zeilen behalten die Start- und "
+"Endzeit"
 
 #: ../src/command/edit.cpp:1125 ../src/command/edit.cpp:1126
-#, fuzzy
 msgid "Split at cursor (at video frame)"
-msgstr "Bei Cursor auftrennen (Zeiten annähern)"
+msgstr "Bei Cursor auftrennen (Videoframe)"
 
 #: ../src/command/edit.cpp:1127
-#, fuzzy
 msgid ""
 "Split the current line at the cursor, dividing the line's duration at the "
 "current video frame"
 msgstr ""
-"Aktuelle Zeile am Cursor aufteilen und die ursprüngliche Zeitdauer zwischen "
-"den neuen Zeilen auteilen"
+"Aktuelle Zeile am Textcursor zerteilen; Zeitdauer wird am momentanen "
+"Videoframe zerteilt"
 
 #: ../src/command/edit.cpp:1143
-#, fuzzy
 msgid "Redo last undone action"
-msgstr "Wiederholt die letzte rückgängig gemachte Aktion"
+msgstr "Stellt die letzte rückgängig gemachte Aktion wiederher"
 
 #: ../src/command/edit.cpp:1148
 msgid "Nothing to &redo"
@@ -1698,7 +1677,6 @@ msgid "Redo %s"
 msgstr "Wiederholen %s"
 
 #: ../src/command/edit.cpp:1169
-#, fuzzy
 msgid "Undo last action"
 msgstr "Macht die letzte Aktion rückgängig"
 
@@ -1812,9 +1790,8 @@ msgid "Attachments"
 msgstr "Anhänge"
 
 #: ../src/command/subtitle.cpp:80
-#, fuzzy
 msgid "Open the attachment manager dialog"
-msgstr "Öffnet die Liste der Anhänge"
+msgstr "Öffnet den Anhangsverwalter"
 
 #: ../src/command/subtitle.cpp:91
 msgid "&Find..."
@@ -1825,9 +1802,8 @@ msgid "Find"
 msgstr "Suchen"
 
 #: ../src/command/subtitle.cpp:93
-#, fuzzy
 msgid "Search for text in the subtitles"
-msgstr "Zeige alle Tags im Untertitelgitter"
+msgstr "Durchsuche Untertitel nach Text"
 
 #: ../src/command/subtitle.cpp:104
 msgid "Find &Next"
@@ -1838,7 +1814,6 @@ msgid "Find Next"
 msgstr "Nächstes Vorkommen"
 
 #: ../src/command/subtitle.cpp:106
-#, fuzzy
 msgid "Find next match of last search"
 msgstr "Suche nächstes Vorkommen der letzten Suchanfrage"
 
@@ -1856,16 +1831,14 @@ msgid "After Current"
 msgstr "Nach aktueller"
 
 #: ../src/command/subtitle.cpp:135
-#, fuzzy
 msgid "Insert a new line after the current one"
-msgstr "Zeile nach der aktuellen einfügen"
+msgstr "Neue Zeile nach aktueller einfügen"
 
 #: ../src/command/subtitle.cpp:167 ../src/command/subtitle.cpp:168
 msgid "After Current, at Video Time"
 msgstr "Nach aktueller, bei Videozeit"
 
 #: ../src/command/subtitle.cpp:169
-#, fuzzy
 msgid "Insert a new line after the current one, starting at video time"
 msgstr "Fügt eine Zeile nach der aktuellen ein (ab aktueller Videozeit)"
 
@@ -1878,16 +1851,14 @@ msgid "Before Current"
 msgstr "Vor aktueller"
 
 #: ../src/command/subtitle.cpp:180
-#, fuzzy
 msgid "Insert a new line before the current one"
-msgstr "Zeile vor aktueller einfügen"
+msgstr "Neue Zeile vor aktueller einfügen"
 
 #: ../src/command/subtitle.cpp:209 ../src/command/subtitle.cpp:210
 msgid "Before Current, at Video Time"
 msgstr "Vor aktueller, bei Videozeit"
 
 #: ../src/command/subtitle.cpp:211
-#, fuzzy
 msgid "Insert a new line before the current one, starting at video time"
 msgstr "Fügt eine Zeile vor der aktuellen ein (ab aktueller Videozeit)"
 
@@ -1912,9 +1883,8 @@ msgid "Open Subtitles"
 msgstr "Öffne Untertitel"
 
 #: ../src/command/subtitle.cpp:236
-#, fuzzy
 msgid "Open a subtitles file"
-msgstr "Öffnet eine Untertitel-Datei"
+msgstr "Öffne eine Untertitel-Datei"
 
 #: ../src/command/subtitle.cpp:248
 msgid "Open A&utosaved Subtitles..."
@@ -1928,20 +1898,19 @@ msgstr "Öffne Autosave-Untertitel"
 msgid "Open a previous version of a file which was autosaved by Aegisub"
 msgstr ""
 "Öffne eine vorherige Version einer Datei, die von Aegisub automatisch "
-"gespeichert wurde."
+"gespeichert wurde"
 
 #: ../src/command/subtitle.cpp:263
 msgid "Open Subtitles with &Charset..."
-msgstr "Öffne Untertitel mit &Zeichensatz"
+msgstr "Öffne Untertitel mit &Zeichensatz..."
 
 #: ../src/command/subtitle.cpp:264
 msgid "Open Subtitles with Charset"
 msgstr "Öffne Untertitel mit &Zeichensatz"
 
 #: ../src/command/subtitle.cpp:265
-#, fuzzy
 msgid "Open a subtitles file with a specific file encoding"
-msgstr "Öffnet eine Untertitel-Datei mit einem bestimmten Zeichensatz"
+msgstr "Öffne Untertitel-Datei mit einem bestimmten Zeichensatz"
 
 #: ../src/command/subtitle.cpp:273
 msgid "Choose charset code:"
@@ -1960,9 +1929,8 @@ msgid "Open Subtitles from Video"
 msgstr "Öffne Untertitel vom Video"
 
 #: ../src/command/subtitle.cpp:284
-#, fuzzy
 msgid "Open the subtitles from the current video file"
-msgstr "Öffnet die Untertitel der aktuellen Videodatei"
+msgstr "Öffne die Untertitel der aktuellen Videodatei"
 
 #: ../src/command/subtitle.cpp:300
 msgid "&Properties..."
@@ -1989,9 +1957,8 @@ msgid "Save Subtitles"
 msgstr "&Speichere Untertitel"
 
 #: ../src/command/subtitle.cpp:335
-#, fuzzy
 msgid "Save the current subtitles"
-msgstr "Letzte Untertitel öffnen"
+msgstr "Speichere die momentanen Untertitel"
 
 #: ../src/command/subtitle.cpp:350
 msgid "Save Subtitles &as..."
@@ -1999,10 +1966,9 @@ msgstr "Speichere Untertitel unter..."
 
 #: ../src/command/subtitle.cpp:351
 msgid "Save Subtitles as"
-msgstr "Speichere Untertitel unter..."
+msgstr "Speichere Untertitel unter"
 
 #: ../src/command/subtitle.cpp:352
-#, fuzzy
 msgid "Save subtitles with another name"
 msgstr "Speichert die Untertitel-Datei unter anderem Namen"
 
@@ -2016,18 +1982,16 @@ msgid "Select All"
 msgstr "Alles aus&wählen"
 
 #: ../src/command/subtitle.cpp:363
-#, fuzzy
 msgid "Select all dialogue lines"
-msgstr "Wähle alle Dialogzeilen aus"
+msgstr "Alle Dialogzeilen auswählen"
 
 #: ../src/command/subtitle.cpp:375 ../src/command/subtitle.cpp:376
 msgid "Select Visible"
 msgstr "Sichtbare auswählen"
 
 #: ../src/command/subtitle.cpp:377
-#, fuzzy
 msgid "Select all dialogue lines that are visible on the current video frame"
-msgstr "Wählt alle Zeilen aus, die im aktuellen Videoframe sichtbar sind"
+msgstr "Wähle alle Zeilen aus, die im aktuellen Videoframe sichtbar sind"
 
 #: ../src/command/subtitle.cpp:407
 msgid "Spell &Checker..."
@@ -2050,9 +2014,8 @@ msgid "ASSDraw3"
 msgstr "AssDraw3"
 
 #: ../src/command/tool.cpp:60
-#, fuzzy
 msgid "Launch the ASSDraw3 tool for vector drawing"
-msgstr "Startet das AssDraw3-Werkzeug für Vektorgrafik"
+msgstr "Starte das AssDraw3-Werkzeug für Vektorgrafiken"
 
 #: ../src/command/tool.cpp:70
 msgid "&Export Subtitles..."
@@ -2060,14 +2023,15 @@ msgstr "Exportiere Untertitel..."
 
 #: ../src/command/tool.cpp:71
 msgid "Export Subtitles"
-msgstr "Exportiere Untertitel..."
+msgstr "Exportiere Untertitel"
 
 #: ../src/command/tool.cpp:72
-#, fuzzy
 msgid ""
 "Save a copy of subtitles in a different format or with processing applied to "
 "it"
-msgstr "Speichert eine nachbearbeitete Kopie der Untertitel"
+msgstr ""
+"Speicher eine Kopie der Untertitel in aufbereiteter Form oder einem anderen "
+"Format"
 
 #: ../src/command/tool.cpp:83
 msgid "&Fonts Collector..."
@@ -2090,9 +2054,8 @@ msgid "Select Lines"
 msgstr "Zeilen auswählen"
 
 #: ../src/command/tool.cpp:97
-#, fuzzy
 msgid "Select lines based on defined criteria"
-msgstr "Wählt Zeilen nach bestimmten Kriterien aus"
+msgstr "Wähle Zeilen nach diversen Kriterien aus"
 
 #: ../src/command/tool.cpp:107
 msgid "&Resample Resolution..."
@@ -2107,6 +2070,8 @@ msgid ""
 "Resample subtitles to maintain their current appearance at a different "
 "script resolution"
 msgstr ""
+"Skaliere die Untertitel auf eine neue Skriptauflösung unter Beibehaltung des "
+"momentanen Aussehens"
 
 #: ../src/command/tool.cpp:122
 msgid "St&yling Assistant..."
@@ -2137,7 +2102,6 @@ msgid "&Styles Manager..."
 msgstr "&Stil-Manager..."
 
 #: ../src/command/tool.cpp:166
-#, fuzzy
 msgid "Open the styles manager"
 msgstr "Öffnet den Stil-Manager"
 
@@ -2149,23 +2113,23 @@ msgstr "Kanji-Timer..."
 msgid "Kanji Timer"
 msgstr "Kanji-Timer"
 
+# Wird scheinbar nirgends sonst “Kanji timer copier” gennant, sondern schlicht “Kanji timer”.
+# Im Deutschen das “copier” einfach unter den Tisch fallen lassen ?
 #: ../src/command/tool.cpp:178
-#, fuzzy
 msgid "Open the Kanji timer copier"
-msgstr "Öffne Kanji-Timer"
+msgstr "Öffne den Kanji-Timer"
 
 #: ../src/command/tool.cpp:188
 msgid "&Timing Post-Processor..."
 msgstr "Timingnachbearbeitung..."
 
 #: ../src/command/tool.cpp:190
-#, fuzzy
 msgid ""
 "Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
 "to scene changes, etc."
 msgstr ""
-"Startet eine Timingnachbearbeitung, die Einlaufbereiche, Auslaufbereiche, "
-"Szenen-Timing usw. übernimmt."
+"Starte eine Timingnachbearbeitung, um Ein- und Auslaufbereiche hinzuzufügen, "
+"Timing auf Keyframes abzustimmen uvm."
 
 #: ../src/command/tool.cpp:200
 msgid "&Translation Assistant..."
@@ -2222,11 +2186,11 @@ msgstr "Einfügen des unübersetzten Textes"
 
 #: ../src/command/app.cpp:58
 msgid "&About"
-msgstr "&Über..."
+msgstr "&Über"
 
 #: ../src/command/app.cpp:59
 msgid "About"
-msgstr "Über..."
+msgstr "Über"
 
 #: ../src/command/app.cpp:60 ../src/dialog_about.cpp:44
 msgid "About Aegisub"
@@ -2234,55 +2198,51 @@ msgstr "Über Aegisub"
 
 #: ../src/command/app.cpp:69
 msgid "&Audio+Subs View"
-msgstr "Audio+Untertitel anzeigen"
+msgstr "&Audio+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:70
 msgid "Audio+Subs View"
-msgstr "Audio+Untertitel anzeigen"
+msgstr "Audio+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:71
-#, fuzzy
 msgid "Display audio and the subtitles grid only"
-msgstr "Zeigt Untertitel und Audiofenster an"
+msgstr "Nur Audio und Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:89
 msgid "&Full view"
-msgstr "Volle Ansicht"
+msgstr "V&olle Ansicht"
 
 #: ../src/command/app.cpp:90
 msgid "Full view"
 msgstr "Volle Ansicht"
 
 #: ../src/command/app.cpp:91
-#, fuzzy
 msgid "Display audio, video and then subtitles grid"
-msgstr "Zeigt Audio, Video und Untertitel an"
+msgstr "Sowohl Audio, Video als auch Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:109
 msgid "S&ubs Only View"
-msgstr "Nur Untertitel anzeigen"
+msgstr "N&ur Untertitel anzeigen"
 
 #: ../src/command/app.cpp:110
 msgid "Subs Only View"
 msgstr "Nur Untertitel anzeigen"
 
 #: ../src/command/app.cpp:111
-#, fuzzy
 msgid "Display the subtitles grid only"
-msgstr "Zeigt nur die Untertitel an"
+msgstr "Nur das Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:125
 msgid "&Video+Subs View"
-msgstr "Video+Untertitel anzeigen"
+msgstr "&Video+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:126
 msgid "Video+Subs View"
-msgstr "Video+Untertitel"
+msgstr "Video+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:127
-#, fuzzy
 msgid "Display video and the subtitles grid only"
-msgstr "Zeigt nur Untertitel und Videofenster an"
+msgstr "Nur Video und Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:145
 msgid "E&xit"
@@ -2334,7 +2294,7 @@ msgstr "Öffne ein neues Programmfenster"
 
 #: ../src/command/app.cpp:206
 msgid "&Options..."
-msgstr "Einstellungen"
+msgstr "Einstellungen..."
 
 #: ../src/command/app.cpp:208
 msgid "Configure Aegisub"
@@ -2345,9 +2305,8 @@ msgid "Toggle global hotkey overrides"
 msgstr "Globale Hotkeys umschalten"
 
 #: ../src/command/app.cpp:224
-#, fuzzy
 msgid "Toggle global hotkey overrides (Medusa Mode)"
-msgstr "Globale Hotkeys umschalten"
+msgstr "Globale Hotkeys umschalten (Medusa Modus)"
 
 #: ../src/command/app.cpp:239
 msgid "Toggle the main toolbar"
@@ -2507,15 +2466,15 @@ msgstr "Durchlaufe Modi der Tag-Anzeige"
 
 #: ../src/command/grid.cpp:266
 msgid "ASS Override Tag mode set to show full tags."
-msgstr "ass-Tag-Modus auf 'alle Tags' setzen."
+msgstr "ASS-Tag-Modus auf 'alle Tags' setzen."
 
 #: ../src/command/grid.cpp:267
 msgid "ASS Override Tag mode set to simplify tags."
-msgstr "ass-Tag-Modus auf 'einfache Tags' setzen."
+msgstr "ASS-Tag-Modus auf 'einfache Tags' setzen."
 
 #: ../src/command/grid.cpp:268
 msgid "ASS Override Tag mode set to hide tags."
-msgstr "ass-Tag-Modus auf 'Tags verstecken' setzen."
+msgstr "ASS-Tag-Modus auf 'Tags verstecken' setzen."
 
 #: ../src/command/grid.cpp:278
 msgid "&Hide Tags"
@@ -2579,9 +2538,8 @@ msgid "Swap Lines"
 msgstr "Zeilen vertauschen"
 
 #: ../src/command/grid.cpp:385
-#, fuzzy
 msgid "Swap the two selected lines"
-msgstr "Vertauscht die ausgewählten Zeilen miteinander"
+msgstr "Vertauscht die zwei ausgewählten Zeilen"
 
 #: ../src/command/grid.cpp:396
 msgid "swap lines"
@@ -2607,11 +2565,11 @@ msgstr "Alle Automatisierungs-Skripte neu geladen"
 
 #: ../src/command/automation.cpp:61
 msgid "R&eload autoload Automation scripts"
-msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+msgstr "Lade automatisch geladene Automatisierungs-Skripte neu"
 
 #: ../src/command/automation.cpp:62
 msgid "Reload autoload Automation scripts"
-msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+msgstr "Lade automatisch geladene Automatisierungs-Skripte neu"
 
 #: ../src/command/automation.cpp:63
 msgid "Rescan the Automation autoload folder"
@@ -2619,7 +2577,7 @@ msgstr "Autom.-Laden-Ordner neu prüfen"
 
 #: ../src/command/automation.cpp:67
 msgid "Reloaded autoload Automation scripts"
-msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
+msgstr "Automatisch geladene Automatisierungs-Skripte neu geladen"
 
 #: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
 msgid "&Automation..."
@@ -2639,6 +2597,9 @@ msgid ""
 "Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
 "autoload folder and reload all automation scripts"
 msgstr ""
+"Automatisierungs-Manager öffnen\n"
+"Strg: Autom.-Laden neu prüfen\n"
+"Strg+Shift: Zusätzlich alle Skripte neu laden"
 
 #: ../src/command/time.cpp:99
 msgid "adjoin"
@@ -2653,11 +2614,8 @@ msgid "Change End"
 msgstr "Ändere Ende"
 
 #: ../src/command/time.cpp:106
-#, fuzzy
 msgid "Change end times of lines to the next line's start time"
-msgstr ""
-"Ändert die Untertitelzeit so, daß die Endzeit auf die Anfangszeit des "
-"nächsten gesetzt wird"
+msgstr "Setze die Endzeit der Zeilen auf den Anfang der jeweiligen Folgezeile"
 
 #: ../src/command/time.cpp:115
 msgid "Change &Start"
@@ -2668,11 +2626,9 @@ msgid "Change Start"
 msgstr "Ändere Anfang"
 
 #: ../src/command/time.cpp:117
-#, fuzzy
 msgid "Change start times of lines to the previous line's end time"
 msgstr ""
-"Ändert die Untertitelzeit so, daß die Anfangszeit auf die Endzeit des "
-"vorigen gesetzt wird"
+"Setze den Startzeit der Zeilen auf das Ende der jeweiligen Vorgängerzeile"
 
 #: ../src/command/time.cpp:127
 msgid "Shift to &Current Frame"
@@ -2685,7 +2641,7 @@ msgstr "Verschiebe auf aktuellen Frame"
 #: ../src/command/time.cpp:129
 msgid "Shift selection so that the active line starts at current frame"
 msgstr ""
-"Verschiebt die ausgewählten Zeilen, so daß die erste ausgewählte Zeile beim "
+"Verschiebt die ausgewählten Zeilen, so dass die erste ausgewählte Zeile beim "
 "aktuellen Frame anfängt"
 
 #: ../src/command/time.cpp:145
@@ -2741,27 +2697,24 @@ msgid "Add lead in and out"
 msgstr "Ein- und Auslaufbereiche hinzufügen"
 
 #: ../src/command/time.cpp:240
-#, fuzzy
 msgid "Add both lead in and out to the selected lines"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Sowohl Ein- als auch Auslaufbereiche zu markierten Zeilen hinzufügen"
 
 #: ../src/command/time.cpp:252 ../src/command/time.cpp:253
 msgid "Add lead in"
 msgstr "Einlaufbereiche hinzufügen"
 
 #: ../src/command/time.cpp:254
-#, fuzzy
 msgid "Add the lead in time to the selected lines"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Einlaufbereiche zu markierten Zeilen hinzufügen"
 
 #: ../src/command/time.cpp:264 ../src/command/time.cpp:265
 msgid "Add lead out"
 msgstr "Auslaufbereiche hinzufügen"
 
 #: ../src/command/time.cpp:266
-#, fuzzy
 msgid "Add the lead out time to the selected lines"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Auslaufbreiche zu markierten Zeilen hinzufügen"
 
 #: ../src/command/time.cpp:275 ../src/command/time.cpp:276
 msgid "Increase length"
@@ -2904,7 +2857,6 @@ msgid "Close Audio"
 msgstr "Audio schließen"
 
 #: ../src/command/audio.cpp:67
-#, fuzzy
 msgid "Close the currently open audio file"
 msgstr "Schließt die geöffnete Audiodatei"
 
@@ -2914,12 +2866,11 @@ msgstr "Ö&ffne Audiodatei..."
 
 #: ../src/command/audio.cpp:78 ../src/command/audio.cpp:85
 msgid "Open Audio File"
-msgstr "Öffne Audiodatei..."
+msgstr "Öffne Audiodatei"
 
 #: ../src/command/audio.cpp:79
-#, fuzzy
 msgid "Open an audio file"
-msgstr "Öffnet eine Audiodatei"
+msgstr "Öffne eine Audiodatei"
 
 #: ../src/command/audio.cpp:82
 msgid "Audio Formats"
@@ -2952,9 +2903,8 @@ msgid "Open Audio from Video"
 msgstr "Öffne Tonspur von &Video"
 
 #: ../src/command/audio.cpp:118
-#, fuzzy
 msgid "Open the audio from the current video file"
-msgstr "Öffnet eine Tonspur der aktuellen Videodatei"
+msgstr "Öffnet die Tonspur der aktuellen Videodatei"
 
 #: ../src/command/audio.cpp:132
 msgid "&Spectrum Display"
@@ -2978,16 +2928,15 @@ msgstr "Wellenform anzeigen"
 
 #: ../src/command/audio.cpp:150
 msgid "Display audio as a linear amplitude graph"
-msgstr "Zeige Audio als linearen Amplitudengrafen an"
+msgstr "Zeige Audio als linearen Amplitudengraphen an"
 
 #: ../src/command/audio.cpp:187 ../src/command/audio.cpp:188
 msgid "Create audio clip"
 msgstr "Erzeuge einen Audioclip"
 
 #: ../src/command/audio.cpp:189
-#, fuzzy
 msgid "Save an audio clip of the selected line"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Exportiere Audioclip für die ausgewählten Zeilen"
 
 #: ../src/command/audio.cpp:200
 msgid "Save audio clip"
@@ -3003,9 +2952,8 @@ msgstr ""
 "Aktuelle Audio-Auswahl wiedergeben, ignoriere Änderungen bei Wiedergabe"
 
 #: ../src/command/audio.cpp:262
-#, fuzzy
 msgid "Play the audio for the current line"
-msgstr "Öffnet eine Tonspur der aktuellen Videodatei"
+msgstr "Spiele Ton der ausgewählten Zeile ab"
 
 #: ../src/command/audio.cpp:275 ../src/command/audio.cpp:276
 msgid "Play audio selection"
@@ -3020,7 +2968,6 @@ msgid "Play audio selection or stop"
 msgstr "Audio-Auswahl wiedergeben oder anhalten"
 
 #: ../src/command/audio.cpp:289
-#, fuzzy
 msgid "Play selection, or stop playback if it's already playing"
 msgstr "Auswahl wiedergeben oder bei Wiedergabe anhalten"
 
@@ -3029,9 +2976,8 @@ msgid "Stop playing"
 msgstr "Wiedergabe anhalten"
 
 #: ../src/command/audio.cpp:306
-#, fuzzy
 msgid "Stop audio and video playback"
-msgstr "Stoppe Abspielen"
+msgstr "Audio- und Videowiedergabe abbrechen"
 
 #: ../src/command/audio.cpp:322 ../src/command/audio.cpp:323
 #: ../src/command/audio.cpp:324
@@ -3101,7 +3047,7 @@ msgstr "Gehe zur Auswahl"
 
 #: ../src/command/audio.cpp:454
 msgid "Scroll the audio display to center on the current audio selection"
-msgstr ""
+msgstr "Zentriere Audio-Anzeige auf aktuelle Auswahl"
 
 #: ../src/command/audio.cpp:463 ../src/command/audio.cpp:464
 msgid "Scroll left"
@@ -3121,9 +3067,8 @@ msgstr "Audioanzeige nach rechts scrollen"
 
 #: ../src/command/audio.cpp:490 ../src/command/audio.cpp:491
 #: ../src/command/audio.cpp:492
-#, fuzzy
 msgid "Auto scroll audio display to selected line"
-msgstr "Audioanzeige automatisch auf ausgewählte Zeile setzen"
+msgstr "Audioanzeige automatisch zu gewählter Zeile verschieben"
 
 #: ../src/command/audio.cpp:507 ../src/command/audio.cpp:508
 #: ../src/command/audio.cpp:509
@@ -3131,14 +3076,12 @@ msgid "Automatically commit all changes"
 msgstr "Änderungen automatisch anwenden"
 
 #: ../src/command/audio.cpp:524 ../src/command/audio.cpp:525
-#, fuzzy
 msgid "Auto go to next line on commit"
-msgstr "Automatisch nach dem Anwenden zur nächsten Zeile gehen"
+msgstr "Nach dem Anwenden direkt zur nächsten Zeile wechseln"
 
 #: ../src/command/audio.cpp:526
-#, fuzzy
 msgid "Automatically go to next line on commit"
-msgstr "Automatisch nach dem Anwenden zur nächsten Zeile gehen"
+msgstr "Nach dem Anwenden, automatisch zur nächsten Zeile wechseln"
 
 #: ../src/command/audio.cpp:541 ../src/command/audio.cpp:542
 #: ../src/command/audio.cpp:543
@@ -3195,15 +3138,15 @@ msgstr "Aegisubs Forum öffnen"
 
 #: ../src/command/help.cpp:93
 msgid "&IRC Channel"
-msgstr "&Irc-Kanal"
+msgstr "&IRC-Kanal"
 
 #: ../src/command/help.cpp:94
 msgid "IRC Channel"
-msgstr "Irc-Kanal"
+msgstr "IRC-Kanal"
 
 #: ../src/command/help.cpp:95
 msgid "Visit Aegisub's official IRC channel"
-msgstr "Aegisubs offiziellen Irc-Channel öffnen"
+msgstr "Aegisubs offiziellen IRC-Channel öffnen"
 
 #: ../src/command/help.cpp:105
 msgid "&Visual Typesetting"
@@ -3234,11 +3177,10 @@ msgid "Close Keyframes"
 msgstr "Schließe Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:51
-#, fuzzy
 msgid ""
 "Discard the currently loaded keyframes and use those from the video, if any"
 msgstr ""
-"Speichere den gerade angezeigten Frame als .png-Bild im Ordner des Videos"
+"Verwerfe momentane Keyframes; falls vorhanden, lade Keyframes des Videos"
 
 #: ../src/command/keyframe.cpp:66
 msgid "Open Keyframes..."
@@ -3246,12 +3188,11 @@ msgstr "Öffne Keyframe-Datei..."
 
 #: ../src/command/keyframe.cpp:67
 msgid "Open Keyframes"
-msgstr "Öffne Keyframe-Datei..."
+msgstr "Öffne Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:68
-#, fuzzy
 msgid "Open a keyframe list file"
-msgstr "Öffnet eine Keyframe-Datei"
+msgstr "Öffne eine Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:72
 msgid "Open keyframes file"
@@ -3263,12 +3204,11 @@ msgstr "Speichere Keyframe-Datei..."
 
 #: ../src/command/keyframe.cpp:86
 msgid "Save Keyframes"
-msgstr "Speichere Keyframe-Datei..."
+msgstr "Speichere Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:87
-#, fuzzy
 msgid "Save the current list of keyframes to a file"
-msgstr "Speichert die aktuelle Keyframeliste"
+msgstr "Speichere die aktuelle Keyframeliste"
 
 #: ../src/command/keyframe.cpp:95
 msgid "Save keyframes file"
@@ -3332,7 +3272,7 @@ msgstr "Aegisub hat die Rechtschreibprüfung für dieses Skript abgeschlossen."
 
 #: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
 msgid "Spell checking complete."
-msgstr "&Rechtschreibprüfung abgeschlossen"
+msgstr "&Rechtschreibprüfung abgeschlossen."
 
 #: ../src/dialog_spellchecker.cpp:283
 msgid "Aegisub has found no spelling mistakes in this script."
@@ -3352,7 +3292,7 @@ msgstr "Durchsuchen..."
 
 #: ../src/preferences_base.cpp:244
 msgid "Choose..."
-msgstr "Auswählen"
+msgstr "Auswählen..."
 
 #: ../src/preferences_base.cpp:252
 msgid "Font Size"
@@ -3425,7 +3365,7 @@ msgstr "3: Intelligent umbrechen, untere Zeile ist breiter"
 
 #: ../src/dialog_properties.cpp:148
 msgid "Wrap Style: "
-msgstr "Umbruch-Stil:"
+msgstr "Umbruch-Stil: "
 
 #: ../src/dialog_properties.cpp:151
 msgid "Scale Border and Shadow"
@@ -3457,14 +3397,14 @@ msgid "Copying fonts to archive...\n"
 msgstr "Kopiere Schriftarten in Archiv...\n"
 
 #: ../src/dialog_fonts_collector.cpp:126
-#, fuzzy, c-format
+#, c-format
 msgid "* Failed to create directory '%s': %s.\n"
-msgstr "* Kopieren fehlgeschlagen: %s\n"
+msgstr "* Nicht möglich Ordner '%s' zu erstellen: %s.\n"
 
 #: ../src/dialog_fonts_collector.cpp:137
-#, fuzzy, c-format
+#, c-format
 msgid "* Failed to open %s.\n"
-msgstr "* Kopieren fehlgeschlagen: %s\n"
+msgstr "* Öffnen von %s fehlgeschlagen.\n"
 
 #: ../src/dialog_fonts_collector.cpp:192
 #, c-format
@@ -3563,7 +3503,7 @@ msgstr "Kann Zielordner nicht anlegen."
 
 #: ../src/dialog_fonts_collector.cpp:311
 msgid "Invalid path for .zip file."
-msgstr "Ungültiger Pfad für .zip-Datei"
+msgstr "Ungültiger Pfad für .zip-Datei."
 
 #: ../src/dialog_fonts_collector.cpp:335
 msgid "Select archive file name"
@@ -3645,9 +3585,8 @@ msgid "Show main toolbar"
 msgstr "Zeige Werkzeugleiste"
 
 #: ../src/preferences.cpp:66
-#, fuzzy
 msgid "Save UI state in subtitles files"
-msgstr "Untertiteldatei speichern"
+msgstr "UI-Status in Untertiteldatei speichern"
 
 #: ../src/preferences.cpp:69
 msgid "Toolbar Icon Size"
@@ -3686,14 +3625,12 @@ msgid "Find/Replace"
 msgstr "Suchen/Ersetzen"
 
 #: ../src/preferences.cpp:83
-#, fuzzy
 msgid "Default styles"
-msgstr "Stil einstellen"
+msgstr "Standardstile"
 
 #: ../src/preferences.cpp:85
-#, fuzzy
 msgid "Default style catalogs"
-msgstr "Standard Auslaufbereich-Länge (ms)"
+msgstr "Standard Stilkatalog"
 
 #: ../src/preferences.cpp:89
 msgid ""
@@ -3702,30 +3639,30 @@ msgid ""
 "\n"
 "You can set up style catalogs in the Style Manager."
 msgstr ""
+"Der gewählte Stilkatalog wird bei neuen oder aus Fremdformaten importierten "
+"Dateien verwendet.\n"
+"\n"
+"Sie können Stilkataloge im Stilmanager erstellen."
 
 #: ../src/preferences.cpp:114
-#, fuzzy
 msgid "New files"
-msgstr "&Neue Untertitel"
+msgstr "Neue Dateien"
 
 #: ../src/preferences.cpp:115
 msgid "MicroDVD import"
-msgstr ""
+msgstr "MicroDVD-Import"
 
 #: ../src/preferences.cpp:116
-#, fuzzy
 msgid "SRT import"
-msgstr "Stilimport"
+msgstr "SRT-Import"
 
 #: ../src/preferences.cpp:117
-#, fuzzy
 msgid "TTXT import"
-msgstr "Stilimport"
+msgstr "TTXT-Import"
 
 #: ../src/preferences.cpp:118
-#, fuzzy
 msgid "Plain text import"
-msgstr "Stilimport"
+msgstr "Reintext-Import"
 
 #: ../src/preferences.cpp:125 ../src/preferences.cpp:354
 msgid "Audio"
@@ -3749,7 +3686,7 @@ msgstr "Auto-Fokus, wenn der Mauszeiger darüber ist"
 
 #: ../src/preferences.cpp:132
 msgid "Play audio when stepping in video"
-msgstr "Audio abspielem im Video-Suchlauf"
+msgstr "Audio abspielen im Video-Suchlauf"
 
 #: ../src/preferences.cpp:133
 msgid "Left-click-drag moves end marker"
@@ -3880,14 +3817,15 @@ msgstr "Standardbreite"
 msgid "Default height"
 msgstr "Standardhöhe"
 
+# "Always set" ist Option bei automatischer Skriptaufl.-Anpassung anhand des Videos.
+# Aus "Immer übernehmen" geht nicht hervor, dass keine Skalierung stattfindet.
 #: ../src/preferences.cpp:195
-#, fuzzy
 msgid "Always set"
-msgstr "Immer"
+msgstr "Vid-Aufl. übernehmen (ohne Skal.)"
 
 #: ../src/preferences.cpp:195
 msgid "Always resample"
-msgstr ""
+msgstr "Immer skalieren"
 
 #: ../src/preferences.cpp:197
 msgid "Match video resolution on open"
@@ -3919,7 +3857,7 @@ msgstr "Wörterbuch-Ordner"
 
 #: ../src/preferences.cpp:214
 msgid "Character Counter"
-msgstr ""
+msgstr "Zeichenzähler"
 
 #: ../src/preferences.cpp:215
 msgid "Maximum characters per line"
@@ -3927,19 +3865,19 @@ msgstr "Maximale Zeichen pro Zeile"
 
 #: ../src/preferences.cpp:216
 msgid "Characters Per Second Warning Threshold"
-msgstr ""
+msgstr "Warngrenze für Zeichen pro Sekunde"
 
 #: ../src/preferences.cpp:217
 msgid "Characters Per Second Error Threshold"
-msgstr ""
+msgstr "Fehlergrenze für Zeichen pro Sekunde"
 
 #: ../src/preferences.cpp:218
 msgid "Ignore whitespace"
-msgstr ""
+msgstr "Ignoriere Leerraum"
 
 #: ../src/preferences.cpp:219
 msgid "Ignore punctuation"
-msgstr ""
+msgstr "Ignoriere Satzzeichen"
 
 #: ../src/preferences.cpp:221
 msgid "Grid"
@@ -3947,7 +3885,7 @@ msgstr "Untertitel-Gitter"
 
 #: ../src/preferences.cpp:222
 msgid "Focus grid on click"
-msgstr ""
+msgstr "Gitter bei Klick fokussieren"
 
 #: ../src/preferences.cpp:223
 msgid "Highlight visible subtitles"
@@ -3990,22 +3928,20 @@ msgid "Syntax Highlighting"
 msgstr "Syntaxhervorhebung"
 
 #: ../src/preferences.cpp:249
-#, fuzzy
 msgid "Background"
-msgstr "Fehlermarkierung"
+msgstr "Hintergrund"
 
 #: ../src/preferences.cpp:250 ../src/preferences.cpp:326
 msgid "Normal"
 msgstr "Normal"
 
 #: ../src/preferences.cpp:251
-#, fuzzy
 msgid "Comments"
 msgstr "Kommentare"
 
 #: ../src/preferences.cpp:252
 msgid "Drawings"
-msgstr ""
+msgstr "Zeichnungen"
 
 #: ../src/preferences.cpp:253
 msgid "Brackets"
@@ -4036,9 +3972,8 @@ msgid "Karaoke templates"
 msgstr "Karaoke-Vorlage"
 
 #: ../src/preferences.cpp:261
-#, fuzzy
 msgid "Karaoke variables"
-msgstr "Karaoke-Vorlage"
+msgstr "Karaoke-Variablen"
 
 #: ../src/preferences.cpp:267
 msgid "Audio Color Schemes"
@@ -4105,9 +4040,8 @@ msgid "Lines"
 msgstr "Zeilen"
 
 #: ../src/preferences.cpp:285
-#, fuzzy
 msgid "CPS Error"
-msgstr "Fehler"
+msgstr "CPS Fehler"
 
 #: ../src/preferences.cpp:294
 msgid "Backup"
@@ -4244,7 +4178,7 @@ msgstr "Keine (Nicht empfohlen)"
 
 #: ../src/preferences.cpp:365
 msgid "RAM"
-msgstr "Ram"
+msgstr "RAM"
 
 #: ../src/preferences.cpp:365
 msgid "Hard Disk"
@@ -4312,7 +4246,7 @@ msgstr "Portaudio-Gerät"
 
 #: ../src/preferences.cpp:403
 msgid "OSS Device"
-msgstr "Oss-Gerät"
+msgstr "OSS-Gerät"
 
 #: ../src/preferences.cpp:408
 msgid "Buffer latency"
@@ -4457,11 +4391,11 @@ msgstr "Kompiliert von %s am %s."
 
 #: ../src/dialog_kara_timing_copy.cpp:57
 msgid "Source: "
-msgstr "Quelle:"
+msgstr "Quelle: "
 
 #: ../src/dialog_kara_timing_copy.cpp:58
 msgid "Dest: "
-msgstr "Ziel:"
+msgstr "Ziel: "
 
 #: ../src/dialog_kara_timing_copy.cpp:470
 msgid "Kanji timing"
@@ -4558,9 +4492,8 @@ msgid "Group all of the source text."
 msgstr "Gruppiere alle Quelltexte."
 
 #: ../src/hotkey.cpp:175
-#, fuzzy
 msgid "Invalid command name for hotkey"
-msgstr "'%s' ist kein gültiger Kommandoname"
+msgstr "Kommandoname nicht für Hotkeys gültig"
 
 #: ../src/dialog_paste_over.cpp:55
 msgid "Select Fields to Paste Over"
@@ -4575,7 +4508,6 @@ msgid "Please select the fields that you want to paste over:"
 msgstr "Bitte wählen Sie die Felder, die Sie überschreiben möchten:"
 
 #: ../src/dialog_paste_over.cpp:63
-#, fuzzy
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -4652,6 +4584,10 @@ msgid ""
 "\n"
 "Error Message: %s"
 msgstr ""
+"Entschuldigung, ein Fehler ist aufgetreten. Bitte speichern Sie Ihre Arbeit "
+"und starten Aegisub neu.\n"
+"\n"
+"Fehlermeldung: %s"
 
 #: ../src/subs_edit_box.cpp:119
 msgid "&Comment"
@@ -4668,9 +4604,8 @@ msgid "Style for this line"
 msgstr "Stil für diese Zeile"
 
 #: ../src/subs_edit_box.cpp:129 ../src/subs_edit_box.cpp:130
-#, fuzzy
 msgid "Edit"
-msgstr "&Bearbeiten"
+msgstr "Bearbeiten"
 
 #: ../src/subs_edit_box.cpp:140
 msgid ""
@@ -4876,33 +4811,33 @@ msgid "Intersect &with selection"
 msgstr "Schnittmenge mit Auswahl"
 
 #: ../src/dialog_selection.cpp:211
-#, fuzzy, c-format
+#, c-format
 msgid "Selection was set to one line"
 msgid_plural "Selection was set to %u lines"
 msgstr[0] "Es wurde eine Zeile ausgewählt"
-msgstr[1] "Es wurde eine Zeile ausgewählt"
+msgstr[1] "Es wurden %u Zeilen ausgewählt"
 
 #: ../src/dialog_selection.cpp:212
 msgid "Selection was set to no lines"
 msgstr "Es wurde keine Zeile ausgewählt"
 
 #: ../src/dialog_selection.cpp:218
-#, fuzzy, c-format
+#, c-format
 msgid "One line was added to selection"
 msgid_plural "%u lines were added to selection"
 msgstr[0] "Eine Zeile wurde zur Auswahl hinzugefügt"
-msgstr[1] "Eine Zeile wurde zur Auswahl hinzugefügt"
+msgstr[1] "%u Zeilen wurden zur Auswahl hinzugefügt"
 
 #: ../src/dialog_selection.cpp:219
 msgid "No lines were added to selection"
 msgstr "Keine Zeile wurde zur Auswahl hinzugefügt"
 
 #: ../src/dialog_selection.cpp:230
-#, fuzzy, c-format
+#, c-format
 msgid "One line was removed from selection"
 msgid_plural "%u lines were removed from selection"
 msgstr[0] "Eine Zeile wurde aus der Auswahl entfernt"
-msgstr[1] "Eine Zeile wurde aus der Auswahl entfernt"
+msgstr[1] "%u Zeilen wurden aus der Auswahl entfernt"
 
 #: ../src/dialog_selection.cpp:231
 msgid "No lines were removed from selection"
@@ -4915,7 +4850,7 @@ msgstr "Auswahl"
 #: ../src/font_file_lister.cpp:72
 #, c-format
 msgid "Style '%s' does not exist\n"
-msgstr ""
+msgstr "Stil '%s' existiert nicht\n"
 
 #: ../src/font_file_lister.cpp:138
 #, c-format
@@ -4930,12 +4865,12 @@ msgstr "'%s' in '%s' gefunden\n"
 #: ../src/font_file_lister.cpp:149
 #, c-format
 msgid "'%s' does not have a bold variant.\n"
-msgstr ""
+msgstr "Keine fette Variante für '%s' verfügbar.\n"
 
 #: ../src/font_file_lister.cpp:151
 #, c-format
 msgid "'%s' does not have an italic variant.\n"
-msgstr ""
+msgstr "Keine kursive Variante für '%s' verfügbar.\n"
 
 #: ../src/font_file_lister.cpp:155
 #, c-format
@@ -4976,19 +4911,19 @@ msgid "All fonts found.\n"
 msgstr "Fertig. Alle Schriftarten gefunden.\n"
 
 #: ../src/font_file_lister.cpp:211
-#, fuzzy, c-format
+#, c-format
 msgid "One font could not be found\n"
 msgid_plural "%d fonts could not be found.\n"
-msgstr[0] "%d Schriftarten konnten nicht gefunden werden.\n"
+msgstr[0] "Eine Schriftart konnte nicht gefunden werden.\n"
 msgstr[1] "%d Schriftarten konnten nicht gefunden werden.\n"
 
 #: ../src/font_file_lister.cpp:214
-#, fuzzy, c-format
+#, c-format
 msgid "One font was found, but was missing glyphs used in the script.\n"
 msgid_plural ""
 "%d fonts were found, but were missing glyphs used in the script.\n"
 msgstr[0] ""
-"%d Schriftarten wurden gefunden, aber es fehlen Zeichen, die im Skript "
+"Eine Schriftart wurde gefunden, aber es fehlen Zeichen, die im Skript "
 "benutzt werden.\n"
 msgstr[1] ""
 "%d Schriftarten wurden gefunden, aber es fehlen Zeichen, die im Skript "
@@ -5014,7 +4949,7 @@ msgstr ""
 "Dies ist nützlich, um die regulären Untertitelzeiten in vfr-ac-"
 "Untertitelzeiten fürs Hardsubbing umzuwandeln.\n"
 "Dies kann auch dafür benutzt werden, um Untertitel in andere Video-"
-"Geschwindigkeiten zu konvertieren, wie z.B. Ntsc zu Pal."
+"Geschwindigkeiten zu konvertieren, wie z.B. NTSC zu PAL."
 
 #: ../src/export_framerate.cpp:92
 msgid "V&ariable"
@@ -5264,19 +5199,16 @@ msgid "S&kip Override Tags"
 msgstr "Tags überspringen"
 
 #: ../src/dialog_search_replace.cpp:87
-#, fuzzy
 msgid "St&yle"
-msgstr "Stilname"
+msgstr "St&ilname"
 
 #: ../src/dialog_search_replace.cpp:87
-#, fuzzy
 msgid "A&ctor"
-msgstr "Sprecher"
+msgstr "Sp&recher"
 
 #: ../src/dialog_search_replace.cpp:88
-#, fuzzy
 msgid "A&ll rows"
-msgstr "Alle Zeilen"
+msgstr "Alle Reihen"
 
 #: ../src/dialog_search_replace.cpp:91
 msgid "Limit to"
@@ -5314,11 +5246,11 @@ msgstr "%s [Wiederhergestellt]"
 
 #: ../src/audio_box.cpp:73
 msgid "Horizontal zoom"
-msgstr "Horizontale Vergrößerung"
+msgstr "Horizontaler Zoom"
 
 #: ../src/audio_box.cpp:74
 msgid "Vertical zoom"
-msgstr "Vertikale Vergrößerung"
+msgstr "Vertikaler Zoom"
 
 #: ../src/audio_box.cpp:75
 msgid "Audio Volume"
@@ -5349,36 +5281,32 @@ msgid "Left"
 msgstr "Links"
 
 #: ../src/grid_column.cpp:238
-#, fuzzy
 msgid "Left Margin"
-msgstr "Ränder"
+msgstr "Linker Rand"
 
 #: ../src/grid_column.cpp:242 ../src/dialog_style_editor.cpp:288
 msgid "Right"
 msgstr "Rechts"
 
 #: ../src/grid_column.cpp:243
-#, fuzzy
 msgid "Right Margin"
-msgstr "Rechten Rand ändern"
+msgstr "Rechter Rand"
 
 #: ../src/grid_column.cpp:247 ../src/dialog_style_editor.cpp:288
 msgid "Vert"
 msgstr "Vertikal"
 
 #: ../src/grid_column.cpp:248
-#, fuzzy
 msgid "Vertical Margin"
-msgstr "Vertikalen Rand ändern"
+msgstr "Vertikaler Rand"
 
 #: ../src/grid_column.cpp:266
-#, fuzzy
 msgid "CPS"
-msgstr "fps"
+msgstr "CPS"
 
 #: ../src/grid_column.cpp:267
 msgid "Characters Per Second"
-msgstr ""
+msgstr "Zeichen pro Sekunde"
 
 #: ../src/dialog_text_import.cpp:47
 msgid "Text import options"
@@ -5398,7 +5326,7 @@ msgstr "Einschließlich leerer Zeilen"
 
 #: ../src/video_box.cpp:57
 msgid "Seek video"
-msgstr "Springe im Video zu..."
+msgstr "Springe im Video zu"
 
 #: ../src/video_box.cpp:62
 msgid "Current frame time and number"
@@ -5410,7 +5338,7 @@ msgstr "Framezeit relativ zu Anfang und Ende der aktuellen Zeile"
 
 #: ../src/ass_style.cpp:193
 msgid "ANSI"
-msgstr "Ansi"
+msgstr "ANSI"
 
 #: ../src/ass_style.cpp:195
 msgid "Symbol"
@@ -5422,7 +5350,7 @@ msgstr "Mac"
 
 #: ../src/ass_style.cpp:197
 msgid "Shift_JIS"
-msgstr "Shift-Jis"
+msgstr "Shift-JIS"
 
 #: ../src/ass_style.cpp:198
 msgid "Hangeul"
@@ -5478,7 +5406,7 @@ msgstr "Osteuropäisch"
 
 #: ../src/ass_style.cpp:211
 msgid "OEM"
-msgstr "Oem"
+msgstr "OEM"
 
 #: ../src/dialog_colorpicker.cpp:542
 msgid "Select Color"
@@ -5490,35 +5418,35 @@ msgstr "Farbspektrum"
 
 #: ../src/dialog_colorpicker.cpp:560
 msgid "RGB/R"
-msgstr "Rgb-R"
+msgstr "RGB-R"
 
 #: ../src/dialog_colorpicker.cpp:560
 msgid "RGB/G"
-msgstr "Rgb-G"
+msgstr "RGB-G"
 
 #: ../src/dialog_colorpicker.cpp:560
 msgid "RGB/B"
-msgstr "Rgb-B"
+msgstr "RGB-B"
 
 #: ../src/dialog_colorpicker.cpp:560
 msgid "HSL/L"
-msgstr "Hsl-L"
+msgstr "HSL-L"
 
 #: ../src/dialog_colorpicker.cpp:560
 msgid "HSV/H"
-msgstr "Hsv-H"
+msgstr "HSV-H"
 
 #: ../src/dialog_colorpicker.cpp:567
 msgid "RGB color"
-msgstr "Rgb-Farbschema"
+msgstr "RGB-Farbschema"
 
 #: ../src/dialog_colorpicker.cpp:568
 msgid "HSL color"
-msgstr "Hsl-Farbschema"
+msgstr "HSL-Farbschema"
 
 #: ../src/dialog_colorpicker.cpp:569
 msgid "HSV color"
-msgstr "Hsv-Farbschema"
+msgstr "HSV-Farbschema"
 
 #: ../src/dialog_colorpicker.cpp:594
 msgid "Spectrum mode:"
@@ -5588,7 +5516,7 @@ msgstr "15.000 fps"
 
 #: ../src/subtitle_format.cpp:109
 msgid "23.976 FPS (Decimated NTSC)"
-msgstr "23.976 fps (Dezimiertes Ntsc)"
+msgstr "23.976 fps (Dezimiertes NTSC)"
 
 #: ../src/subtitle_format.cpp:110
 msgid "24.000 FPS (FILM)"
@@ -5596,15 +5524,15 @@ msgstr "24.000 fps (Film)"
 
 #: ../src/subtitle_format.cpp:111
 msgid "25.000 FPS (PAL)"
-msgstr "25.000 fps (Pal)"
+msgstr "25.000 fps (PAL)"
 
 #: ../src/subtitle_format.cpp:112
 msgid "29.970 FPS (NTSC)"
-msgstr "29.970 fps (Ntsc)"
+msgstr "29.970 fps (NTSC)"
 
 #: ../src/subtitle_format.cpp:114
 msgid "29.970 FPS (NTSC with SMPTE dropframe)"
-msgstr "29.970 fps (Ntsc mit Smpte-Frame)"
+msgstr "29.970 fps (NTSC mit Smpte-Frame)"
 
 #: ../src/subtitle_format.cpp:115
 msgid "30.000 FPS"
@@ -5612,11 +5540,11 @@ msgstr "30.000 fps"
 
 #: ../src/subtitle_format.cpp:116
 msgid "50.000 FPS (PAL x2)"
-msgstr "50.000 fps (Pal x2)"
+msgstr "50.000 fps (PAL x2)"
 
 #: ../src/subtitle_format.cpp:117
 msgid "59.940 FPS (NTSC x2)"
-msgstr "59.940 fps (Ntsc x2)"
+msgstr "59.940 fps (NTSC x2)"
 
 #: ../src/subtitle_format.cpp:118
 msgid "60.000 FPS"
@@ -5624,7 +5552,7 @@ msgstr "60.000 fps"
 
 #: ../src/subtitle_format.cpp:119
 msgid "119.880 FPS (NTSC x4)"
-msgstr "119.880 fps (Ntsc x4)"
+msgstr "119.880 fps (NTSC x4)"
 
 #: ../src/subtitle_format.cpp:120
 msgid "120.000 FPS"
@@ -5634,6 +5562,7 @@ msgstr "120.000 fps"
 msgid "Please choose the appropriate FPS for the subtitles:"
 msgstr "Bitte wählen Sie die entsprechende Framerate für den Untertitel:"
 
+# Ja, im Deutschen wird fps kleingeschrieben
 #: ../src/subtitle_format.cpp:124
 msgid "FPS"
 msgstr "fps"
@@ -5678,44 +5607,40 @@ msgid "Do you want to load/unload the associated files?"
 msgstr "Wollen Sie die verknüpften Dateien laden/entladen?"
 
 #: ../src/project.cpp:198
-#, fuzzy
 msgid "Unload audio"
-msgstr "Audio laden"
+msgstr "Audio entladen"
 
 #: ../src/project.cpp:198
-#, fuzzy, c-format
+#, c-format
 msgid "Load audio file: %s"
-msgstr "Audio laden"
+msgstr "Audio-Datei laden: %s"
 
 #: ../src/project.cpp:200
-#, fuzzy
 msgid "Unload video"
-msgstr "Video abspielen"
+msgstr "Video entladen"
 
 #: ../src/project.cpp:200
-#, fuzzy, c-format
+#, c-format
 msgid "Load video file: %s"
-msgstr "Öffnet eine Videodatei"
+msgstr "Öffne Videodatei: %s"
 
 #: ../src/project.cpp:202
-#, fuzzy
 msgid "Unload timecodes"
-msgstr "Zeitcodes ersetzen?"
+msgstr "Zeitcodes entladen"
 
 #: ../src/project.cpp:202
-#, fuzzy, c-format
+#, c-format
 msgid "Load timecodes file: %s"
-msgstr "Speichere Zeitcode-Datei"
+msgstr "Lade Zeitcode-Datei: %s"
 
 #: ../src/project.cpp:204
-#, fuzzy
 msgid "Unload keyframes"
-msgstr "Schließe Keyframe-Datei"
+msgstr "Keyframe-Datei entladen"
 
 #: ../src/project.cpp:204
-#, fuzzy, c-format
+#, c-format
 msgid "Load keyframes file: %s"
-msgstr "Speichere Keyframe-Datei"
+msgstr "Keyframe-Datei laden: %s"
 
 #: ../src/project.cpp:206
 msgid "(Un)Load files?"
@@ -5723,7 +5648,7 @@ msgstr "Dateien (ent)laden?"
 
 #: ../src/project.cpp:255
 msgid "The audio file was not found: "
-msgstr ""
+msgstr "Die Audio-Datei konnte nicht gefunden werden: "
 
 #: ../src/project.cpp:263
 msgid ""
@@ -5732,6 +5657,10 @@ msgid ""
 "\n"
 "The following providers were tried:\n"
 msgstr ""
+"Keine der verfügbaren Audioprovider konnte etwas mit der gewählten Datei "
+"anfangen.\n"
+"\n"
+"Die folgenden Provider haben es versucht:\n"
 
 #: ../src/project.cpp:266
 msgid ""
@@ -5740,6 +5669,9 @@ msgid ""
 "\n"
 "The following providers were tried:\n"
 msgstr ""
+"Keiner der Audioprovider besitzt den notwendigen Codec für die gewählte "
+"Datei.\n"
+"Die folgenden Provider wurden versucht:\n"
 
 #: ../src/dialog_style_editor.cpp:127
 msgid "Style Editor"
@@ -5862,8 +5794,8 @@ msgid ""
 "Encoding, only useful in unicode if the font doesn't have the proper unicode "
 "mapping"
 msgstr ""
-"Kodierung, nur sinnvoll im Unicode, falls die Schriftart keine richtigen "
-"Unicode-Tabellen besitzt."
+"Kodierung (nur sinnvoll im Unicode, falls die Schriftart keine richtigen "
+"Unicode-Tabellen besitzt)"
 
 #: ../src/dialog_style_editor.cpp:232
 msgid "Character spacing, in pixels"
@@ -5950,7 +5882,7 @@ msgid ""
 "Time code offset in incorrect format. Ensure it is entered as four groups of "
 "two digits separated by colons."
 msgstr ""
-"Das Zeitcode-Offset ist in einem falschen Format. Stellen Sie sicher, daß "
+"Das Zeitcode-Offset ist in einem falschen Format. Stellen Sie sicher, dass "
 "sie vier Gruppen aus je zwei Zahlen, die durch Doppelpunkte getrennt sind, "
 "eingegeben haben."
 
@@ -5996,27 +5928,27 @@ msgstr "Out-Times sind eingeschlossen"
 
 #: ../src/dialog_export_ebu3264.cpp:116
 msgid "ISO 6937-2 (Latin/Western Europe)"
-msgstr "Iso 6937-2 (Latein/Westeuropäisch)"
+msgstr "ISO 6937-2 (Latein/Westeuropäisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:117
 msgid "ISO 8859-5 (Cyrillic)"
-msgstr "Iso 8859-5 (Kyrillisch)"
+msgstr "ISO 8859-5 (Kyrillisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:118
 msgid "ISO 8859-6 (Arabic)"
-msgstr "Iso 8859-6 (Arabisch)"
+msgstr "ISO 8859-6 (Arabisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:119
 msgid "ISO 8859-7 (Greek)"
-msgstr "Iso 8859-7 (Griechisch)"
+msgstr "ISO 8859-7 (Griechisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:120
 msgid "ISO 8859-8 (Hebrew)"
-msgstr "Iso 8859-8 (Hebräisch)"
+msgstr "ISO 8859-8 (Hebräisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:121
 msgid "UTF-8 Unicode (non-standard)"
-msgstr "Utf-8 Unicode (Nicht-Standard)"
+msgstr "UTF-8 Unicode (Nicht-Standard)"
 
 #: ../src/dialog_export_ebu3264.cpp:123
 msgid "Text encoding"
@@ -6024,7 +5956,7 @@ msgstr "Text-Kodierung"
 
 #: ../src/dialog_export_ebu3264.cpp:126
 msgid "Automatically wrap long lines (ASS)"
-msgstr "Automatisch lange Zeilen umbrechen (ass)"
+msgstr "Automatisch lange Zeilen umbrechen (ASS)"
 
 #: ../src/dialog_export_ebu3264.cpp:127
 msgid "Automatically wrap long lines (Balanced)"
@@ -6117,29 +6049,27 @@ msgstr ""
 "Videoauflösung:\t%d x %d\n"
 "Untertitelauflösung:\t%d x %d\n"
 "\n"
-"Untertitel-Auflösung anpassen, sodaß sie zum Video paßt?"
+"Untertitel-Auflösung anpassen, sodass sie zum Video passt?"
 
 #: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
-#, fuzzy
 msgid "Set to video resolution"
-msgstr "Videoauflösung:"
+msgstr "Auf Videoauflösung setzen"
 
 #: ../src/dialog_video_properties.cpp:55
 msgid "Resample script (stretch to new aspect ratio)"
-msgstr ""
+msgstr "Skript skalieren (auf neues Format strecken)"
 
 #: ../src/dialog_video_properties.cpp:56
 msgid "Resample script (add borders)"
-msgstr ""
+msgstr "Skript skalieren (Ränder hinzufügen)"
 
 #: ../src/dialog_video_properties.cpp:57
 msgid "Resample script (remove borders)"
-msgstr ""
+msgstr "Skript skalieren (Ränder entfernen)"
 
 #: ../src/dialog_video_properties.cpp:64
-#, fuzzy
 msgid "Resample script"
-msgstr "Auflösung anpassen"
+msgstr "Skript skalieren"
 
 #: ../src/dialog_video_properties.cpp:163
 msgid "change script resolution"
@@ -6239,30 +6169,28 @@ msgid "&Symmetrical"
 msgstr "Symmetrisch"
 
 #: ../src/dialog_resample.cpp:143
-#, fuzzy
 msgid "From s&cript"
-msgstr "Keine Skripte"
+msgstr "Vom S&kript"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Stretch"
-msgstr ""
+msgstr "Strecken"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Add borders"
-msgstr ""
+msgstr "Ränder hinzufügen"
 
 #: ../src/dialog_resample.cpp:146
-#, fuzzy
 msgid "Remove borders"
-msgstr "Entfernen"
+msgstr "Ränder entfernen"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Manual"
-msgstr ""
+msgstr "Manuell"
 
 #: ../src/dialog_resample.cpp:147
 msgid "Aspect Ratio Handling"
-msgstr ""
+msgstr "Seitenverhältnisanpassung"
 
 #: ../src/dialog_resample.cpp:162
 msgid "Margin offset"
@@ -6274,17 +6202,15 @@ msgstr "x"
 
 #: ../src/dialog_resample.cpp:172 ../src/dialog_resample.cpp:186
 msgid "YCbCr Matrix:"
-msgstr ""
+msgstr "YCbCr Farbmatrix:"
 
 #: ../src/dialog_resample.cpp:175
-#, fuzzy
 msgid "Source Resolution"
-msgstr "Skriptauflösung"
+msgstr "Quellauflösung"
 
 #: ../src/dialog_resample.cpp:189
-#, fuzzy
 msgid "Destination Resolution"
-msgstr "Auflösung anpassen"
+msgstr "Zielauflösung"
 
 #: ../src/dialog_version_check.cpp:94
 msgid "Version Checker"
@@ -6309,7 +6235,7 @@ msgstr "Konnte nichts vom Update-Server herunterladen."
 #: ../src/dialog_version_check.cpp:312
 #, c-format
 msgid "HTTP request failed, got HTTP response %d."
-msgstr "http-Anforderung fehlgeschlagen, bekam http-Antwort %d"
+msgstr "HTTP-Anfrage mit Code %d fehlgeschlagen."
 
 #: ../src/dialog_version_check.cpp:343
 msgid "An update to Aegisub was found."
@@ -6441,7 +6367,7 @@ msgstr "Seitenverhältnis ändern"
 
 #: default_menu.json:0
 msgid "&Export As..."
-msgstr "Exportiere als..."
+msgstr ""
 
 #: default_hotkey.json:602:
 msgid "Subtitle Edit Box"
@@ -6449,59 +6375,54 @@ msgstr "Untertitel-Bearbeitungsbox"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:6
 msgid "Add edgeblur"
-msgstr ""
+msgstr "Füge \\be-Tags hinzu"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:7
 msgid "A demo macro showing how to do simple line modification in Automation 4"
 msgstr ""
+"Makro zur Veranschaulichung einfacher Zeilenmodifikation in Automation 4"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:21
-#, fuzzy
 msgid "Adds \\be1 tags to all selected lines"
-msgstr "Vertauscht die ausgewählten Zeilen miteinander"
+msgstr ""
 
 #: ../automation/autoload/karaoke-auto-leadin.lua:32
-#, fuzzy
 msgid "Automatic karaoke lead-in"
-msgstr "Automatisch speichern"
+msgstr "Automatischer Karaoke-Einlaufbereich"
 
 #: ../automation/autoload/karaoke-auto-leadin.lua:33
-#, fuzzy
 msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
-msgstr "Fügt die markierten Zeilen zu einer zusammen (als Karaoke)"
+msgstr ""
 
 #: ../automation/autoload/cleantags-autoload.lua:31
-#, fuzzy
 msgid "Clean Tags"
-msgstr "Tags verstecken"
+msgstr "Tags säubern"
 
 #: ../automation/autoload/cleantags-autoload.lua:32
 msgid ""
 "Clean subtitle lines by re-arranging ASS tags and override blocks within the "
 "lines"
-msgstr ""
+msgstr "Füge benachbarte Tag-Blöcke zusammen und sortiere die Tags darin"
 
 #: ../automation/autoload/kara-templater.lua:36
 #, fuzzy
 msgid "Karaoke Templater"
-msgstr "Karaoke-Vorlage"
+msgstr "Karaoke-Vorlagenumsetzer"
 
 #: ../automation/autoload/kara-templater.lua:37
 msgid ""
 "Macro and export filter to apply karaoke effects using the template language"
-msgstr ""
+msgstr "Makro und Export-Filter, der Karaoke-Vorlagen anwendet"
 
 #: ../automation/autoload/kara-templater.lua:858
-#, fuzzy
 msgid "Apply karaoke template"
-msgstr "Karaoke-Vorlage"
+msgstr "Karaoke-Vorlage anwenden"
 
 #: ../automation/autoload/kara-templater.lua:858
 msgid "Applies karaoke effects from templates"
-msgstr ""
+msgstr "Wendet Karaoke-Vorlagen an"
 
 #: ../automation/autoload/kara-templater.lua:859
-#, fuzzy
 msgid "Karaoke template"
 msgstr "Karaoke-Vorlage"
 
@@ -6514,29 +6435,28 @@ msgstr ""
 
 #: ../automation/autoload/strip-tags.lua:17
 msgid "Strip tags"
-msgstr ""
+msgstr "Entferne Tags"
 
 #: ../automation/autoload/strip-tags.lua:18
 msgid "Remove all override tags from selected lines"
-msgstr ""
+msgstr "Entfernte alle Tags der ausgewählten Zeilen"
 
 #: ../automation/autoload/strip-tags.lua:28
 msgid "strip tags"
-msgstr ""
+msgstr "entferne Tags"
 
 #: ../automation/autoload/macro-2-mkfullwitdh.lua:77
 #, fuzzy
 msgid "Make fullwidth"
-msgstr "Standardbreite"
+msgstr "Zu Vollbreite konvertieren"
 
 #: ../automation/autoload/macro-2-mkfullwitdh.lua:80
 msgid "Convert Latin letters to SJIS fullwidth letters"
-msgstr ""
+msgstr "Ersetze lateinische Buchstaben durch ihre SJIS-Vollbreitenform"
 
 #: aegisub.desktop:4
-#, fuzzy
 msgid "Aegisub"
-msgstr "Über Aegisub"
+msgstr "Aegisub"
 
 #: aegisub.desktop:5
 msgid "Subtitle Editor"
@@ -6548,20 +6468,19 @@ msgstr "Erzeugt und bearbeitet Untertitel für Filme und Videos."
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Installing runtime libraries..."
-msgstr ""
+msgstr "Laufzeit-Bibliotheken werden installiert..."
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Create a start menu icon"
-msgstr ""
+msgstr "Startmenü-Icon anlegen"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Automatically check for new versions of Aegisub"
-msgstr ""
+msgstr "Automatisch nach neuen Aegisub-Versionen suchen"
 
 #: packages/win_installer/fragment_strings.iss:1
-#, fuzzy
 msgid "Update Checker:"
-msgstr "Rechtschreibprüfung"
+msgstr "Update-Sucher:"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid ""
@@ -6571,6 +6490,14 @@ msgid ""
 "warranties of any kind are given either.%n%nSee the Aegisub website for "
 "information on obtaining the source code."
 msgstr ""
+"Dies wird Aegisub {#BUILD_GIT_VERSION_STRING} auf Ihrem Computer "
+"installieren.%n%nAegisub steht unter der GNU General Public License Version "
+"2. Das bedeutet unter anderem, dass Sie diese Anwendung für jeden Zweck "
+"kostenfrei verwenden können. Es besteht keine Garantie oder Gewährleistung "
+"jeglicher Art. Wollen Sie Derivate veröffentlichen so müssen diese ebenfalls "
+"unter GPL v2 oder einer kompatiblen Lizenz stehen. Insbesondere muss der "
+"Quellcode frei zugänglich sein.%n%nWeitere Informationen und den Quellcode "
+"finden Sie auf der Webseite."
 
 #~ msgid "Allow grid to take focus"
 #~ msgstr "Gitter darf Fokus annehmen"
@@ -6622,10 +6549,10 @@ msgstr ""
 #~ msgstr "Schließt die aktuelle Keyframe-Datei"
 
 #~ msgid "Changes resolution and modifies subtitles to conform to change"
-#~ msgstr "Verändert die Auflösung und paßt die Untertitel entsprechend an"
+#~ msgstr "Verändert die Auflösung und passt die Untertitel entsprechend an"
 
 #~ msgid "Are you sure you want to delete these %d styles?"
-#~ msgstr "Sind Sie sicher, daß Sie %d Stile löschen wollen?"
+#~ msgstr "Sind Sie sicher, dass Sie %d Stile löschen wollen?"
 
 #~ msgid "Reading into RAM"
 #~ msgstr "Lade in Arbeitsspeicher"


### PR DESCRIPTION
Update `de.po` to "newest" (2014) po-template, and then update the translation itself (add missing, defuzz and corrections)

These commits are derived from my corresponding patch in [wangqr/Aegisub#63](https://github.com/wangqr/Aegisub/pull/63).
If this pr ever gets merged, other prs will likely also have been merged before or the POT will have been updated. Deriving a new patch from the wangqr/Aegisub-version will likely cover a lot of new strings added since 2014.
If that ever happens, just ping me and I can update this patch accordingly — or you can do it yourself with `msgmerge -o de.po de.po.wangqr aegisub.pot`.

*(Updating the POT in this pr would likely just introduce unneccessary conflicts wit other translation-prs and be out-of-date by the time it gets merged – if it does at all)*